### PR TITLE
Remove harvest source along with associated datasets in CKAN

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -314,7 +314,7 @@ def delete_organization(org_id):
         else:
             raise Exception()
     except Exception:
-        flash("Failed to delete harvest source")
+        flash("Failed to delete organization")
         return {"message": "failed"}
 
 
@@ -473,6 +473,7 @@ def edit_harvest_source(source_id: str):
 
 # Delete Source
 @mod.route("/harvest_source/config/delete/<source_id>", methods=["POST"])
+@login_required
 def delete_harvest_source(source_id):
     try:
         result = db.delete_harvest_source(source_id)

--- a/app/templates/view_data.html
+++ b/app/templates/view_data.html
@@ -28,13 +28,13 @@
             <button class="btn btn-secondary">Harvest</button>
         </a>
         <button class="btn btn-danger"
-            onclick="confirmDelete('harvest source', '/harvest_source/delete/{{source_id}}')">Delete</button>
+            onclick="confirmDelete('harvest source', '/harvest_source/config/delete/{{source_id}}')">Delete</button>
         {% elif org_id %}
         <a href="{{ url_for('harvest.edit_organization', org_id=org_id)}}">
             <button class="btn btn-primary">Edit</button>
         </a>
         <button class="btn btn-danger"
-            onclick="confirmDelete('organization', '/organization/delete/{{org_id}}')">Delete</button>
+            onclick="confirmDelete('organization', '/organization/config/delete/{{org_id}}')">Delete</button>
         {% endif %}
     {% endif %}
 </div>

--- a/app/templates/view_org_data.html
+++ b/app/templates/view_org_data.html
@@ -35,7 +35,7 @@
             </li>
             <li class="usa-button-group__item">
                 <button class="usa-button usa-button--secondary"
-                    onclick="confirmDelete('/organization/delete/{{data.organization.id}}')">Delete</button>
+                    onclick="confirmDelete('/organization/config/delete/{{data.organization.id}}')">Delete</button>
             </li>
         </ul>
     </div>

--- a/app/templates/view_source_data.html
+++ b/app/templates/view_source_data.html
@@ -41,7 +41,7 @@
             </li>
             <li class="usa-button-group__item">
                 <button class="usa-button usa-button--secondary"
-                    onclick="confirmDelete('/harvest_source/delete/{{data.harvest_source.id}}')">Delete</button>
+                    onclick="confirmDelete('/harvest_source/config/delete/{{data.harvest_source.id}}')">Delete</button>
             </li>
         </ul>
     </div>

--- a/database/interface.py
+++ b/database/interface.py
@@ -160,7 +160,7 @@ class HarvesterDBInterface:
         if not ckan_ids:
             self.db.delete(source)
             self.db.commit()
-            return "Harvest source deleted successfully, no records found."
+            return "Harvest source deleted successfully"
 
         ckan = RemoteCKAN(
             os.getenv("CKAN_API_URL"), apikey=os.getenv("CKAN_API_TOKEN"))
@@ -201,9 +201,9 @@ class HarvesterDBInterface:
             .all()
         )
         if remaining_records == 0:
-            return "Harvest source deleted successfully."
+            return "Harvest source deleted successfully"
         else:
-            return "Harvest source delete failed."
+            return "Harvest source delete failed"
 
 
 

--- a/database/interface.py
+++ b/database/interface.py
@@ -6,6 +6,7 @@ from sqlalchemy import create_engine, inspect, or_, text
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import scoped_session, sessionmaker
 from ckanapi import RemoteCKAN, NotFound
