### PR TITLE
Adds support for title deconflicting to create unique ckan urls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@
   name: Deploy to cloud.gov
 
   on:
+    push:
+      branches:
+        - main
     workflow_dispatch:
       inputs:
         version_no:

--- a/app/routes.py
+++ b/app/routes.py
@@ -547,7 +547,7 @@ def update_harvest_job(job_id):
 @mod.route("/harvest_job/<job_id>", methods=["DELETE"])
 def delete_harvest_job(job_id):
     result = db.delete_harvest_job(job_id)
-    return db._to_dict(result)
+    return result
 
 
 # Get Job Errors by Type

--- a/database/models.py
+++ b/database/models.py
@@ -107,6 +107,7 @@ class HarvestRecord(db.Model):
     date_created = db.Column(db.DateTime, index=True, default=func.now())
     date_finished = db.Column(db.DateTime, index=True)
     ckan_id = db.Column(db.String, index=True)
+    ckan_name = db.Column(db.String, index=True)
     action = db.Column(
         Enum("create", "update", "delete", name="record_action"), index=True
     )

--- a/example_data/dcatus/dcatus_same_title.json
+++ b/example_data/dcatus/dcatus_same_title.json
@@ -1,0 +1,61 @@
+{
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@id": "http://www.cftc.gov/data.json",
+    "@type": "dcat:Catalog",
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "dataset": [
+        {
+            "contactPoint": {
+                "fn": "Harold W. Hild",
+                "hasEmail": "mailto:hhild@CFTC.GOV"
+            },
+            "describedBy": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/ExplanatoryNotes/index.htm",
+            "description": "COT reports provide a breakdown of each Tuesday's open interest for futures and options on futures market in which 20 or more traders hold positions equal to or above the reporting levels established by CFTC",
+            "distribution": [
+                {
+                    "accessURL": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/index.htm"
+                }
+            ],
+            "modified": "R/P1W",
+            "programCode": ["000:000"],
+            "publisher": {
+                "name": "U.S. Commodity Futures Trading Commission",
+                "subOrganizationOf": {
+                    "name": "U.S. Government"
+                }
+            },
+            "title": "Commitment of Traders",
+            "accessLevel": "public",
+            "bureauCode": ["339:00"],
+            "identifier": "cftc-dc1",
+            "keyword": ["commitment of traders", "cot", "open interest"]
+        },
+        {
+            "accessLevel": "public",
+            "bureauCode": ["339:00"],
+            "contactPoint": {
+                "fn": "Harold W. Hild",
+                "hasEmail": "mailto:hhild@CFTC.GOV"
+            },
+            "describedBy": "https://www.cftc.gov/MarketReports/BankParticipationReports/ExplanatoryNotes/index.htm",
+            "description": "The Bank Participation Report (BPR), developed by the Division of Market Oversight to provide the U.S. banking authorities and the Bank for International Settlements (BIS, located in Basel, Switzerland) aggregate large-trader positions of banks participating in various financial and non-financial commodity futures.",
+            "distribution": [
+                {
+                    "accessURL": "https://www.cftc.gov/MarketReports/BankParticipationReports/index.htm"
+                }
+            ],
+            "identifier": "cftc-dc2",
+            "keyword": ["bank participation report", "bpr", "banking"],
+            "modified": "R/P1M",
+            "programCode": ["000:000"],
+            "publisher": {
+                "name": "U.S. Commodity Futures Trading Commission",
+                "subOrganizationOf": {
+                    "name": "U.S. Government"
+                }
+            },
+            "title": "Commitment of Traders"
+        }
+    ]
+}

