### PR TITLE
adds db healthcheck to prevent app starting before db is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ down: ## Tears down the flask and harvester containers
 up-debug: ## Sets up local docker environment
 	docker compose -f docker-compose.yml -f docker-compose_debug.yml up -d
 
-clean: down ## Cleans docker images
+clean: ## Cleans docker images
 	docker compose down -v --remove-orphans
+	docker compose -p harvest-app down -v --remove-orphans
 
 lint:  ## Lints wtih ruff, isort, black
 	ruff .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,16 @@ services:
         - "${DATABASE_PORT}:5432"
       volumes:
         - postgres_data:/var/lib/postgresql/data
+      healthcheck:
+        test: ["CMD-SHELL", "pg_isready"]
+        interval: 5s
+        timeout: 5s
+        retries: 5
   app:
     build: .
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - .:/app
     environment:


### PR DESCRIPTION
# Pull Request

Related to:
  - ongoing db headaches
  - restoring my sanity

## About

One issue with moving to postgres is the DB now takes a bit of time to initialize and sometimes the app crashes. This healthcheck prevents that.

## PR TASKS

- [X] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [pyproject.toml](https://github.com/GSA/datagov-harvesting-logic/blob/8078c5b9f015ca7fb8a142e4e4b2e22ad2fd49b1/pyproject.toml#L3) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
