### PR TITLE
add additional db transform logic

### DIFF
--- a/harvester/__init__.py
+++ b/harvester/__init__.py
@@ -1,11 +1,10 @@
 import logging.config
+import os
 
 from dotenv import load_dotenv
 
 from config.logger_config import LOGGING_CONFIG
 from database.interface import HarvesterDBInterface
-
-import os
 
 load_dotenv()
 
@@ -21,5 +20,5 @@ SMTP_CONFIG = {
     "password": os.getenv("HARVEST_SMTP_PASSWORD"),
     "default_sender": os.getenv("HARVEST_SMTP_SENDER"),
     "base_url": os.getenv("REDIRECT_URI").rsplit("/", 1)[0],
-    "recipient": os.getenv("HARVEST_SMTP_RECIPIENT")
+    "recipient": os.getenv("HARVEST_SMTP_RECIPIENT"),
 }

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -161,7 +161,6 @@ class HarvestSource:
             )
 
     def get_record_identifier(self, record: dict) -> str:
-
         record_id = "identifier" if self.schema_type.startswith("dcatus") else "url"
 
         if record_id not in record:
@@ -180,7 +179,6 @@ class HarvestSource:
         logger.info("converting harvest records to id: hash")
         for record in records:
             try:
-
                 identifier = self.get_record_identifier(record)
 
                 if self.source_type == "document":
@@ -564,7 +562,6 @@ class Record:
         self._status = value
 
     def transform(self) -> None:
-
         data = {
             "file": self.metadata["content"],
             "reader": self.reader_map[self.harvest_source.schema_type],
@@ -585,10 +582,8 @@ class Record:
 
         record_id = self.harvest_source.internal_records_lookup_table[self.identifier]
         if 200 <= resp.status_code < 300:
-
             logger.info(
-                f"successfully transformed record: {self.name} of {self.url} \n"
-                f"db record id: {record_id}"
+                f"successfully transformed record: {self.identifier} db id: {record_id}"
             )
             self.transformed_data = json.loads(data["writerOutput"])
 

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -16,12 +16,11 @@ from jsonschema import Draft202012Validator
 
 sys.path.insert(1, "/".join(os.path.realpath(__file__).split("/")[0:-2]))
 
-from harvester import SMTP_CONFIG
 import smtplib
-from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 
-from harvester import HarvesterDBInterface, db_interface
+from harvester import SMTP_CONFIG, HarvesterDBInterface, db_interface
 from harvester.exceptions import (
     CompareException,
     DCATUSToCKANException,
@@ -73,7 +72,7 @@ class HarvestSource:
             "schema_type",
             "source_type",
             "id",  # db guuid
-            "notification_emails"
+            "notification_emails",
         ],
         repr=False,
     )
@@ -196,7 +195,7 @@ class HarvestSource:
             except Exception as e:
                 # TODO: do something with 'e'
                 raise ExtractExternalException(
-                    f"{self.title} {self.url} failed to convert to id:hash",
+                    f"{self.name} {self.url} failed to convert to id:hash",
                     self.job_id,
                 )
 
@@ -248,7 +247,7 @@ class HarvestSource:
         except Exception as e:
             # TODO: do something with 'e'
             raise CompareException(
-                f"{self.title} {self.url} failed to run compare. exiting.",
+                f"{self.name} {self.url} failed to run compare. exiting.",
                 self.job_id,
             )
 
@@ -435,8 +434,9 @@ class HarvestSource:
 
                 for recipient in all_recipients:
                     msg["To"] = recipient
-                    server.sendmail(SMTP_CONFIG["default_sender"], [recipient],
-                                    msg.as_string())
+                    server.sendmail(
+                        SMTP_CONFIG["default_sender"], [recipient], msg.as_string()
+                    )
                     logger.info(f"Notification email sent to: {recipient}")
         except Exception as e:
             logger.error(f"Failed to send notification email: {e}")
@@ -583,7 +583,13 @@ class Record:
                 self.harvest_source.internal_records_lookup_table[self.identifier],
             )
 
+        record_id = self.harvest_source.internal_records_lookup_table[self.identifier]
         if 200 <= resp.status_code < 300:
+
+            logger.info(
+                f"successfully transformed record: {self.name} of {self.url} \n"
+                f"db record id: {record_id}"
+            )
             self.transformed_data = json.loads(data["writerOutput"])
 
     def validate(self) -> None:

--- a/tests/integration/harvest/test_harvest_full_flow.py
+++ b/tests/integration/harvest/test_harvest_full_flow.py
@@ -1,5 +1,6 @@
 import json
 from unittest.mock import patch
+
 from harvester.harvest import HarvestSource
 
 
@@ -171,7 +172,7 @@ class TestHarvestFullFlow:
         interface,
         organization_data,
         source_data_dcatus_single_record,
-        caplog
+        caplog,
     ):
         CKANMock.action.package_create.return_value = {"id": 1234}
         CKANMock.action.package_update = "ok"
@@ -186,8 +187,9 @@ class TestHarvestFullFlow:
         )
         job_id = harvest_job.id
         harvest_source = HarvestSource(job_id)
-        harvest_source.notification_emails = [source_data_dcatus_single_record[
-                                            "notification_emails"]]
+        harvest_source.notification_emails = [
+            source_data_dcatus_single_record["notification_emails"]
+        ]
 
         results = {"create": 10, "update": 5, "delete": 3, None: 2}
 
@@ -199,4 +201,3 @@ class TestHarvestFullFlow:
         mock_smtp.side_effect = Exception("SMTP failed")
         harvest_source.send_notification_emails(results)
         assert "Failed to send notification email: SMTP failed" in caplog.text
-

--- a/tests/integration/harvest/test_transform.py
+++ b/tests/integration/harvest/test_transform.py
@@ -37,6 +37,19 @@ class TestTransform:
 
         assert test_record.mdt_msgs == expected
 
+        expected_error_msg = (
+            "record failed to transform: structure messages:  \n"
+            "validation messages: WARNING: ISO19115-2 reader: element "
+            "'role' is missing valid nil reason within 'CI_ResponsibleParty'"
+        )
+
+        job_errors = interface.get_harvest_record_errors_by_job(harvest_job.id)
+        assert len(job_errors) == 1
+        assert job_errors[0].message == expected_error_msg
+
+        record = interface.get_harvest_record(job_errors[0].record.id)
+        assert record.status == "error"
+
     def test_valid_transform_iso19115_2(
         self,
         interface,

--- a/tests/integration/harvest/test_transform.py
+++ b/tests/integration/harvest/test_transform.py
@@ -63,7 +63,8 @@ class TestTransform:
         harvest_job = interface.add_harvest_job(job_data_waf_iso19115_2)
 
         harvest_source = HarvestSource(harvest_job.id)
-        harvest_source.prepare_external_data()
+        harvest_source.get_record_changes()
+        harvest_source.write_compare_to_db()
 
         name = "http://localhost:80/iso_2_waf/valid_47598.xml"
         test_record = harvest_source.external_records[name]


### PR DESCRIPTION
- lint (i ended up keeping this because it's a result of running our `make lint` command)
- add log for successful transformation
- update invalid transform test to check db error message and record status
- update valid transform test so the "transform" function has access to the db record id. i can change this but it seemed informative to include the db record guuid in the log. 

# Pull Request

Related to [#4759](https://github.com/GSA/data.gov/issues/4759)

## About

<!-- any pertinent notes -->

## PR TASKS

- [x] The actual code changes.
- [x] Tests written and passed.
- [ ] Any changes to docs?