--- a/example_data/dcatus/dcatus_same_title_step_2.json
+++ b/example_data/dcatus/dcatus_same_title_step_2.json
@@ -1,0 +1,61 @@
+{
+    "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+    "@id": "http://www.cftc.gov/data.json",
+    "@type": "dcat:Catalog",
+    "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+    "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+    "dataset": [
+        {
+            "contactPoint": {
+                "fn": "Harold W. Hild",
+                "hasEmail": "mailto:hhild@CFTC.GOV"
+            },
+            "describedBy": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/ExplanatoryNotes/index.htm",
+            "description": "COT reports provide a breakdown of each Tuesday's open interest for futures and options on futures market in which 20 or more traders hold positions equal to or above the reporting levels established by CFTC",
+            "distribution": [
+                {
+                    "accessURL": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/index.htm"
+                }
+            ],
+            "modified": "R/P1W",
+            "programCode": ["000:000"],
+            "publisher": {
+                "name": "U.S. Commodity Futures Trading Commission",
+                "subOrganizationOf": {
+                    "name": "U.S. Government"
+                }
+            },
+            "title": "Commitment of Traders",
+            "accessLevel": "public",
+            "bureauCode": ["339:00"],
+            "identifier": "cftc-dc1",
+            "keyword": ["commitment of traders", "cot", "open interest"]
+        },
+        {
+            "accessLevel": "public",
+            "bureauCode": ["339:00"],
+            "contactPoint": {
+                "fn": "Harold W. Hild",
+                "hasEmail": "mailto:hhild@CFTC.GOV"
+            },
+            "describedBy": "https://www.cftc.gov/MarketReports/BankParticipationReports/ExplanatoryNotes/index.htm",
+            "description": "The Bank Participation Report (BPR), developed by the Division of Market Oversight to provide the U.S. banking authorities and the Bank for International Settlements (BIS, located in Basel, Switzerland) aggregate large-trader positions of banks participating in various financial and non-financial commodity futures.",
+            "distribution": [
+                {
+                    "accessURL": "https://www.cftc.gov/MarketReports/BankParticipationReports/index.htm"
+                }
+            ],
+            "identifier": "cftc-dc2",
+            "keyword": ["changed", "key", "words", "to", "trigger", "update"],
+            "modified": "R/P1M",
+            "programCode": ["000:000"],
+            "publisher": {
+                "name": "U.S. Commodity Futures Trading Commission",
+                "subOrganizationOf": {
+                    "name": "U.S. Government"
+                }
+            },
+            "title": "Commitment of Traders"
+        }
+    ]
+}

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F841
 # ruff: noqa: E402
 import functools
+import json
 import logging
 import os
 import sys
@@ -9,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
+from boltons.setutils import IndexedSet
 from ckanapi import RemoteCKAN
 from jsonschema import Draft202012Validator
 
@@ -23,7 +25,7 @@ from harvester.exceptions import (
     SynchronizeException,
     ValidationException,
 )
-from harvester.utils.ckan_utils import ckanify_dcatus
+from harvester.utils.ckan_utils import add_uuid_to_package_name, ckanify_dcatus
 from harvester.utils.general_utils import (
     dataset_to_hash,
     download_file,
@@ -45,6 +47,8 @@ ckan = RemoteCKAN(
     apikey=os.getenv("CKAN_API_TOKEN"),
     session=session,
 )
+
+CKAN_ERRORS = {"URL_IN_USE": "That URL is already in use"}
 
 # logging data
 # logging.getLogger(name) follows a singleton pattern
@@ -139,6 +143,7 @@ class HarvestSource:
                 record["source_raw"],
                 record["source_hash"],
                 _ckan_id=record["ckan_id"],
+                _ckan_name=record["ckan_name"],
             )
 
     def external_records_to_id_hash(self, records: list[dict]) -> None:
@@ -197,8 +202,8 @@ class HarvestSource:
         logger.info("comparing our records with theirs")
 
         try:
-            external_ids = set(self.external_records.keys())
-            internal_ids = set(self.internal_records.keys())
+            external_ids = IndexedSet(self.external_records.keys())
+            internal_ids = IndexedSet(self.internal_records.keys())
             same_ids = external_ids & internal_ids
 
             self.compare_data["delete"] = internal_ids - external_ids
