### PR TITLE
Cud ckan

### DIFF
--- a/harvester/load/ckan.py
+++ b/harvester/load/ckan.py
@@ -3,7 +3,7 @@ import re
 
 
 def create_ckan_extra_base(*args):
-    keys = ["publisher_hierarchy", "resource-type"]
+    keys = ["publisher_hierarchy", "resource-type", "publisher"]
     data = zip(keys, args)
     return [{"key": d[0], "value": d[1]} for d in data]
 
@@ -32,7 +32,6 @@ def create_ckan_extras_additions(dcatus_catalog, additions):
 
 
 def create_ckan_tags(keywords):
-    # TODO: add remaining data
     output = []
 
     for keyword in keywords:
@@ -59,7 +58,6 @@ def get_email_from_str(in_str):
 
 
 def create_ckan_resources(dists):
-    # TODO: add remaining data
     output = []
 
     for dist in dists:
@@ -99,13 +97,9 @@ def simple_transform(dcatus_catalog):
 
 
 def create_defaults():
-    # all of these will be handled by the DB
     return {
         "author": None,
         "author_email": None,
-        "license_id": "notspecified",
-        "license_title": "License not specified",
-        "type": "dataset",
     }
 
 
@@ -116,6 +110,7 @@ def dcatus_to_ckan(dcatus_catalog):
         - https://catalog.data.gov/harvest/object/cb22fea9-0c90-43e9-94bf-903eacd37c92
     - to this:
         - https://catalog.data.gov/api/action/package_show?id=fdic-failed-bank-list
