### PR TITLE
AutoCommit db connections

### DIFF
--- a/database/interface.py
+++ b/database/interface.py
@@ -73,14 +73,13 @@ class HarvesterDBInterface:
         if session is None:
             engine = create_engine(
                 DATABASE_URI,
+                isolation_level="AUTOCOMMIT",
                 pool_size=10,
                 max_overflow=20,
                 pool_timeout=60,
                 pool_recycle=1800,
             )
-            session_factory = sessionmaker(
-                bind=engine, autocommit=False, autoflush=False
-            )
+            session_factory = sessionmaker(bind=engine, autoflush=True)
             self.db = scoped_session(session_factory)
         else:
             self.db = session


### PR DESCRIPTION
Limits db connections getting caught 'idle in transaction', which prevents them from getting recycled

# Pull Request

Related to https://github.com/GSA/data.gov/issues/4971

## About

<!-- any pertinent notes -->

## PR TASKS

- [X] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