@@ -239,9 +244,10 @@ class HarvestSource:
                         "harvest_job_id": record.harvest_source.job_id,
                         "harvest_source_id": record.harvest_source.id,
                         "source_hash": record.metadata_hash,
-                        "source_raw": str(record.metadata),
+                        "source_raw": json.dumps(record.metadata),
                         "action": action,
                         "ckan_id": record.ckan_id,
+                        "ckan_name": record.ckan_name,
                     }
                 )
 
@@ -251,7 +257,7 @@ class HarvestSource:
 
     def synchronize_records(self) -> None:
         """runs the delete, update, and create
-        - self.compare can be empty becuase there was no harvest source response
+        - self.compare can be empty because there was no harvest source response
         or there's truly nothing to process
         """
         logger.info("synchronizing records")
@@ -286,6 +292,7 @@ class HarvestSource:
                     record = self.external_records[i]
                     if action == "update":
                         record.ckan_id = self.internal_records[i].ckan_id
+                        record.ckan_name = self.internal_records[i].ckan_name
 
                     # no longer setting action in compare so setting it here...
                     record.action = action
@@ -365,6 +372,7 @@ class Record:
     _validation_msg: str = ""
     _status: str = None
     _ckan_id: str = None
+    _ckan_name: str = None
 
     ckanified_metadata: dict = field(default_factory=lambda: {})
 
@@ -387,6 +395,14 @@ class Record:
     @ckan_id.setter
     def ckan_id(self, value) -> None:
         self._ckan_id = value
+
+    @property
+    def ckan_name(self) -> str:
+        return self._ckan_name
+
+    @ckan_name.setter
+    def ckan_name(self, value) -> None:
+        self._ckan_name = value
 
     @property
     def identifier(self) -> str:
@@ -460,9 +476,14 @@ class Record:
     def create_record(self):
         result = ckan.action.package_create(**self.ckanified_metadata)
         self.ckan_id = result["id"]
+        self.ckan_name = self.ckanified_metadata["name"]
 
     def update_record(self) -> dict:
-        ckan.action.package_update(**self.ckanified_metadata, **{"id": self.ckan_id})
+        updated_metadata = {
+            **self.ckanified_metadata,
+            **{"id": self.ckan_id, "name": self.ckan_name},
+        }
+        ckan.action.package_update(**updated_metadata)
 
     def delete_record(self) -> None:
         ckan.action.dataset_purge(**{"id": self.ckan_id})
@@ -472,6 +493,8 @@ class Record:
         data = {"status": "success", "date_finished": datetime.now(timezone.utc)}
         if self.ckan_id is not None:
             data["ckan_id"] = self.ckan_id
+        if self.ckan_name is not None:
+            data["ckan_name"] = self.ckan_name
 
         self.harvest_source.db_interface.update_harvest_record(
             self.harvest_source.internal_records_lookup_table[self.identifier],
@@ -491,13 +514,14 @@ class Record:
                 self.harvest_source.internal_records_lookup_table[self.identifier],
             )
 
-    def sync(self) -> None:
+    def sync(self, iter_count=0) -> None:
         # ruff: noqa: F841
         if self.valid is False:
             logger.warning(f"{self.identifier} is invalid. bypassing {self.action}")
             return
 
-        self.ckanify_dcatus()
+        if iter_count == 0:
+            self.ckanify_dcatus()
 
         start = datetime.now(timezone.utc)
 
@@ -507,12 +531,19 @@ class Record:
             if self.action == "update":
                 self.update_record()
         except Exception as e:
