### PR TITLE
Update db after validate

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,8 +5,8 @@ from flask import Flask
 from flask_bootstrap import Bootstrap
 from flask_migrate import Migrate
 
-from database.models import db
 from app.scripts.load_manager import load_manager
+from database.models import db
 
 load_dotenv()
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, flash, jsonify, redirect, render_template, request
 
-from .forms import HarvestSourceForm, OrganizationForm
 from database.interface import HarvesterDBInterface
+
+from .forms import HarvestSourceForm, OrganizationForm
 
 mod = Blueprint("harvest", __name__)
 db = HarvesterDBInterface()

--- a/app/scripts/load_manager.py
+++ b/app/scripts/load_manager.py
@@ -1,4 +1,5 @@
 import os
+
 from database.interface import HarvesterDBInterface
 from harvester.utils import CFHandler
 

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 
 load_dotenv()

--- a/database/interface.py
+++ b/database/interface.py
@@ -247,6 +247,23 @@ class HarvesterDBInterface:
             self.db.rollback()
             return None
 
+    def update_harvest_record(self, record_id, updates):
+        try:
+            source = self.db.get(HarvestRecord, record_id)
+
+            for key, value in updates.items():
+                if hasattr(source, key):
+                    setattr(source, key, value)
+                else:
+                    print(f"Warning: non-existing field '{key}' in HarvestRecord")
+
+            self.db.commit()
+            return self._to_dict(source)
+
+        except NoResultFound:
+            self.db.rollback()
+            return None
+
     def get_harvest_record(self, record_id):
         result = self.db.query(HarvestRecord).filter_by(id=record_id).first()
         return HarvesterDBInterface._to_dict(result)
