### PR TITLE
Scroll Bars are always displayed on the job error table

### DIFF
--- a/app/static/_scss/_uswds-theme-custom-styles.scss
+++ b/app/static/_scss/_uswds-theme-custom-styles.scss
@@ -63,8 +63,6 @@ ul.menu {
   }
 }
 
-div.job-data {
-  .usa-table-container--scrollable {
-    overflow: scroll;
-  }
+.usa-table-container--scrollable {
+  overflow: scroll;
 }

--- a/app/static/_scss/_uswds-theme-custom-styles.scss
+++ b/app/static/_scss/_uswds-theme-custom-styles.scss
@@ -62,3 +62,9 @@ ul.menu {
     cursor: pointer;
   }
 }
+
+div.job-data {
+  .usa-table-container--scrollable {
+    overflow: scroll;
+  }
+}


### PR DESCRIPTION
# Pull Request

Related to [4982](https://github.com/GSA/data.gov/issues/4982)
## About
This makes it so that the scroll bars on the Job error table are always displayed so no hover is needed.

![Screenshot from 2025-01-28 13-58-14](https://github.com/user-attachments/assets/483bfc7e-c3fb-4181-9428-ca158990aa79)

Note for consideration:
- I know we have a similar table on the Organization Data page, so I made the scss change specific to the Job data Page only. The change could be made so we affect both tables though.

## PR TASKS

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