-            self.status = "error"
-            raise SynchronizeException(
-                f"failed to {self.action} for {self.identifier} :: {repr(e)}",
-                self.harvest_source.job_id,
-                self.harvest_source.internal_records_lookup_table[self.identifier],
-            )
+            if iter_count == 0 and CKAN_ERRORS["URL_IN_USE"] in repr(e):
+                self.ckanified_metadata["name"] = add_uuid_to_package_name(
+                    self.ckanified_metadata["name"]
+                )
+                self.ckan_name = self.ckanified_metadata["name"]
+                return self.sync(iter_count=1)
+            else:
+                self.status = "error"
+                raise SynchronizeException(
+                    f"failed to {self.action} for {self.identifier} :: {repr(e)}",
+                    self.harvest_source.job_id,
+                    self.harvest_source.internal_records_lookup_table[self.identifier],
+                )
         self.update_self_in_db()
 
         logger.info(

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -1,4 +1,5 @@
 import re
+import uuid
 
 # all of these are copy/pasted from ckan core
 # https://github.com/ckan/ckan/blob/master/ckan/lib/munge.py
@@ -292,3 +293,7 @@ def ckanify_dcatus(metadata: dict, owner_org: str) -> dict:
     ckanified_metadata["extras"] = create_ckan_extras(metadata)
 
     return ckanified_metadata
+
+
+def add_uuid_to_package_name(name: str) -> str:
+    return name + "-" + str(uuid.uuid4())[:5]

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -4,7 +4,7 @@ import uuid
 # all of these are copy/pasted from ckan core
 # https://github.com/ckan/ckan/blob/master/ckan/lib/munge.py
 
-PACKAGE_NAME_MAX_LENGTH = 100
+PACKAGE_NAME_MAX_LENGTH = 90
 PACKAGE_NAME_MIN_LENGTH = 2
 
 MAX_TAG_LENGTH = 100
@@ -129,7 +129,7 @@ def munge_title_to_name(name: str) -> str:
     # remove leading or trailing hyphens
     name = name.strip("-")
     # if longer than max_length, keep last word if a year
-    max_length = PACKAGE_NAME_MAX_LENGTH - 5
+    max_length = PACKAGE_NAME_MAX_LENGTH
     # (make length less than max, in case we need a few for '_' chars
     # to de-clash names.)
     if len(name) > max_length:

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,6 +238,17 @@ files = [
 ]
 
 [[package]]
+name = "boltons"
+version = "24.0.0"
+description = "When they're not builtins, they're boltons."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "boltons-24.0.0-py3-none-any.whl", hash = "sha256:9618695a6ec4f50412e7072e5d78910a00b4111d0b9b549e4a3d60bc321e7807"},
+    {file = "boltons-24.0.0.tar.gz", hash = "sha256:7153feccaea1ff2e1472f68d4b57fadb796a2ee49d29f638f1c9cd8fb5ebd916"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2337,4 +2348,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10"
-content-hash = "4d9ee39bc2f1fcb4bf35cb49b9c00f461f7889c10f092ff4fa43387a7e1ea92d"
+content-hash = "d81c4af263f6891c477453ddc74ed90cc7da9d3cdac3e945c1ced15930a757ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ flask-bootstrap = "^3.3.7.1"
 cloudfoundry-client = "^1.36.0"
 pyjwt = "^2.8.0"
 cryptography = "^42.0.8"
+boltons = "^24.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.3.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,21 @@ def source_data_dcatus_2(organization_data: dict) -> dict:
 
 
 @pytest.fixture
+def source_data_dcatus_same_title(organization_data: dict) -> dict:
+    return {
+        "id": "50301cdb-5766-46ed-8f46-ca63844315a2",
+        "name": "Test Source Same Title",
+        "notification_emails": "email@example.com",
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_same_title.json",
+        "schema_type": "type1",
+        "source_type": "dcatus",
+        "status": "active",
+    }
+
+
+@pytest.fixture
 def source_orm_dcatus(source_data_dcatus: dict) -> HarvestSource:
     return HarvestSource(**source_data_dcatus)
 

--- a/tests/integration/database/test_db.py
+++ b/tests/integration/database/test_db.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 
 from database.models import HarvestJobError, HarvestRecordError
@@ -292,6 +293,16 @@ class TestDatabase:
             == 6
         )
 