+
     """
 
     output = simple_transform(dcatus_catalog)
@@ -124,7 +119,9 @@ def dcatus_to_ckan(dcatus_catalog):
     tags = create_ckan_tags(dcatus_catalog["keyword"])
     pubisher_hierarchy = create_ckan_publisher_hierarchy(dcatus_catalog["publisher"])
 
-    extras_base = create_ckan_extra_base(pubisher_hierarchy, "Dataset")
+    extras_base = create_ckan_extra_base(
+        pubisher_hierarchy, "Dataset", dcatus_catalog["publisher"]["name"]
+    )
     extras = create_ckan_extras_additions(dcatus_catalog, extras_base)
 
     defaults = create_defaults()

--- a/tests/load/ckan/test_ckan_cud.py
+++ b/tests/load/ckan/test_ckan_cud.py
@@ -3,7 +3,63 @@ from harvester.load.ckan import (
     purge_ckan_package,
     patch_ckan_package,
     update_ckan_package,
+    dcatus_to_ckan,
 )
+from deepdiff import DeepDiff
+
+
+def test_dcatus_to_ckan_transform(test_ckan_package_id, test_dcatus_catalog):
+    expected_result = {
+        "name": "fdic-failed-bank-list",
+        "owner_org": "test",
+        "maintainer": "FDIC Public Data Feedback",
+        "maintainer_email": "FDICPublicDataFeedback@fdic.gov",
+        "notes": "The FDIC is often appointed as receiver for failed banks. This list includes banks which have failed since October 1, 2000.",
+        "title": "FDIC Failed Bank List",
+        "resources": [
+            {
+                "url": "https://www.fdic.gov/bank/individual/failed/banklist.csv",
+                "mimetype": "text/csv",
+            },
+            {
+                "url": "https://www.fdic.gov/bank/individual/failed/index.html",
+                "mimetype": "text/html",
+            },
+        ],
+        "tags": [
+            {"name": "financial-institution"},
+            {"name": "banks"},
+            {"name": "failures"},
+            {"name": "assistance-transactions"},
+        ],
+        "extras": [
+            {
+                "key": "publisher_hierarchy",
+                "value": "U.S. Government > Federal Deposit Insurance Corporation > Division of Insurance and Research",
+            },
+            {"key": "resource-type", "value": "Dataset"},
+            {"key": "publisher", "value": "Division of Insurance and Research"},
+            {"key": "accessLevel", "value": "public"},
+            {"key": "bureauCode", "value": ["357:20"]},
+            {
+                "key": "identifier",
+                "value": "https://www.fdic.gov/bank/individual/failed/",
+            },
+            {"key": "modified", "value": "R/P1W"},
+            {"key": "programCode", "value": ["000:000"]},
+            {"key": "publisher", "value": "Division of Insurance and Research"},
+            {
+                "key": "publisher_hierarchy",
+                "value": "U.S. Government > Federal Deposit Insurance Corporation > Division of Insurance and Research",
+            },
+            {"key": "resource-type", "value": "Dataset"},
+            {"key": "publisher", "value": "Division of Insurance and Research"},
+        ],
+        "author": None,
+        "author_email": None,
+    }
+
+    assert DeepDiff(dcatus_to_ckan(test_dcatus_catalog), expected_result) == {}
 
 
 def test_create_package(ckan_entrypoint, test_ckan_package):
@@ -12,7 +68,10 @@ def test_create_package(ckan_entrypoint, test_ckan_package):
         purge_ckan_package(ckan_entrypoint, {"id": test_ckan_package["id"]})
     except:  # noqa E722
         pass
-    assert create_ckan_package(ckan_entrypoint, test_ckan_package)
+    assert (
+        create_ckan_package(ckan_entrypoint, test_ckan_package)["title"]
+        == test_ckan_package["title"]
+    )
 
 
 def test_update_package(ckan_entrypoint, test_ckan_update_package):

--- a/tests/load/ckan/test_ckan_cud.py
+++ b/tests/load/ckan/test_ckan_cud.py
@@ -8,13 +8,13 @@ from harvester.load.ckan import (
 from deepdiff import DeepDiff
 
 
-def test_dcatus_to_ckan_transform(test_ckan_package_id, test_dcatus_catalog):
+def test_dcatus_to_ckan_transform(test_dcatus_catalog):
     expected_result = {
         "name": "fdic-failed-bank-list",
         "owner_org": "test",
         "maintainer": "FDIC Public Data Feedback",
         "maintainer_email": "FDICPublicDataFeedback@fdic.gov",
-        "notes": "The FDIC is often appointed as receiver for failed banks. This list includes banks which have failed since October 1, 2000.",
+        "notes": "The FDIC is often appointed as receiver for failed banks. This list includes banks which have failed since October 1, 2000.",  # noqa E501
         "title": "FDIC Failed Bank List",
         "resources": [
             {
@@ -35,7 +35,7 @@ def test_dcatus_to_ckan_transform(test_ckan_package_id, test_dcatus_catalog):
         "extras": [
             {
                 "key": "publisher_hierarchy",
-                "value": "U.S. Government > Federal Deposit Insurance Corporation > Division of Insurance and Research",
+                "value": "U.S. Government > Federal Deposit Insurance Corporation > Division of Insurance and Research",  # noqa E501
             },
             {"key": "resource-type", "value": "Dataset"},
             {"key": "publisher", "value": "Division of Insurance and Research"},
@@ -50,7 +50,7 @@ def test_dcatus_to_ckan_transform(test_ckan_package_id, test_dcatus_catalog):
             {"key": "publisher", "value": "Division of Insurance and Research"},
             {
                 "key": "publisher_hierarchy",
-                "value": "U.S. Government > Federal Deposit Insurance Corporation > Division of Insurance and Research",
+                "value": "U.S. Government > Federal Deposit Insurance Corporation > Division of Insurance and Research",  # noqa E501
             },
             {"key": "resource-type", "value": "Dataset"},
             {"key": "publisher", "value": "Division of Insurance and Research"},


### PR DESCRIPTION
# Pull Request

Related to [link](https://github.com/orgs/GSA/projects/11/views/1?pane=issue&itemId=38511285)

## About

Continuation of dcatus creation on ckan. The addition in this branch is the dcatus-to-ckan transformation logic and associated test. 

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [pyproject.toml](https://github.com/GSA/datagov-harvesting-logic/blob/8078c5b9f015ca7fb8a142e4e4b2e22ad2fd49b1/pyproject.toml#L3) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
