### PR TITLE
Fix fixture json email

### DIFF
--- a/tests/fixtures.json
+++ b/tests/fixtures.json
@@ -17,7 +17,7 @@
             "frequency": "daily",
             "url": "http://localhost:80/dcatus/dcatus.json",
             "schema_type": "dcatus1.1: federal",
-            "source_type": "document",
+            "source_type": "document"
         }
     ],
     "job": [

--- a/tests/fixtures.json
+++ b/tests/fixtures.json
@@ -10,12 +10,14 @@
         {
             "id": "2f2652de-91df-4c63-8b53-bfced20b276b",
             "name": "Test Source",
-            "notification_emails": "email@example.com",
+            "notification_emails": [
+                "email@example.com"
+            ],
             "organization_id": "d925f84d-955b-4cb7-812f-dcfd6681a18f",
             "frequency": "daily",
             "url": "http://localhost:80/dcatus/dcatus.json",
             "schema_type": "dcatus1.1: federal",
-            "source_type": "document"
+            "source_type": "document",
         }
     ],
     "job": [


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5066

## About

In the fixture we have the `notification_email` set as a string. When this then gets loaded in the parser is expecting an json array, which then in parsing breaks the current string into individual characters. By replacing it with the expected array this then allows it to be parsed correctly.
![Screenshot from 2025-02-06 17-01-57](https://github.com/user-attachments/assets/f03da96f-a309-4aca-8bb2-34b1d2572719)


## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