+    def test_delete_harvest_job(
+        self,
+        interface_no_jobs,
+        job_data_dcatus,
+    ):
+        interface_no_jobs.add_harvest_job(job_data_dcatus)
+        res = interface_no_jobs.delete_harvest_job(job_data_dcatus["id"])
+        assert isinstance(res, str)
+        assert res == "Harvest job deleted successfully"
+
     def test_get_latest_harvest_records(
         self,
         interface,
@@ -329,6 +340,7 @@ class TestDatabase:
                 "date_created": datetime(2024, 3, 1, 0, 0, 0, 1000),
                 "date_finished": None,
                 "ckan_id": None,
+                "ckan_name": None,
                 "action": "update",
                 "status": "success",
             },
@@ -341,6 +353,7 @@ class TestDatabase:
                 "date_created": datetime(2024, 3, 1, 0, 0, 0, 1000),
                 "date_finished": None,
                 "ckan_id": None,
+                "ckan_name": None,
                 "action": "create",
                 "status": "success",
             },
@@ -353,6 +366,7 @@ class TestDatabase:
                 "date_created": datetime(2024, 5, 1, 0, 0, 0, 1000),
                 "date_finished": None,
                 "ckan_id": None,
+                "ckan_name": None,
                 "action": "create",
                 "status": "success",
             },
@@ -365,6 +379,7 @@ class TestDatabase:
                 "date_created": datetime(2024, 4, 3, 0, 0, 0, 1000),
                 "date_finished": None,
                 "ckan_id": None,
+                "ckan_name": None,
                 "action": "create",
                 "status": "success",
             },
@@ -396,7 +411,7 @@ class TestDatabase:
                     "harvest_job_id": job_data_dcatus["id"],
                     "harvest_source_id": job_data_dcatus["harvest_source_id"],
                     "source_hash": dataset_to_hash(sort_dataset(record)),
-                    "source_raw": str(record),
+                    "source_raw": json.dumps(record),
                 }
             )
 

--- a/tests/integration/harvest/test_harvest_full_flow.py
+++ b/tests/integration/harvest/test_harvest_full_flow.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from harvester.harvest import HarvestSource
@@ -15,6 +16,7 @@ class TestHarvestFullFlow:
         CKANMock.action.package_create.return_value = {"id": 1234}
         CKANMock.action.package_update = "ok"
         CKANMock.action.dataset_purge = "ok"
+
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_single_record)
         harvest_job = interface.add_harvest_job(
@@ -47,6 +49,7 @@ class TestHarvestFullFlow:
     ):
         CKANMock.action.dataset_purge.side_effect = Exception()
         download_file_mock.return_value = dict({"dataset": []})
+
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)
@@ -72,3 +75,90 @@ class TestHarvestFullFlow:
         assert len(interface_errors) == harvest_job.records_errored
         assert len(interface_errors) == len(job_errors)
         assert interface_errors[0].harvest_record_id == job_errors[0].harvest_record_id
