### PR TITLE
Removes size and status from harvest source model

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -248,13 +248,13 @@ def cli_remove_harvest_source(id):
 # Helper Functions
 def make_new_source_contract(form):
     return {
+        "organization_id": form.organization_id.data,
         "name": form.name.data,
+        "url": form.url.data,
         "notification_emails": form.notification_emails.data,
         "frequency": form.frequency.data,
-        "url": form.url.data,
         "schema_type": form.schema_type.data,
         "source_type": form.source_type.data,
-        "organization_id": form.organization_id.data,
     }
 
 

--- a/database/models.py
+++ b/database/models.py
@@ -34,11 +34,12 @@ class Organization(db.Model):
 class HarvestSource(db.Model):
     __tablename__ = "harvest_source"
 
-    name = db.Column(db.String, nullable=False)
-    notification_emails = db.Column(db.ARRAY(db.String))
     organization_id = db.Column(
         db.String(36), db.ForeignKey("organization.id"), nullable=False
     )
+    name = db.Column(db.String, nullable=False)
+    url = db.Column(db.String, nullable=False, unique=True)
+    notification_emails = db.Column(db.ARRAY(db.String))
     frequency = db.Column(
         Enum(
             "manual",
@@ -51,11 +52,8 @@ class HarvestSource(db.Model):
         nullable=False,
         index=True,
     )
-    url = db.Column(db.String, nullable=False, unique=True)
-    size = db.Column(Enum("small", "medium", "large", name="size"))
     schema_type = db.Column(db.String, nullable=False)
     source_type = db.Column(db.String, nullable=False)
-    status = db.Column(db.String)
     jobs = db.relationship(
         "HarvestJob", backref="source", cascade="all, delete-orphan", lazy=True
     )

--- a/harvester/lib/cf_handler.py
+++ b/harvester/lib/cf_handler.py
@@ -1,3 +1,4 @@
+import os
 from cloudfoundry_client.client import CloudFoundryClient
 from cloudfoundry_client.v3.tasks import TaskManager
 
@@ -14,10 +15,10 @@ class CFHandler:
         self.client.init_with_user_credentials(self.user, self.password)
         self.task_mgr = TaskManager(self.url, self.client)
 
-    def start_task(self, app_guuid, command, task_id, memory_in_mb=512, disk_in_mb=512):
-        return self.task_mgr.create(
-            app_guuid, command, task_id, memory_in_mb, disk_in_mb
-        )
+    def start_task(self, app_guuid, command, task_id):
+        TASK_MEMORY = os.getenv("HARVEST_RUNNER_TASK_MEM", "4096")
+        TASK_DISK = os.getenv("HARVEST_RUNNER_TASK_DISK", "1536")
+        return self.task_mgr.create(app_guuid, command, task_id, TASK_MEMORY, TASK_DISK)
 
     def stop_task(self, task_id):
         return self.task_mgr.cancel(task_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,11 +104,9 @@ def source_data_dcatus(organization_data: dict) -> dict:
         "notification_emails": "email@example.com",
         "organization_id": organization_data["id"],
         "frequency": "daily",
-        "size": "small",
         "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus.json",
         "schema_type": "type1",
         "source_type": "dcatus",
-        "status": "active",
     }
 
 
@@ -120,11 +118,9 @@ def source_data_dcatus_2(organization_data: dict) -> dict:
         "notification_emails": "email@example.com",
         "organization_id": organization_data["id"],
         "frequency": "daily",
-        "size": "medium",
         "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_2.json",
         "schema_type": "type1",
         "source_type": "dcatus",
-        "status": "active",
     }
 
 
@@ -136,11 +132,9 @@ def source_data_dcatus_same_title(organization_data: dict) -> dict:
         "notification_emails": "email@example.com",
         "organization_id": organization_data["id"],
         "frequency": "daily",
-        "size": "small",
         "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_same_title.json",
         "schema_type": "type1",
         "source_type": "dcatus",
-        "status": "active",
     }
 
 
@@ -157,11 +151,9 @@ def source_data_waf(organization_data: dict) -> dict:
         "notification_emails": "wafl@example.com",
         "organization_id": organization_data["id"],
         "frequency": "daily",
-        "size": "small",
         "url": f"{HARVEST_SOURCE_URL}/waf/",
         "schema_type": "type1",
         "source_type": "waf",
-        "status": "active",
     }
 
 
@@ -176,7 +168,6 @@ def source_data_dcatus_invalid(organization_data: dict) -> dict:
         "url": f"{HARVEST_SOURCE_URL}/dcatus/missing_title.json",
         "schema_type": "type1",
         "source_type": "dcatus",
-        "status": "active",
     }
 
 
@@ -242,7 +233,6 @@ def source_data_dcatus_single_record(organization_data: dict) -> dict:
         "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_single_record.json",
         "schema_type": "type1",
         "source_type": "dcatus",
-        "status": "active",
     }
 
 
@@ -279,7 +269,6 @@ def source_data_dcatus_bad_url(organization_data: dict) -> dict:
         "url": f"{HARVEST_SOURCE_URL}/dcatus/bad_url.json",
         "schema_type": "type1",
         "source_type": "dcatus",
-        "status": "active",
     }
 
 
@@ -303,7 +292,6 @@ def source_data_dcatus_invalid_records(organization_data) -> dict:
         "url": "http://localhost/dcatus/missing_title.json",
         "schema_type": "type1",
         "source_type": "dcatus",
-        "status": "active",
     }
 
 


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4784

## About

Removes size and status from harvest source model in favor of passing in same val for memory and disk to all tasks, with eventual focus on shaving memory requirements off after proper profiling

## PR TASKS

- [X] The actual code changes.
- [X] Tests written and passed.
- [ ] Any changes to docs?
