### PR TITLE
Writes harvest error to db when harvester fails to delete a record;

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -300,7 +300,7 @@ def get_harvest_error(error_id=None):
 
         job_id = request.args.get("harvest_job_id")
         if job_id:
-            error = db.get_harvest_error_by_job(job_id)
+            error = db.get_harvest_errors_by_job(job_id)
             if not error:
                 return "No harvest errors found for this harvest job", 404
         else:

--- a/database/interface.py
+++ b/database/interface.py
@@ -203,8 +203,14 @@ class HarvesterDBInterface:
         result = self.db.query(HarvestError).filter_by(id=error_id).first()
         return HarvesterDBInterface._to_dict(result)
 
-    def get_harvest_error_by_job(self, job_id):
+    def get_harvest_errors_by_job(self, job_id: str) -> list:
         harvest_errors = self.db.query(HarvestError).filter_by(harvest_job_id=job_id)
+        return [HarvesterDBInterface._to_dict(err) for err in harvest_errors]
+
+    def get_harvest_errors_by_record_id(self, record_id: str) -> list:
+        harvest_errors = self.db.query(HarvestError).filter_by(
+            harvest_record_id=record_id
+        )
         return [HarvesterDBInterface._to_dict(err) for err in harvest_errors]
 
     def add_harvest_record(self, record_data):

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from . import HarvesterDBInterface, db_interface
 
@@ -12,7 +12,6 @@ class HarvestCriticalException(Exception):
         self.msg = msg
         self.harvest_job_id = harvest_job_id
         self.severity = "CRITICAL"
-        self.type = "job"
 
         self.db_interface: HarvesterDBInterface = db_interface
         self.logger = logging.getLogger("harvest_runner")
@@ -21,8 +20,8 @@ class HarvestCriticalException(Exception):
             "harvest_job_id": self.harvest_job_id,
             "message": self.msg,
             "severity": self.severity,
-            "type": self.type,
-            "date_created": datetime.utcnow(),
+            "type": self.__class__.__name__,
+            "date_created": datetime.now(timezone.utc),
         }
 
         self.db_interface.add_harvest_error(error_data)
@@ -49,7 +48,6 @@ class HarvestNonCriticalException(Exception):
         self.msg = msg
         self.harvest_job_id = harvest_job_id
         self.severity = "ERROR"
-        self.type = "record"
         self.harvest_record_id = record_id
 
         self.db_interface: HarvesterDBInterface = db_interface
@@ -59,8 +57,8 @@ class HarvestNonCriticalException(Exception):
             "harvest_job_id": self.harvest_job_id,
             "message": self.msg,
             "severity": self.severity,
-            "type": self.type,
-            "date_created": datetime.utcnow(),
+            "type": self.__class__.__name__,
+            "date_created": datetime.now(timezone.utc),
             "harvest_record_id": record_id,  # to-do
         }
 

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -256,7 +256,18 @@ class HarvestSource:
                             self, self.internal_records[i].identifier
                         )
                         self.external_records[i].action = action
-                        self.external_records[i].delete_record()
+                        try:
+                            self.external_records[i].delete_record()
+                        except Exception as e:
+                            raise SynchronizeException(
+                                f"failed to {self.external_records[i].action} \
+                                    for {self.external_records[i].identifier} :: \
+                                        {repr(e)}",
+                                self.job_id,
+                                self.internal_records_lookup_table[
+                                    self.external_records[i].identifier
+                                ],
+                            )
                         continue
 
                     record = self.external_records[i]
@@ -393,7 +404,7 @@ class Record:
             self.valid = False
             # TODO: do something with 'e' in logger?
             raise ValidationException(
-                f"{self.identifier} failed validation",
+                repr(e),
                 self.harvest_source.job_id,
                 self.harvest_source.internal_records_lookup_table[self.identifier],
             )
@@ -417,7 +428,7 @@ class Record:
             )
         except Exception as e:
             raise DCATUSToCKANException(
-                f"failed to convert dcatus to ckan for {self.identifier}",
+                repr(e),
                 self.harvest_source.job_id,
                 self.harvest_source.name,
             )
@@ -438,9 +449,8 @@ class Record:
             if self.action == "update":
                 self.update_record()
         except Exception as e:
-            # TODO: something with 'e'
             raise SynchronizeException(
-                f"failed to {self.action} for {self.identifier}",
+                f"failed to {self.action} for {self.identifier} :: {repr(e)}",
                 self.harvest_source.job_id,
                 self.identifier,
             )


### PR DESCRIPTION
adds new get_harvest_errors_by_record_id method
updates exceptions to map type to error class
fixes deprecation issue with datetime;

# Pull Request

Resolves https://github.com/GSA/data.gov/issues/4746

## About

<!-- any pertinent notes -->

## PR TASKS

- [X] The actual code changes.
- [X] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [pyproject.toml](https://github.com/GSA/datagov-harvesting-logic/blob/8078c5b9f015ca7fb8a142e4e4b2e22ad2fd49b1/pyproject.toml#L3) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