+
+    @patch("harvester.harvest.ckan")
+    @patch("harvester.utils.ckan_utils.uuid")
+    def test_validate_same_title(
+        self,
+        UUIDMock,
+        CKANMock,
+        interface,
+        organization_data,
+        source_data_dcatus_same_title,
+    ):
+        UUIDMock.uuid4.return_value = 12345
+        # ruff: noqa: E501
+        CKANMock.action.package_create.side_effect = [
+            {"id": 1234},
+            Exception(
+                "ValidationError({'name': ['That URL is already in use.'], '__type': 'Validation Error'}"
+            ),
+            {"id": 5678},
+        ]
+        CKANMock.action.package_update.return_value = "ok"
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_same_title)
+        harvest_job = interface.add_harvest_job(
+            {
+                "status": "new",
+                "harvest_source_id": source_data_dcatus_same_title["id"],
+            }
+        )
+        job_id = harvest_job.id
+        harvest_source = HarvestSource(job_id)
+        harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
+        harvest_source.synchronize_records()
+        harvest_source.report()
+
+        harvest_job = interface.get_harvest_job(job_id)
+        assert harvest_job.status == "complete"
+
+        raw_source_0 = json.loads(harvest_job.records[0].source_raw)
+        raw_source_1 = json.loads(harvest_job.records[1].source_raw)
+
+        ## assert title is same
+        assert raw_source_0["title"] == raw_source_1["title"]
+        ## assert name is unique
+        assert harvest_job.records[0].ckan_name != harvest_job.records[1].ckan_name
+
+        ## assert ckan_name persists in db
+        for idx, record in enumerate(harvest_job.records):
+            db_record = interface.get_harvest_record(record.id)
+            assert db_record.ckan_name == harvest_job.records[idx].ckan_name
+
+        ## now do a package_update & confirm it uses ckan_name
+        harvest_job = interface.add_harvest_job(
+            {
+                "status": "new",
+                "harvest_source_id": source_data_dcatus_same_title["id"],
+            }
+        )
+
+        job_id = harvest_job.id
+        harvest_source = HarvestSource(job_id)
+        harvest_source.url = "http://localhost:80/dcatus/dcatus_same_title_step_2.json"
+        harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
+        harvest_source.synchronize_records()
+        harvest_source.report()
+
+        # assert job reports correct metrics
+        harvest_job = interface.get_harvest_job(job_id)
+        assert harvest_job.records_updated == 1
+        assert harvest_job.records_ignored == 1
+        assert harvest_job.records_errored == 0
+
+        # assert db record retains correct ckan_id & ckan_name
+        db_record = interface.get_harvest_record(harvest_job.records[0].id)
+        assert db_record.action == "update"
+        assert db_record.ckan_id == "5678"
+        assert db_record.ckan_name == "commitment-of-traders-12345"
+        assert db_record.identifier == "cftc-dc2"
+
+        ## finally, assert package_update called with proper kwargs
+        args, kwargs = CKANMock.action.package_update.call_args_list[0]
+        assert kwargs["name"] == "commitment-of-traders-12345"
+        assert kwargs["title"] == "Commitment of Traders"
+        assert kwargs["id"] == "5678"
+        assert kwargs["identifier"] == "cftc-dc2"

--- a/tests/integration/harvest/test_validate_dcatus.py
+++ b/tests/integration/harvest/test_validate_dcatus.py
@@ -9,7 +9,6 @@ class TestValidateDCATUS:
         source_data_dcatus,
         job_data_dcatus,
     ):
-
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus)
         harvest_job = interface.add_harvest_job(job_data_dcatus)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -34,8 +34,8 @@ class TestCKANUtils:
             ("s", "s_"),  # too short
             ("random:other%character&", "random-othercharacter"),
             ("u with umlaut \xfc", "u-with-umlaut-u"),
-            ("reallylong" * 12, "reallylong" * 9 + "reall"),
-            ("reallylong" * 12 + " - 2012", "reallylong" * 9 + "-2012"),
+            ("reallylong" * 12, "reallylong" * 9),
+            ("reallylong" * 12 + " - 2012", "reallylong" * 8 + "reall" + "-2012"),
             (
                 "10cm - 50cm Near InfraRed (NI) Digital Aerial Photography (AfA142)",
                 "10cm-50cm-near-infrared-ni-digital-aerial-photography-afa142",


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4849

## About

Harvester creates CKAN "name" based on dataset title. When titles conflict, we need to namespace them with unique characters.

## PR TASKS

- [X] The actual code changes.
- [X] Tests written and passed.
- [ ] Any changes to docs?
