### PR TITLE
Update DB on Job Complete

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -1,7 +1,7 @@
 import uuid
 
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy import Enum, func, String, Column
+from sqlalchemy import Column, Enum, String, func
 from sqlalchemy.orm import DeclarativeBase
 
 
@@ -10,6 +10,7 @@ class Base(DeclarativeBase):
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
 
 
+# For ref: https://stackoverflow.com/questions/22698478/what-is-the-difference-between-the-declarative-base-and-db-model
 db = SQLAlchemy(model_class=Base)
 
 

--- a/example_data/dcatus/dcatus_single_record.json
+++ b/example_data/dcatus/dcatus_single_record.json
@@ -1,0 +1,35 @@
+{
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@id": "http://www.cftc.gov/data.json",
+    "@type": "dcat:Catalog",
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "dataset": [
+        {
+            "contactPoint": {
+                "fn": "Harold W. Hild",
+                "hasEmail": "mailto:hhild@CFTC.GOV"
+            },
+            "describedBy": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/ExplanatoryNotes/index.htm",
+            "description": "COT reports provide a breakdown of each Tuesday's open interest for futures and options on futures market in which 20 or more traders hold positions equal to or above the reporting levels established by CFTC",
+            "distribution": [
+                {
+                    "accessURL": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/index.htm"
+                }
+            ],
+            "modified": "R/P1W",
+            "programCode": ["000:000"],
+            "publisher": {
+                "name": "U.S. Commodity Futures Trading Commission",
+                "subOrganizationOf": {
+                    "name": "U.S. Government"
+                }
+            },
+            "title": "Commitment of Traders",
+            "accessLevel": "public",
+            "bureauCode": ["339:00"],
+            "identifier": "cftc-dc1",
+            "keyword": ["commitment of traders", "cot", "open interest"]
+        }
+    ]
+}

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -27,8 +27,7 @@ class HarvestCriticalException(Exception):
             "date_finished": datetime.now(timezone.utc),
         }
 
-        self.db_interface.add_harvest_error(error_data, "job")
-        self.db_interface.add_harvest_error(error_data)
+        self.db_interface.add_harvest_job_error(error_data)
         self.db_interface.update_harvest_job(harvest_job_id, job_status)
         self.logger.critical(self.msg, exc_info=True)
 
@@ -64,7 +63,7 @@ class HarvestNonCriticalException(Exception):
             "harvest_record_id": record_id,  # to-do
         }
 
-        self.db_interface.add_harvest_error(error_data, "record")
+        self.db_interface.add_harvest_record_error(error_data)
         self.db_interface.update_harvest_record(record_id, {"status": "error"})
         self.logger.error(self.msg, exc_info=True)
 

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -22,7 +22,14 @@ class HarvestCriticalException(Exception):
             "date_created": datetime.now(timezone.utc),
         }
 
+        job_status = {
+            "status": "error",
+            "date_finished": datetime.now(timezone.utc),
+        }
+
         self.db_interface.add_harvest_error(error_data, "job")
+        self.db_interface.add_harvest_error(error_data)
+        self.db_interface.update_harvest_job(harvest_job_id, job_status)
         self.logger.critical(self.msg, exc_info=True)
 
 

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -118,7 +118,7 @@ class HarvestSource:
     def get_source_info_from_job_id(self, job_id: str) -> None:
         # TODO: validate values here?
         try:
-            source_data = self.db_interface.get_source_by_jobid(job_id)
+            source_data = self.db_interface.get_harvest_source_by_jobid(job_id)
             for attr in self.source_attrs:
                 setattr(self, attr, source_data[attr])
         except Exception as e:

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -4,7 +4,7 @@ import functools
 import logging
 import os
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -320,7 +320,7 @@ class HarvestSource:
 
         job_status = {
             "status": "complete",
-            "date_created": datetime.now(),
+            "date_finished": datetime.now(timezone.utc),
             "records_added": actual_results["created"],
             "records_updated": actual_results["updated"],
             "records_deleted": actual_results["deleted"],
@@ -459,7 +459,7 @@ class Record:
 
         self.ckanify_dcatus()
 
-        start = datetime.now()
+        start = datetime.now(timezone.utc)
 
         try:
             if self.action == "create":
@@ -476,7 +476,10 @@ class Record:
 
         self.harvest_source.db_interface.update_harvest_record(
             self.harvest_source.internal_records_lookup_table[self.identifier],
-            {"status": "success", "date_finished": datetime.now()},
+            {"status": "success", "date_finished": datetime.now(timezone.utc)},
         )
 
-        logger.info(f"time to {self.action} {self.identifier} {datetime.now()-start}")
+        logger.info(
+            f"time to {self.action} {self.identifier} \
+                {datetime.now(timezone.utc)-start}"
+        )

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -117,14 +117,15 @@ class HarvestSource:
 
     def get_source_info_from_job_id(self, job_id: str) -> None:
         # TODO: validate values here?
-        source_data = self.db_interface.get_source_by_jobid(job_id)
-        if source_data is None:
+        try:
+            source_data = self.db_interface.get_source_by_jobid(job_id)
+            for attr in self.source_attrs:
+                setattr(self, attr, source_data[attr])
+        except Exception as e:
             raise ExtractInternalException(
                 f"failed to extract source info from {job_id}. exiting",
                 self.job_id,
             )
-        for attr in self.source_attrs:
-            setattr(self, attr, source_data[attr])
 
     def internal_records_to_id_hash(self, records: list[dict]) -> None:
         for record in records:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,6 +112,21 @@ def source_data_dcatus_2(organization_data: dict) -> dict:
 
 
 @pytest.fixture
+def source_data_dcatus_single_record(organization_data: dict) -> dict:
+    return {
+        "id": "2f2652de-91df-4c63-8b53-bfced20b276b",
+        "name": "Single Record Test Source",
+        "notification_emails": "email@example.com",
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_single_record.json",
+        "schema_type": "type1",
+        "source_type": "dcatus",
+        "status": "active",
+    }
+
+
+@pytest.fixture
 def source_data_waf(organization_data: dict) -> dict:
     return {
         "id": "55dca495-3b92-4fe4-b9c5-d433cbc3c82d",

--- a/tests/integration/database/test_db.py
+++ b/tests/integration/database/test_db.py
@@ -98,7 +98,7 @@ class TestDatabase:
         job_data_dcatus["harvest_source_id"] = source.id
 
         harvest_job = interface.add_harvest_job(job_data_dcatus)
-        harvest_source = interface.get_source_by_jobid(harvest_job.id)
+        harvest_source = interface.get_harvest_source_by_jobid(harvest_job.id)
 
         assert source.id == harvest_source["id"]
 
@@ -113,31 +113,10 @@ class TestDatabase:
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus)
         interface.add_harvest_job(job_data_dcatus)
+        harvest_job_error = interface.add_harvest_job_error(job_error_data)
 
-        harvest_job_error = interface.add_harvest_error(job_error_data, "job")
         assert isinstance(harvest_job_error, HarvestJobError)
         assert harvest_job_error.message == job_error_data["message"]
-
-    def test_get_all_errors_of_job(
-        self,
-        interface,
-        organization_data,
-        source_data_dcatus,
-        job_data_dcatus,
-        job_error_data,
-    ):
-        interface.add_organization(organization_data)
-        interface.add_harvest_source(source_data_dcatus)
-        interface.add_harvest_job(job_data_dcatus)
-        interface.add_harvest_error(job_error_data, "job")
-
-        all_errors = interface.get_all_errors_of_job(job_data_dcatus["id"])
-
-        assert len(all_errors) == 2
-        assert len(all_errors[0]) == 1  # job error
-        assert len(all_errors[1]) == 0  # record errors
-        assert all_errors[0][0]["type"] == "ExtractInternalException"
-        assert len(all_errors[1]) == 0
 
     def test_add_harvest_record(
         self,
@@ -170,11 +149,11 @@ class TestDatabase:
         interface.add_harvest_job(job_data_dcatus)
         interface.add_harvest_record(record_data_dcatus)
 
-        harvest_record_error = interface.add_harvest_error(record_error_data, "record")
+        harvest_record_error = interface.add_harvest_record_error(record_error_data)
         assert isinstance(harvest_record_error, HarvestRecordError)
         assert harvest_record_error.message == record_error_data["message"]
 
-        harvest_record_error_from_db = interface.get_harvest_record_error(
+        harvest_record_error_from_db = interface.get_harvest_error(
             harvest_record_error.id
         )
         assert harvest_record_error.id == harvest_record_error_from_db["id"]
@@ -278,7 +257,7 @@ class TestDatabase:
         interface.add_harvest_job(job_data_dcatus_2)
         interface.add_harvest_records(latest_records)
 
-        latest_records = interface.get_latest_records_by_source(
+        latest_records = interface.get_latest_harvest_records_by_source(
             source_data_dcatus["id"]
         )
 
@@ -349,7 +328,6 @@ class TestDatabase:
         interface,
         internal_compare_data,
     ):
-
         # add the necessary records to satisfy FKs
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus)

--- a/tests/integration/exception/test_exception_handling.py
+++ b/tests/integration/exception/test_exception_handling.py
@@ -13,7 +13,7 @@ def download_mock(_, __):
     return dict({"dataset": []})
 
 
-class TestCriticalExceptionHandling:
+class TestHarvestJobExceptionHandling:
     def test_bad_harvest_source_url_exception(
         self,
         interface,
@@ -32,7 +32,7 @@ class TestCriticalExceptionHandling:
 
         assert harvest_job.status == "error"
 
-        harvest_error = interface.get_harvest_errors_by_job(harvest_job.id)[0]
+        harvest_error = interface.get_harvest_job_errors_by_job(harvest_job.id)[0]
         assert harvest_error["type"] == "ExtractExternalException"
 
     def test_extract_internal_exception(
@@ -56,7 +56,7 @@ class TestCriticalExceptionHandling:
 
         assert harvest_job.status == "error"
 
-        harvest_error = interface.get_harvest_errors_by_job(harvest_job.id)[0]
+        harvest_error = interface.get_harvest_job_errors_by_job(harvest_job.id)[0]
         assert harvest_error["type"] == "ExtractInternalException"
 
     def test_no_source_info_exception(self, job_data_dcatus):
@@ -64,7 +64,7 @@ class TestCriticalExceptionHandling:
             HarvestSource(job_data_dcatus["id"])
 
 
-class TestNonCritialExceptionHandling:
+class TestHarvestRecordExceptionHandling:
     @patch("harvester.harvest.ckan", ckanapi.RemoteCKAN("mock_address"))
     @patch("harvester.harvest.download_file", download_mock)
     def test_delete_exception(
@@ -91,7 +91,7 @@ class TestNonCritialExceptionHandling:
                 single_internal_record["identifier"]
             ]
         )
-        interface_errors = interface.get_harvest_record_errors(
+        interface_errors = interface.get_harvest_record_errors_by_record(
             harvest_source.internal_records_lookup_table[
                 single_internal_record["identifier"]
             ]
@@ -125,7 +125,7 @@ class TestNonCritialExceptionHandling:
         interface_record = interface.get_harvest_record(
             harvest_source.internal_records_lookup_table[test_record.identifier]
         )
-        interface_errors = interface.get_harvest_record_errors(
+        interface_errors = interface.get_harvest_record_errors_by_record(
             harvest_source.internal_records_lookup_table[test_record.identifier]
         )
         assert (
@@ -158,7 +158,7 @@ class TestNonCritialExceptionHandling:
         interface_record = interface.get_harvest_record(
             harvest_source.internal_records_lookup_table[test_record.identifier]
         )
-        interface_errors = interface.get_harvest_record_errors(
+        interface_errors = interface.get_harvest_record_errors_by_record(
             harvest_source.internal_records_lookup_table[test_record.identifier]
         )
 
@@ -194,7 +194,7 @@ class TestNonCritialExceptionHandling:
             harvest_source.internal_records_lookup_table[test_record.identifier]
         )
 
-        interface_errors = interface.get_harvest_record_errors(
+        interface_errors = interface.get_harvest_record_errors_by_record(
             harvest_source.internal_records_lookup_table[test_record.identifier]
         )
 

--- a/tests/integration/full-flow/test_harvest_full_flow.py
+++ b/tests/integration/full-flow/test_harvest_full_flow.py
@@ -7,13 +7,12 @@ class TestHarvestFullFlow:
     @patch("harvester.harvest.ckan")
     def test_harvest_single_record_created(
         self,
-        CKANMOCK,
+        CKANMock,
         interface,
         organization_data,
         source_data_dcatus_single_record,
-        single_internal_record,
     ):
-        CKANMOCK.return_value.action = "ok"
+        CKANMock.return_value.action = "ok"
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_single_record)
         harvest_job = interface.add_harvest_job(
@@ -33,10 +32,10 @@ class TestHarvestFullFlow:
 
     @patch("harvester.harvest.RemoteCKAN")
     @patch("harvester.harvest.download_file")
-    def test_harvest_errors_reported(
+    def test_harvest_record_errors_reported(
         self,
-        CKANMock,
         download_file_mock,
+        CKANMock,
         interface,
         organization_data,
         source_data_dcatus,

--- a/tests/integration/full-flow/test_harvest_full_flow.py
+++ b/tests/integration/full-flow/test_harvest_full_flow.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+from harvester.harvest import HarvestSource
+
+
+class TestHarvestFullFlow:
+    @patch("harvester.harvest.ckan")
+    def test_harvest_single_record_created(
+        self,
+        CKANMOCK,
+        interface,
+        organization_data,
+        source_data_dcatus_single_record,
+        single_internal_record,
+    ):
+        CKANMOCK.return_value.action = "ok"
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_single_record)
+        harvest_job = interface.add_harvest_job(
+            {
+                "status": "pending",
+                "harvest_source_id": source_data_dcatus_single_record["id"],
+            }
+        )
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
+        harvest_source.synchronize_records()
+        harvest_source.report()
+
+        assert harvest_job.status == "complete"
+        assert harvest_job.records_added == len(harvest_source.external_records)
+
+    @patch("harvester.harvest.RemoteCKAN")
+    @patch("harvester.harvest.download_file")
+    def test_harvest_errors_reported(
+        self,
+        CKANMock,
+        download_file_mock,
+        interface,
+        organization_data,
+        source_data_dcatus,
+        job_data_dcatus,
+        single_internal_record,
+    ):
+        CKANMock.return_value.action.dataset_purge.side_effect = Exception()
+        download_file_mock.return_value = dict({"dataset": []})
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus)
+        harvest_job = interface.add_harvest_job(job_data_dcatus)
+
+        interface.add_harvest_record(single_internal_record)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
+        harvest_source.synchronize_records()
+        harvest_source.report()
+
+        interface_errors = interface.get_harvest_errors_by_record_id(
+            harvest_source.internal_records_lookup_table[
+                single_internal_record["identifier"]
+            ]
+        )
+
+        assert harvest_job.status == "complete"
+        assert len(interface_errors) == harvest_job.records_errored
+        assert len(interface_errors) == len(harvest_job.errors)
+        assert (
+            interface_errors[0]["harvest_record_id"]
+            == harvest_job.errors[0].harvest_record_id
+        )

--- a/tests/integration/full-flow/test_harvest_full_flow.py
+++ b/tests/integration/full-flow/test_harvest_full_flow.py
@@ -17,7 +17,7 @@ class TestHarvestFullFlow:
         interface.add_harvest_source(source_data_dcatus_single_record)
         harvest_job = interface.add_harvest_job(
             {
-                "status": "pending",
+                "status": "new",
                 "harvest_source_id": source_data_dcatus_single_record["id"],
             }
         )
@@ -56,16 +56,18 @@ class TestHarvestFullFlow:
         harvest_source.synchronize_records()
         harvest_source.report()
 
-        interface_errors = interface.get_harvest_errors_by_record_id(
+        interface_errors = interface.get_harvest_record_errors_by_record(
             harvest_source.internal_records_lookup_table[
                 single_internal_record["identifier"]
             ]
         )
 
+        job_errors = [
+            error for record in harvest_job.records for error in record.errors
+        ]
         assert harvest_job.status == "complete"
         assert len(interface_errors) == harvest_job.records_errored
-        assert len(interface_errors) == len(harvest_job.errors)
+        assert len(interface_errors) == len(job_errors)
         assert (
-            interface_errors[0]["harvest_record_id"]
-            == harvest_job.errors[0].harvest_record_id
+            interface_errors[0]["harvest_record_id"] == job_errors[0].harvest_record_id
         )

--- a/tests/integration/load/test_ckan_load.py
+++ b/tests/integration/load/test_ckan_load.py
@@ -29,7 +29,6 @@ class TestCKANLoad:
         interface,
         internal_compare_data,
     ):
-
         # add the necessary records to satisfy FKs
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus)
@@ -47,6 +46,7 @@ class TestCKANLoad:
 
         harvest_source = HarvestSource(internal_compare_data["job_id"])
         harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
         harvest_source.synchronize_records()
 
         created = sum(
@@ -71,7 +71,6 @@ class TestCKANLoad:
         source_data_dcatus,
         job_data_dcatus,
     ):
-
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)

--- a/tests/unit/cf/test_cf_tasks.py
+++ b/tests/unit/cf/test_cf_tasks.py
@@ -1,88 +1,43 @@
-import collections
 from unittest.mock import patch
 
 from harvester.utils import CFHandler
 
 
-class AppMock:
-    def __init__(self, x):
-        self.tasks = self.tasksMock
-        self.recent_logs = self.logsMock
-
-    def tasksMock(x):
-        return [1, 2, 3]
-
-    def logsMock(x):
-        return [{"cf_task_integration": 1}, 2, 3]
-
-    def __getitem__(self, x):
-        return self
-
-
-class V2Mock:
-    def __init__(self, x):
-        self.apps = AppMock(x)
-
-
-class V3Mock:
-    def __init__(self, x):
-        self.apps = AppMock(x)
-
-
-class CFClientMock:
-    def __init__(self, x):
-        self.v2 = V2Mock(x)
-        self.v3 = V3Mock(x)
-        pass
-
-    def init_with_user_credentials(self, a, b):
-        pass
-
-
-class TaskManagerMock:
-    def __init__(self, x, y):
-        pass
-
-    def create(self, a, b, c):
-        return collections.defaultdict(list)
-
-    def get(self, a):
-        return collections.defaultdict(list)
-
-    def cancel(self, a):
-        return "cancelled"
-
-
-with patch("harvester.utils.CloudFoundryClient", CFClientMock), patch(
-    "harvester.utils.TaskManager", TaskManagerMock
-):
-    CFUtil = CFHandler("url", "user", "password")
-
-
+@patch("harvester.utils.CloudFoundryClient")
+@patch("harvester.utils.TaskManager")
 class TestCFTasking:
-    def test_add_task(self, dhl_cf_task_data):
+    def test_add_task(self, TMMock, CFClientMock, dhl_cf_task_data):
+        CFUtil = CFHandler("url", "user", "password")
         assert CFUtil.start_task(**dhl_cf_task_data) is not None
 
-    def test_get_task(self, dhl_cf_task_data):
+    def test_get_task(self, TMMock, CFClientMock, dhl_cf_task_data):
+        CFUtil = CFHandler("url", "user", "password")
         task = CFUtil.get_task(dhl_cf_task_data["task_id"])
         assert task is not None
 
-    def test_get_all_app_tasks(self, dhl_cf_task_data):
+    def test_get_all_app_tasks(self, TMMock, CFClientMock, dhl_cf_task_data):
+        CFUtil = CFHandler("url", "user", "password")
+        # ruff: noqa: E501
+        CFClientMock.return_value.v3.apps.__getitem__.return_value.tasks.return_value = [
+            1
+        ]
         tasks = CFUtil.get_all_app_tasks(dhl_cf_task_data["app_guuid"])
         assert len(tasks) > 0
 
-    def test_get_all_running_app_tasks(self):
+    def test_get_all_running_app_tasks(self, CFClientMock, TMMock):
+        CFUtil = CFHandler("url", "user", "password")
         tasks = [{"state": "RUNNING"}, {"state": "SUCCEEDED"}]
         running_tasks = CFUtil.get_all_running_tasks(tasks)
         assert running_tasks == 1
 
-    def test_cancel_task(self, dhl_cf_task_data):
+    def test_cancel_task(self, TMMock, CFClientMock, dhl_cf_task_data):
+        CFUtil = CFHandler("url", "user", "password")
         task = CFUtil.stop_task(dhl_cf_task_data["task_id"])
         assert task is not None
 
-    def test_read_recent_task_logs(self, dhl_cf_task_data):
+    def test_read_recent_task_logs(self, TMMock, CFClientMock, dhl_cf_task_data):
+        CFUtil = CFHandler("url", "user", "password")
         logs = CFUtil.read_recent_app_logs(
             dhl_cf_task_data["app_guuid"], dhl_cf_task_data["task_id"]
         )
-
         assert logs is not None


### PR DESCRIPTION
- adds new single record dcat source;
- updates ckan import for better mocking;
- sets error status on internal record prior to raising error; 
- creates job status update dict for report method;
- updates job status on job complete;
- updates record status on success;
- adds tests;
- cleans up mocking;

# Pull Request

Related to https://github.com/GSA/data.gov/issues/4762

## About

Updates db after job complete.

## PR TASKS

- [X] The actual code changes.
- [X] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Bumped version number in [pyproject.toml](https://github.com/GSA/datagov-harvesting-logic/blob/8078c5b9f015ca7fb8a142e4e4b2e22ad2fd49b1/pyproject.toml#L3) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).