+import logging
 
 from .models import (
     HarvestJob,
@@ -18,6 +19,9 @@ from .models import (
 )
 
 DATABASE_URI = os.getenv("DATABASE_URI")
+
+logger = logging.getLogger("harvest_admin")
+
 
 class HarvesterDBInterface:
     def __init__(self, session=None):
@@ -147,29 +151,61 @@ class HarvesterDBInterface:
         if source is None:
             return "Harvest source not found"
 
-        # Delete packages in the CKAN associated with the same harvest source.
         records = (
+            self.db.query(HarvestRecord)
+            .filter_by(harvest_source_id=source_id).all()
+        )
+        ckan_ids = [record.ckan_id for record in records]
+
+        if not ckan_ids:
+            self.db.delete(source)
+            self.db.commit()
+            return "Harvest source deleted successfully, no records found."
+
+        ckan = RemoteCKAN(
+            os.getenv("CKAN_API_URL"), apikey=os.getenv("CKAN_API_TOKEN"))
+
+        failed_delete = []
+
+        for pkg_id in ckan_ids:
+            try:
+                ckan.action.dataset_purge(id=pkg_id)
+            except NotFound:
+                logger.warning(f"Dataset with id {pkg_id} was not found.")
+            except Exception as e:
+                failed_delete.append(pkg_id)
+                logger.error(f"An error occurred while deleting {pkg_id}: {e}")
+
+        # If all CKAN datasets were successfully deleted
+        if len(failed_delete) == 0:
+            self.db.delete(source)
+            logger.info(
+                "Harvest source and all associated records deleted successfully.")
+        else:
+            # Only delete records that were successfully purged from CKAN
+            self.db.query(HarvestRecord).filter(
+                    ~HarvestRecord.ckan_id.in_(failed_delete),
+                    HarvestRecord.harvest_source_id == source_id
+                ).delete(synchronize_session=False)
+
+            logger.warning(
+                f"Warning: Not all CKAN datasets could be deleted.
+                {len(failed_delete)} records remain."
+            )
+
+        self.db.commit()
+
+        remaining_records = (
             self.db.query(HarvestRecord)
             .filter_by(harvest_source_id=source_id)
             .all()
         )
-        ckan_ids = [record.ckan_id for record in records]
-        if ckan_ids:
-            ckan = RemoteCKAN(
-                os.getenv("CKAN_API_URL"), 
-                apikey=os.getenv("CKAN_API_TOKEN")
-            )
-            for pkg_id in ckan_ids:
-                try:
-                    ckan.action.dataset_purge(id=pkg_id)
-                except NotFound:
-                    print(f"Dataset with id {pkg_id} was not found.")
-                except Exception as e:
-                    print(f"An error occurred while deleting {pkg_id}: {e}")
+        if remaining_records == 0:
+            return "Harvest source deleted successfully."
+        else:
+            return "Harvest source delete failed."
 
-        self.db.delete(source)
-        self.db.commit()
-        return "Harvest source deleted successfully"
+
 
     ## HARVEST JOB
     def add_harvest_job(self, job_data):

--- a/database/interface.py
+++ b/database/interface.py
@@ -190,22 +190,11 @@ class HarvesterDBInterface:
             
             logger.warning(
                 f"Warning: Not all CKAN datasets could be deleted. "
-                f"{len(failed_delete)} records remain."
+                f"{len(failed_delete)} records remain: {failed_delete}"
             )
 
         self.db.commit()
-
-        remaining_records = (
-            self.db.query(HarvestRecord)
-            .filter_by(harvest_source_id=source_id)
-            .all()
-        )
-        if remaining_records == 0:
-            return "Harvest source deleted successfully"
-        else:
-            return "Harvest source delete failed"
-
-
+        return "Harvest source deleted successfully"
 
     ## HARVEST JOB
     def add_harvest_job(self, job_data):

--- a/database/interface.py
+++ b/database/interface.py
@@ -147,7 +147,7 @@ class HarvesterDBInterface:
         if source is None:
             return "Harvest source not found"
 
-        # Delete packages in the CKAN database associated with the same harvest source.
+        # Delete packages in the CKAN associated with the same harvest source.
         records = (
             self.db.query(HarvestRecord)
             .filter_by(harvest_source_id=source_id)

--- a/database/interface.py
+++ b/database/interface.py
@@ -148,7 +148,11 @@ class HarvesterDBInterface:
             return "Harvest source not found"
 
         # Delete packages in the CKAN database associated with the same harvest source.
-        records = self.db.query(HarvestRecord).filter_by(harvest_source_id=source_id).all()
+        records = (
+            self.db.query(HarvestRecord)
+            .filter_by(harvest_source_id=source_id)
+            .all()
+        )
         ckan_ids = [record.ckan_id for record in records]
         if ckan_ids:
             ckan = RemoteCKAN(os.getenv("CKAN_API_URL"), apikey=os.getenv("CKAN_API_TOKEN"))

--- a/database/interface.py
+++ b/database/interface.py
@@ -187,10 +187,10 @@ class HarvesterDBInterface:
                     ~HarvestRecord.ckan_id.in_(failed_delete),
                     HarvestRecord.harvest_source_id == source_id
                 ).delete(synchronize_session=False)
-
+            
             logger.warning(
-                f"Warning: Not all CKAN datasets could be deleted.
-                {len(failed_delete)} records remain."
+                f"Warning: Not all CKAN datasets could be deleted. "
+                f"{len(failed_delete)} records remain."
             )
 
         self.db.commit()

--- a/database/interface.py
+++ b/database/interface.py
@@ -155,7 +155,10 @@ class HarvesterDBInterface:
         )
         ckan_ids = [record.ckan_id for record in records]
         if ckan_ids:
-            ckan = RemoteCKAN(os.getenv("CKAN_API_URL"), apikey=os.getenv("CKAN_API_TOKEN"))
+            ckan = RemoteCKAN(
+                os.getenv("CKAN_API_URL"), 
+                apikey=os.getenv("CKAN_API_TOKEN")
+            )
             for pkg_id in ckan_ids:
                 try:
                     ckan.action.dataset_purge(id=pkg_id)

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,7 @@ applications:
       FLASK_APP: run.py
       CF_API_URL: ((CF_API_URL))
       HARVEST_RUNNER_APP_GUID: ((HARVEST_RUNNER_APP_GUID))
+      CKAN_API_URL: ((CKAN_API_URL))
       CLIENT_ID: ((CLIENT_ID))
       ISSUER: ((ISSUER))
       REDIRECT_URI: ((REDIRECT_URI))

--- a/tests/integration/app/test_login_required.py
+++ b/tests/integration/app/test_login_required.py
@@ -57,7 +57,7 @@ def test_org_edit_buttons__logged_in(
     button_string_text = '<div class="config-actions">'
     org_edit_text = f'<a href="/organization/config/edit/{organization_data["id"]}"'
     org_delete_text = (
-        f"onclick=\"confirmDelete('/organization/delete/{organization_data['id']}')"
+        f"onclick=\"confirmDelete('/organization/config/delete/{organization_data['id']}')"
     )
     assert res.status_code == 200
     assert res.text.find(button_string_text) != -1
@@ -71,7 +71,7 @@ def test_org_edit_buttons__logged_out(client, interface_no_jobs, organization_da
     button_string_text = '<div class="config-actions">'
     org_edit_text = f'<a href="/organization/config/edit/{organization_data["id"]}"'
     org_delete_text = (
-        f"onclick=\"confirmDelete('/organization/delete/{organization_data['id']}')"
+        f"onclick=\"confirmDelete('/organization/config/delete/{organization_data['id']}')"
     )
     assert res.status_code == 200
     assert res.text.find(button_string_text) == -1
@@ -90,7 +90,7 @@ def test_harvest_data_edit_buttons__logged_in(
         f'<a href="/harvest_source/config/edit/{source_data_dcatus["id"]}"'
     )
     source_delete_text = (
-        f"onclick=\"confirmDelete('/harvest_source/delete/{source_data_dcatus['id']}')"
+        f"onclick=\"confirmDelete('/harvest_source/config/delete/{source_data_dcatus['id']}')"
     )
     assert res.status_code == 200
     assert res.text.find(button_string_text) != -1
@@ -108,7 +108,7 @@ def test_harvest_data_edit_buttons__logged_out(
         f'<a href="/harvest_source/config/edit/{source_data_dcatus["id"]}"'
     )
     source_delete_text = (
-        f"onclick=\"confirmDelete('/harvest_source/delete/{source_data_dcatus['id']}')"
+        f"onclick=\"confirmDelete('/harvest_source/config/delete/{source_data_dcatus['id']}')"
     )
     assert res.status_code == 200
     assert res.text.find(button_string_text) == -1


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/4691

- Corrected the API call to delete the harvest source and organization.
- Added API remote call to purge datasets in CKAN.
- Ensured all dataset records, errors, and jobs are removed from the harvestDB after harvest_source deleted.