@@ -266,7 +283,7 @@ class HarvesterDBInterface:
         sql = text(
             f"""SELECT * FROM (
                 SELECT DISTINCT ON (identifier) *
-                FROM harvest_record 
+                FROM harvest_record
                 WHERE status = 'success' AND harvest_source_id = '{source_id}'
                 ORDER BY identifier, date_created DESC ) sq
                 WHERE sq.action != 'delete';"""

--- a/database/interface.py
+++ b/database/interface.py
@@ -1,16 +1,11 @@
 import os
 import uuid
+
 from sqlalchemy import create_engine, inspect, or_, text
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from .models import (
-    HarvestError,
-    HarvestJob,
-    HarvestRecord,
-    HarvestSource,
-    Organization,
-)
+from .models import HarvestError, HarvestJob, HarvestRecord, HarvestSource, Organization
 
 DATABASE_URI = os.getenv("DATABASE_URI")
 

--- a/harvester/__init__.py
+++ b/harvester/__init__.py
@@ -2,9 +2,8 @@ import logging.config
 
 from dotenv import load_dotenv
 
-from harvester.logger_config import LOGGING_CONFIG
-
 from database.interface import HarvesterDBInterface
+from harvester.logger_config import LOGGING_CONFIG
 
 load_dotenv()
 

--- a/harvester/__init__.py
+++ b/harvester/__init__.py
@@ -4,6 +4,10 @@ from dotenv import load_dotenv
 
 from harvester.logger_config import LOGGING_CONFIG
 
+from database.interface import HarvesterDBInterface
+
 load_dotenv()
 
 logging.config.dictConfig(LOGGING_CONFIG)
+
+db_interface = HarvesterDBInterface()

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -43,33 +43,36 @@ class CompareException(HarvestCriticalException):
 
 # non-critical exceptions
 class HarvestNonCriticalException(Exception):
-    def __init__(self, msg, harvest_job_id, title):
-        super().__init__(msg, harvest_job_id, title)
+    def __init__(self, msg, harvest_job_id, record_id):
+        super().__init__(msg, harvest_job_id, record_id)
 
-        self.title = title
         self.msg = msg
         self.harvest_job_id = harvest_job_id
         self.severity = "ERROR"
         self.type = "record"
+        self.harvest_record_id = record_id
 
         self.db_interface = HarvesterDBInterface()
         self.logger = logging.getLogger("harvest_runner")
 
-        error_data = {
+        self.error_data = {
             "harvest_job_id": self.harvest_job_id,
             "message": self.msg,
             "severity": self.severity,
             "type": self.type,
             "date_created": datetime.utcnow(),
-            "harvest_record_id": self.title,  # to-do
+            "harvest_record_id": record_id,  # to-do
         }
 
-        self.db_interface.add_harvest_error(error_data)
+        # self.db_interface.add_harvest_error(error_data)
         self.logger.error(self.msg, exc_info=True)
 
 
 class ValidationException(HarvestNonCriticalException):
-    pass
+    def __init__(self, msg, harvest_job_id, record_id):
+        super().__init__(msg, harvest_job_id, record_id)
+
+        # self.db_interface.update_harvest_record(record_id, {"status": "error"})
 
 
 class TranformationException(HarvestNonCriticalException):

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -70,8 +70,7 @@ class HarvestNonCriticalException(Exception):
 
 
 class ValidationException(HarvestNonCriticalException):
-    def __init__(self, msg, harvest_job_id, record_id):
-        super().__init__(msg, harvest_job_id, record_id)
+    pass
 
 
 class TranformationException(HarvestNonCriticalException):

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -65,14 +65,13 @@ class HarvestNonCriticalException(Exception):
         }
 
         self.db_interface.add_harvest_error(error_data)
+        self.db_interface.update_harvest_record(record_id, {"status": "error"})
         self.logger.error(self.msg, exc_info=True)
 
 
 class ValidationException(HarvestNonCriticalException):
     def __init__(self, msg, harvest_job_id, record_id):
         super().__init__(msg, harvest_job_id, record_id)
-
-        self.db_interface.update_harvest_record(record_id, {"status": "error"})
 
 
 class TranformationException(HarvestNonCriticalException):

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from database.interface import HarvesterDBInterface
+from . import db_interface
 
 
 # critical exceptions
@@ -14,7 +14,7 @@ class HarvestCriticalException(Exception):
         self.severity = "CRITICAL"
         self.type = "job"
 
-        self.db_interface = HarvesterDBInterface()
+        self.db_interface = db_interface
         self.logger = logging.getLogger("harvest_runner")
 
         error_data = {
@@ -52,10 +52,10 @@ class HarvestNonCriticalException(Exception):
         self.type = "record"
         self.harvest_record_id = record_id
 
-        self.db_interface = HarvesterDBInterface()
+        self.db_interface = db_interface
         self.logger = logging.getLogger("harvest_runner")
 
-        self.error_data = {
+        error_data = {
             "harvest_job_id": self.harvest_job_id,
             "message": self.msg,
             "severity": self.severity,
@@ -64,7 +64,7 @@ class HarvestNonCriticalException(Exception):
             "harvest_record_id": record_id,  # to-do
         }
 
-        # self.db_interface.add_harvest_error(error_data)
+        self.db_interface.add_harvest_error(error_data)
         self.logger.error(self.msg, exc_info=True)
 
 
@@ -72,7 +72,7 @@ class ValidationException(HarvestNonCriticalException):
     def __init__(self, msg, harvest_job_id, record_id):
         super().__init__(msg, harvest_job_id, record_id)
 
-        # self.db_interface.update_harvest_record(record_id, {"status": "error"})
+        self.db_interface.update_harvest_record(record_id, {"status": "error"})
 
 
 class TranformationException(HarvestNonCriticalException):

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -1,8 +1,7 @@
 import logging
 from datetime import datetime
 
-from database.interface import HarvesterDBInterface
-from . import db_interface
+from . import HarvesterDBInterface, db_interface
 
 
 # critical exceptions

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+from database.interface import HarvesterDBInterface
 from . import db_interface
 
 
@@ -14,7 +15,7 @@ class HarvestCriticalException(Exception):
         self.severity = "CRITICAL"
         self.type = "job"
 
-        self.db_interface = db_interface
+        self.db_interface: HarvesterDBInterface = db_interface
         self.logger = logging.getLogger("harvest_runner")
 
         error_data = {
@@ -52,7 +53,7 @@ class HarvestNonCriticalException(Exception):
         self.type = "record"
         self.harvest_record_id = record_id
 
-        self.db_interface = db_interface
+        self.db_interface: HarvesterDBInterface = db_interface
         self.logger = logging.getLogger("harvest_runner")
 
         error_data = {

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -90,7 +90,7 @@ class HarvestSource:
     internal_records: dict = field(default_factory=lambda: {}, repr=False)
 
     def __post_init__(self) -> None:
-        self._db_interface = db_interface
+        self._db_interface: HarvesterDBInterface = db_interface
         self.get_source_info_from_job_id(self.job_id)
 
     @property
@@ -98,7 +98,7 @@ class HarvestSource:
         return self._job_id
 
     @property
-    def db_interface(self):
+    def db_interface(self) -> HarvesterDBInterface:
         return self._db_interface
 
     @property

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -31,8 +31,9 @@ from .utils import (
     download_waf,
     traverse_waf,
 )
-
 from database.interface import HarvesterDBInterface
+
+from . import db_interface
 
 # requests data
 session = requests.Session()
@@ -58,7 +59,6 @@ class HarvestSource:
     """Class for Harvest Sources"""
 
     _job_id: str
-    _db_interface: HarvesterDBInterface
 
     _source_attrs: dict = field(
         default_factory=lambda: [
@@ -90,6 +90,7 @@ class HarvestSource:
     internal_records: dict = field(default_factory=lambda: {}, repr=False)
 
     def __post_init__(self) -> None:
+        self._db_interface = db_interface
         self.get_source_info_from_job_id(self.job_id)
 
     @property
@@ -97,7 +98,7 @@ class HarvestSource:
         return self._job_id
 
     @property
-    def db_interface(self) -> HarvesterDBInterface:
+    def db_interface(self):
         return self._db_interface
 
     @property
@@ -218,7 +219,6 @@ class HarvestSource:
         self.compare()
 
     def write_compare_to_db(self) -> dict:
-
         records = []
 
         for action, ids in self.compare_data.items():
@@ -276,10 +276,7 @@ class HarvestSource:
                     DCATUSToCKANException,
                     SynchronizeException,
                 ) as e:
-                    self.db_interface.add_harvest_error(e.error_data)
-                    self.db_interface.update_harvest_record(
-                        e.harvest_record_id, {"status": "error"}
-                    )
+                    pass
 
     def report(self) -> None:
         logger.info("report results")

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 import ckanapi
 import requests
-
 from jsonschema import Draft202012Validator
 
+from . import HarvesterDBInterface, db_interface
 from .ckan_utils import ckanify_dcatus
 from .exceptions import (
     CompareException,
@@ -21,19 +21,15 @@ from .exceptions import (
     SynchronizeException,
     ValidationException,
 )
-
 from .utils import (
     dataset_to_hash,
-    open_json,
     download_file,
-    sort_dataset,
-    get_title_from_fgdc,
     download_waf,
+    get_title_from_fgdc,
+    open_json,
+    sort_dataset,
     traverse_waf,
 )
-from database.interface import HarvesterDBInterface
-
-from . import db_interface
 
 # requests data
 session = requests.Session()

--- a/harvester/utils.py
+++ b/harvester/utils.py
@@ -6,8 +6,8 @@ import xml.etree.ElementTree as ET
 from typing import Union
 
 import requests
-from bs4 import BeautifulSoup
 import sansjson
+from bs4 import BeautifulSoup
 from cloudfoundry_client.client import CloudFoundryClient
 from cloudfoundry_client.v3.tasks import TaskManager
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,14 @@
-import os
 import logging
+import os
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from dotenv import load_dotenv
-from sqlalchemy.orm import scoped_session, sessionmaker
-from app import create_app
 from flask import Flask
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from app import create_app
 from database.interface import HarvesterDBInterface
 from database.models import db
 from harvester.utils import CFHandler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
+import logging
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from dotenv import load_dotenv
@@ -11,6 +13,8 @@ from database.models import db
 from harvester.utils import CFHandler
 
 load_dotenv()
+
+logger = logging.getLogger("pytest.conftest")
 
 EXAMPLE_DATA = Path(__file__).parents[1] / "example_data"
 
@@ -45,6 +49,16 @@ def session(app) -> scoped_session:
 @pytest.fixture(scope="function")
 def interface(session) -> HarvesterDBInterface:
     return HarvesterDBInterface(session=session)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def default_session_fixture(interface):
+    logger.info("Patching core.feature.service")
+    with patch("harvester.harvest.db_interface", interface), patch(
+        "harvester.exceptions.db_interface", interface
+    ):
+        yield
+    logger.info("Patching complete. Unpatching")
 
 
 @pytest.fixture

--- a/tests/integration/cf/test_load_manager.py
+++ b/tests/integration/cf/test_load_manager.py
@@ -1,9 +1,13 @@
+from unittest.mock import patch
+
 import pytest
 
-from unittest.mock import patch
-from app.scripts.load_manager import load_manager, sort_jobs
-from app.scripts.load_manager import CFHandler
-from app.scripts.load_manager import HarvesterDBInterface
+from app.scripts.load_manager import (
+    CFHandler,
+    HarvesterDBInterface,
+    load_manager,
+    sort_jobs,
+)
 
 
 @pytest.fixture

--- a/tests/integration/compare/test_compare.py
+++ b/tests/integration/compare/test_compare.py
@@ -27,7 +27,7 @@ class TestCompare:
             }
             interface.add_harvest_record(data)
 
-        harvest_source = HarvestSource(internal_compare_data["job_id"], interface)
+        harvest_source = HarvestSource(internal_compare_data["job_id"])
         harvest_source.get_record_changes()
 
         assert len(harvest_source.compare_data["create"]) == 6

--- a/tests/integration/database/test_db.py
+++ b/tests/integration/database/test_db.py
@@ -308,10 +308,10 @@ class TestDatabase:
 
             interface.add_harvest_record(data)
 
-        harvest_source = HarvestSource(job_data_dcatus["id"], interface)
+        harvest_source = HarvestSource(job_data_dcatus["id"])
         harvest_source.get_record_changes()
 
-        harvest_records = harvest_source.write_compare_to_db()
+        harvest_source.write_compare_to_db()
 
         expected = sorted(
             [
@@ -326,5 +326,5 @@ class TestDatabase:
             ]
         )
 
-        assert len(harvest_records) == 8
-        assert sorted(list(harvest_records.keys())) == expected
+        assert len(harvest_source.internal_records_lookup_table) == 8
+        assert sorted(list(harvest_source.internal_records_lookup_table)) == expected

--- a/tests/integration/exception/test_exception_handling.py
+++ b/tests/integration/exception/test_exception_handling.py
@@ -1,5 +1,10 @@
 # ruff: noqa: F841
 
+from unittest.mock import patch
+
+import ckanapi
+import pytest
+
 import harvester
 from harvester.exceptions import (
     DCATUSToCKANException,
@@ -9,10 +14,6 @@ from harvester.exceptions import (
     ValidationException,
 )
 from harvester.harvest import HarvestSource
-
-import ckanapi
-import pytest
-from unittest.mock import patch
 
 
 class TestExceptionHandling:

--- a/tests/integration/exception/test_exception_handling.py
+++ b/tests/integration/exception/test_exception_handling.py
@@ -27,7 +27,7 @@ class TestExceptionHandling:
         interface.add_harvest_source(source_data_dcatus_bad_url)
         harvest_job = interface.add_harvest_job(job_data_dcatus_bad_url)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
+        harvest_source = HarvestSource(harvest_job.id)
 
         with pytest.raises(ExtractExternalException) as e:
             harvest_source.prepare_external_data()
@@ -43,27 +43,24 @@ class TestExceptionHandling:
         source_data_dcatus_invalid,
         job_data_dcatus_invalid,
     ):
-        org = interface.add_organization(organization_data)
-        source = interface.add_harvest_source(source_data_dcatus_invalid)
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_invalid)
         harvest_job = interface.add_harvest_job(job_data_dcatus_invalid)
 
-        with patch("harvester.harvest.db_interface", interface), patch(
-            "harvester.exceptions.db_interface", interface
-        ):
-            harvest_source = HarvestSource(harvest_job.id)
-            harvest_source.get_record_changes()
-            harvest_source.write_compare_to_db()
-            harvest_source.synchronize_records()
-            test_record = harvest_source.external_records["null-spatial"]
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
+        harvest_source.synchronize_records()
+        test_record = harvest_source.external_records["null-spatial"]
 
-            interface_record = interface.get_harvest_record(
-                harvest_source.internal_records_lookup_table[test_record.identifier]
-            )
-            assert (
-                interface_record["id"]
-                == harvest_source.internal_records_lookup_table[test_record.identifier]
-            )
-            assert interface_record["status"] == "error"
+        interface_record = interface.get_harvest_record(
+            harvest_source.internal_records_lookup_table[test_record.identifier]
+        )
+        assert (
+            interface_record["id"]
+            == harvest_source.internal_records_lookup_table[test_record.identifier]
+        )
+        assert interface_record["status"] == "error"
 
     def test_dcatus_to_ckan_exception(
         self,
@@ -97,7 +94,7 @@ class TestExceptionHandling:
         source = interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
+        harvest_source = HarvestSource(harvest_job.id)
         harvest_source.prepare_external_data()
 
         test_record = harvest_source.external_records["cftc-dc1"]

--- a/tests/integration/exception/test_exception_handling.py
+++ b/tests/integration/exception/test_exception_handling.py
@@ -23,7 +23,6 @@ class TestExceptionHandling:
         source_data_dcatus_bad_url,
         job_data_dcatus_bad_url,
     ):
-
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_bad_url)
         harvest_job = interface.add_harvest_job(job_data_dcatus_bad_url)
@@ -44,18 +43,27 @@ class TestExceptionHandling:
         source_data_dcatus_invalid,
         job_data_dcatus_invalid,
     ):
-
-        interface.add_organization(organization_data)
+        org = interface.add_organization(organization_data)
         source = interface.add_harvest_source(source_data_dcatus_invalid)
         harvest_job = interface.add_harvest_job(job_data_dcatus_invalid)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
-        harvest_source.prepare_external_data()
-
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
+        harvest_source.synchronize_records()
         test_record = harvest_source.external_records["null-spatial"]
 
-        with pytest.raises(ValidationException) as e:
-            test_record.validate()
+        # with pytest.raises(ValidationException) as e:
+        #     test_record.validate()
+
+        interface_record = interface.get_harvest_record(
+            harvest_source.internal_records_lookup_table[test_record.identifier]
+        )
+        assert (
+            interface_record["id"]
+            == harvest_source.internal_records_lookup_table[test_record.identifier]
+        )
+        assert interface_record["status"] == "error"
 
     def test_dcatus_to_ckan_exception(
         self,
@@ -64,12 +72,11 @@ class TestExceptionHandling:
         source_data_dcatus_invalid,
         job_data_dcatus_invalid,
     ):
-
         interface.add_organization(organization_data)
         source = interface.add_harvest_source(source_data_dcatus_invalid)
         harvest_job = interface.add_harvest_job(job_data_dcatus_invalid)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
+        harvest_source = HarvestSource(harvest_job.id)
         harvest_source.prepare_external_data()
 
         test_record = harvest_source.external_records["null-spatial"]
@@ -86,7 +93,6 @@ class TestExceptionHandling:
         source_data_dcatus,
         job_data_dcatus,
     ):
-
         interface.add_organization(organization_data)
         source = interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)

--- a/tests/integration/exception/test_exception_handling.py
+++ b/tests/integration/exception/test_exception_handling.py
@@ -47,23 +47,23 @@ class TestExceptionHandling:
         source = interface.add_harvest_source(source_data_dcatus_invalid)
         harvest_job = interface.add_harvest_job(job_data_dcatus_invalid)
 
-        harvest_source = HarvestSource(harvest_job.id)
-        harvest_source.get_record_changes()
-        harvest_source.write_compare_to_db()
-        harvest_source.synchronize_records()
-        test_record = harvest_source.external_records["null-spatial"]
+        with patch("harvester.harvest.db_interface", interface), patch(
+            "harvester.exceptions.db_interface", interface
+        ):
+            harvest_source = HarvestSource(harvest_job.id)
+            harvest_source.get_record_changes()
+            harvest_source.write_compare_to_db()
+            harvest_source.synchronize_records()
+            test_record = harvest_source.external_records["null-spatial"]
 
-        # with pytest.raises(ValidationException) as e:
-        #     test_record.validate()
-
-        interface_record = interface.get_harvest_record(
-            harvest_source.internal_records_lookup_table[test_record.identifier]
-        )
-        assert (
-            interface_record["id"]
-            == harvest_source.internal_records_lookup_table[test_record.identifier]
-        )
-        assert interface_record["status"] == "error"
+            interface_record = interface.get_harvest_record(
+                harvest_source.internal_records_lookup_table[test_record.identifier]
+            )
+            assert (
+                interface_record["id"]
+                == harvest_source.internal_records_lookup_table[test_record.identifier]
+            )
+            assert interface_record["status"] == "error"
 
     def test_dcatus_to_ckan_exception(
         self,

--- a/tests/integration/extract/test_extract.py
+++ b/tests/integration/extract/test_extract.py
@@ -14,7 +14,7 @@ class TestExtract:
         interface.add_harvest_source(source_data_waf)
         harvest_job = interface.add_harvest_job(job_data_waf)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
+        harvest_source = HarvestSource(harvest_job.id)
         harvest_source.prepare_external_data()
 
         assert len(harvest_source.external_records) == 7
@@ -31,7 +31,7 @@ class TestExtract:
         interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
+        harvest_source = HarvestSource(harvest_job.id)
         harvest_source.prepare_external_data()
 
         assert len(harvest_source.external_records) == 7

--- a/tests/integration/load/test_ckan_load.py
+++ b/tests/integration/load/test_ckan_load.py
@@ -45,7 +45,7 @@ class TestCKANLoad:
             }
             interface.add_harvest_record(data)
 
-        harvest_source = HarvestSource(internal_compare_data["job_id"], interface)
+        harvest_source = HarvestSource(internal_compare_data["job_id"])
         harvest_source.get_record_changes()
         harvest_source.synchronize_records()
 
@@ -76,7 +76,7 @@ class TestCKANLoad:
         interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
+        harvest_source = HarvestSource(harvest_job.id)
         harvest_source.prepare_external_data()
 
         expected_result = {

--- a/tests/integration/validate/test_validate_dcatus.py
+++ b/tests/integration/validate/test_validate_dcatus.py
@@ -14,7 +14,7 @@ class TestValidateDCATUS:
         interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)
 
-        harvest_source = HarvestSource(harvest_job.id, interface)
+        harvest_source = HarvestSource(harvest_job.id)
         harvest_source.prepare_external_data()
 
         test_record = harvest_source.external_records["cftc-dc1"]


### PR DESCRIPTION
# Pull Request

Resolves https://github.com/GSA/data.gov/issues/4747
Resolves https://github.com/GSA/data.gov/issues/4764

## About

Allows us to patch the db_interface by outputting it from a common exported instance in `/harvest/__init__`.

Adds global patch to conftest to reduce testing boilerplate.

Note: this moves attaching of the db_interface to Harvest Source to the __post_init__ method due to the particularities of the python dataclass

## PR TASKS

- [X] The actual code changes.
- [X] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [pyproject.toml](https://github.com/GSA/datagov-harvesting-logic/blob/8078c5b9f015ca7fb8a142e4e4b2e22ad2fd49b1/pyproject.toml#L3) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
