### PR TITLE
silence tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Run Pytest
-        run: poetry run pytest -s --junitxml=pytest.xml --cov=harvester | tee pytest-coverage.txt
+        run: poetry run pytest --junitxml=pytest.xml --cov=harvester | tee pytest-coverage.txt
 
       - name: Report test coverage
         uses: MishaKav/pytest-coverage-comment@main


### PR DESCRIPTION
Changes github action `poetry pytest` to silence output. 

From this:
![image](https://github.com/GSA/datagov-harvesting-logic/assets/91547795/2a9584c0-8b83-43dc-bf82-55e6184e3767)
 to: 
![image](https://github.com/GSA/datagov-harvesting-logic/assets/91547795/c6d2f24b-8199-45f0-ab58-ed45a4fa1bc1)
