### PR TITLE
Detect Mimetype and Other Information from JSON

### DIFF
--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -1,8 +1,8 @@
-import re
-import uuid
 import mimetypes
-from typing import Union, Tuple
+import re
 import urllib
+import uuid
+from typing import Tuple, Union
 
 from harvester.harvest import HarvestSource
 

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -16,6 +16,7 @@ MAX_TAG_LENGTH = 100
 MIN_TAG_LENGTH = 2
 
 # mapping of file formats and their respective names
+# taken from https://github.com/GSA/ckanext-geodatagov/blob/4510c5be2bb9ecc16de8bae082fef4d970f10f55/ckanext/geodatagov/plugin.py#L59-L282
 RESOURCE_MAPPING = {
     # ArcGIS File Types
     "esri rest": ("Esri REST", "Esri REST API Endpoint"),
@@ -471,6 +472,8 @@ def get_email_from_str(in_str: str) -> str:
 def get_filename_and_extension(resource: dict) -> Tuple[str, str]:
     """
     Attempt to extract a file name and extension from a provided resource.
+    Original Code from:
+    https://github.com/GSA/ckanext-geodatagov/blob/4510c5be2bb9ecc16de8bae082fef4d970f10f55/ckanext/geodatagov/plugin.py#L342
     """
     url = resource.get("url").rstrip("/")
     if "?" in url:
@@ -489,6 +492,8 @@ def get_filename_and_extension(resource: dict) -> Tuple[str, str]:
 def change_resource_details(resource: dict) -> None:
     """
     Pull the provided file name, format, and description.
+    Original Code from:
+    https://github.com/GSA/ckanext-geodatagov/blob/4510c5be2bb9ecc16de8bae082fef4d970f10f55/ckanext/geodatagov/plugin.py#L357
     """
     formats = list(RESOURCE_MAPPING.keys())
     resource_format = resource.get("format", "").lower().lstrip(".")
@@ -525,6 +530,8 @@ def guess_resource_format(url: str, use_mimetypes: bool = True) -> Union[str, No
 
     Returns None if no format could be guessed.
 
+    Original Code from:
+    https://github.com/GSA/ckanext-spatial/blob/418f0f9daaef4f5363525162fc42904ce954a467/ckanext/spatial/harvesters/base.py#L63
     """
     url = url.lower().strip()
 
@@ -571,8 +578,9 @@ def guess_resource_format(url: str, use_mimetypes: bool = True) -> Union[str, No
         if any(url.endswith(extension) for extension in extensions):
             return file_type
 
-    resource_format, encoding = mimetypes.guess_type(url)
-    if resource_format:
+    # to align with the comment I'm adding this code in case
+    if use_mimetypes:
+        resource_format, encoding = mimetypes.guess_type(url)
         return resource_format
 
     return None

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -1,5 +1,8 @@
 import re
 import uuid
+import mimetypes
+from typing import Union, Tuple
+import urllib
 
 from harvester.harvest import HarvestSource
 
@@ -11,6 +14,223 @@ PACKAGE_NAME_MIN_LENGTH = 2
 
 MAX_TAG_LENGTH = 100
 MIN_TAG_LENGTH = 2
+
+# mapping of file formats and their respective names
+RESOURCE_MAPPING = {
+    # ArcGIS File Types
+    "esri rest": ("Esri REST", "Esri REST API Endpoint"),
+    "arcgis_rest": ("Esri REST", "Esri REST API Endpoint"),
+    "web map application": ("ArcGIS Online Map", "ArcGIS Online Map"),
+    "arcgis map preview": ("ArcGIS Map Preview", "ArcGIS Map Preview"),
+    "arcgis map service": ("ArcGIS Map Service", "ArcGIS Map Service"),
+    "wms": ("WMS", "ArcGIS Web Mapping Service"),
+    "wfs": ("WFS", "ArcGIS Web Feature Service"),
+    "wcs": ("WCS", "Web Coverage Service"),
+    # CSS File Types
+    "css": ("CSS", "Cascading Style Sheet File"),
+    "text/css": ("CSS", "Cascading Style Sheet File"),
+    # CSV File Types
+    "csv": ("CSV", "Comma Separated Values File"),
+    "text/csv": ("CSV", "Comma Separated Values File"),
+    # EXE File Types
+    "exe": ("EXE", "Windows Executable Program"),
+    "application/x-msdos-program": ("EXE", "Windows Executable Program"),
+    # HyperText Markup Language (HTML) File Types
+    "htx": ("HTML", "Web Page"),
+    "htm": ("HTML", "Web Page"),
+    "html": ("HTML", "Web Page"),
+    "htmls": ("HTML", "Web Page"),
+    "xhtml": ("HTML", "Web Page"),
+    "text/html": ("HTML", "Web Page"),
+    "application/xhtml+xml": ("HTML", "Web Page"),
+    "application/x-httpd-php": ("HTML", "Web Page"),
+    # Image File Types - BITMAP
+    "bm": ("BMP", "Bitmap Image File"),
+    "bmp": ("BMP", "Bitmap Image File"),
+    "pbm": ("BMP", "Bitmap Image File"),
+    "xbm": ("BMP", "Bitmap Image File"),
+    "image/bmp": ("BMP", "Bitmap Image File"),
+    "image/x-ms-bmp": ("BMP", "Bitmap Image File"),
+    "image/x-xbitmap": ("BMP", "Bitmap Image File"),
+    "image/x-windows-bmp": ("BMP", "Bitmap Image File"),
+    "image/x-portable-bitmap": ("BMP", "Bitmap Image File"),
+    # Image File Types - Graphics Interchange Format (GIF)
+    "gif": ("GIF", "GIF Image File"),
+    "image/gif": ("GIF", "GIF Image File"),
+    # Image File Types - ICON
+    "ico": ("ICO", "Icon Image File"),
+    "image/x-icon": ("ICO", "Icon Image File"),
+    # Image File Types - JPEG
+    "jpe": ("JPEG", "JPEG Image File"),
+    "jpg": ("JPEG", "JPEG Image File"),
+    "jps": ("JPEG", "JPEG Image File"),
+    "jpeg": ("JPEG", "JPEG Image File"),
+    "pjpeg": ("JPEG", "JPEG Image File"),
+    "image/jpeg": ("JPEG", "JPEG Image File"),
+    "image/pjpeg": ("JPEG", "JPEG Image File"),
+    "image/x-jps": ("JPEG", "JPEG Image File"),
+    "image/x-citrix-jpeg": ("JPEG", "JPEG Image File"),
+    # Image File Types - PNG
+    "png": ("PNG", "PNG Image File"),
+    "x-png": ("PNG", "PNG Image File"),
+    "image/png": ("PNG", "PNG Image File"),
+    "image/x-citrix-png": ("PNG", "PNG Image File"),
+    # Image File Types - Scalable Vector Graphics (SVG)
+    "svg": ("SVG", "SVG Image File"),
+    "image/svg+xml": ("SVG", "SVG Image File"),
+    # Image File Types - Tagged Image File Format (TIFF)
+    "tif": ("TIFF", "TIFF Image File"),
+    "tiff": ("TIFF", "TIFF Image File"),
+    "image/tiff": ("TIFF", "TIFF Image File"),
+    "image/x-tiff": ("TIFF", "TIFF Image File"),
+    # JSON File Types
+    "json": ("JSON", "JSON File"),
+    "text/x-json": ("JSON", "JSON File"),
+    "application/json": ("JSON", "JSON File"),
+    # KML File Types
+    "kml": ("KML", "KML File"),
+    "kmz": ("KML", "KMZ File"),
+    "application/vnd.google-earth.kml+xml": ("KML", "KML File"),
+    "application/vnd.google-earth.kmz": ("KML", "KMZ File"),
+    # MS Access File Types
+    "mdb": ("ACCESS", "MS Access Database"),
+    "access": ("ACCESS", "MS Access Database"),
+    "application/mdb": ("ACCESS", "MS Access Database"),
+    "application/msaccess": ("ACCESS", "MS Access Database"),
+    "application/x-msaccess": ("ACCESS", "MS Access Database"),
+    "application/vnd.msaccess": ("ACCESS", "MS Access Database"),
+    "application/vnd.ms-access": ("ACCESS", "MS Access Database"),
+    # MS Excel File Types
+    "xl": ("EXCEL", "MS Excel File"),
+    "xla": ("EXCEL", "MS Excel File"),
+    "xlb": ("EXCEL", "MS Excel File"),
+    "xlc": ("EXCEL", "MS Excel File"),
+    "xld": ("EXCEL", "MS Excel File"),
+    "xls": ("EXCEL", "MS Excel File"),
+    "xlsx": ("EXCEL", "MS Excel File"),
+    "xlsm": ("EXCEL", "MS Excel File"),
+    "excel": ("EXCEL", "MS Excel File"),
+    "openXML": ("EXCEL", "MS Excel File"),
+    "application/excel": ("EXCEL", "MS Excel File"),
+    "application/x-excel": ("EXCEL", "MS Excel File"),
+    "application/x-msexcel": ("EXCEL", "MS Excel File"),
+    "application/vnd.ms-excel": ("EXCEL", "MS Excel File"),
+    "application/vnd.ms-excel.sheet.macroEnabled.12": ("EXCEL", "MS Excel File"),
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": (
+        "EXCEL",
+        "MS Excel File",
+    ),
+    # MS PowerPoint File Types
+    "ppt": ("POWERPOINT", "MS PowerPoint File"),
+    "pps": ("POWERPOINT", "MS PowerPoint File"),
+    "pptx": ("POWERPOINT", "MS PowerPoint File"),
+    "ppsx": ("POWERPOINT", "MS PowerPoint File"),
+    "pptm": ("POWERPOINT", "MS PowerPoint File"),
+    "ppsm": ("POWERPOINT", "MS PowerPoint File"),
+    "sldx": ("POWERPOINT", "MS PowerPoint File"),
+    "sldm": ("POWERPOINT", "MS PowerPoint File"),
+    "application/powerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/mspowerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/x-mspowerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/vnd.ms-powerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/vnd.ms-powerpoint.presentation.macroEnabled.12": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.ms-powerpoint.slideshow.macroEnabled.12": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.ms-powerpoint.slide.macroEnabled.12": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.openxmlformats-officedocument.presentationml.slide": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.openxmlformats-officedocument.presentationml.slideshow": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    # MS Word File Types
+    "doc": ("DOC", "MS Word File"),
+    "docx": ("DOC", "MS Word File"),
+    "docm": ("DOC", "MS Word File"),
+    "word": ("DOC", "MS Word File"),
+    "application/msword": ("DOC", "MS Word File"),
+    "application/vnd.ms-word.document.macroEnabled.12": ("DOC", "MS Word File"),
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
+        "DOC",
+        "MS Word File",
+    ),
+    # Network Common Data Form (NetCDF) File Types
+    "nc": ("CDF", "NetCDF File"),
+    "cdf": ("CDF", "NetCDF File"),
+    "netcdf": ("CDF", "NetCDF File"),
+    "application/x-netcdf": ("NETCDF", "NetCDF File"),
+    # PDF File Types
+    "pdf": ("PDF", "PDF File"),
+    "application/pdf": ("PDF", "PDF File"),
+    # PERL File Types
+    "pl": ("PERL", "Perl Script File"),
+    "pm": ("PERL", "Perl Module File"),
+    "perl": ("PERL", "Perl Script File"),
+    "text/x-perl": ("PERL", "Perl Script File"),
+    # QGIS File Types
+    "qgis": ("QGIS", "QGIS File"),
+    "application/x-qgis": ("QGIS", "QGIS File"),
+    # RAR File Types
+    "rar": ("RAR", "RAR Compressed File"),
+    "application/rar": ("RAR", "RAR Compressed File"),
+    "application/vnd.rar": ("RAR", "RAR Compressed File"),
+    "application/x-rar-compressed": ("RAR", "RAR Compressed File"),
+    # Resource Description Framework (RDF) File Types
+    "rdf": ("RDF", "RDF File"),
+    "application/rdf+xml": ("RDF", "RDF File"),
+    # Rich Text Format (RTF) File Types
+    "rt": ("RICH TEXT", "Rich Text File"),
+    "rtf": ("RICH TEXT", "Rich Text File"),
+    "rtx": ("RICH TEXT", "Rich Text File"),
+    "text/richtext": ("RICH TEXT", "Rich Text File"),
+    "text/vnd.rn-realtext": ("RICH TEXT", "Rich Text File"),
+    "application/rtf": ("RICH TEXT", "Rich Text File"),
+    "application/x-rtf": ("RICH TEXT", "Rich Text File"),
+    # SID File Types - Primary association: Commodore64 (C64)?
+    "sid": ("SID", "SID File"),
+    "mrsid": ("SID", "SID File"),
+    "audio/psid": ("SID", "SID File"),
+    "audio/x-psid": ("SID", "SID File"),
+    "audio/sidtune": ("SID", "MID File"),
+    "audio/x-sidtune": ("SID", "SID File"),
+    "audio/prs.sid": ("SID", "SID File"),
+    # Tab Separated Values (TSV) File Types
+    "tsv": ("TSV", "Tab Separated Values File"),
+    "text/tab-separated-values": ("TSV", "Tab Separated Values File"),
+    # Tape Archive (TAR) File Types
+    "tar": ("TAR", "TAR Compressed File"),
+    "application/x-tar": ("TAR", "TAR Compressed File"),
+    # Text File Types
+    "txt": ("TEXT", "Text File"),
+    "text/plain": ("TEXT", "Text File"),
+    # Extensible Markup Language (XML) File Types
+    "xml": ("XML", "XML File"),
+    "text/xml": ("XML", "XML File"),
+    "application/xml": ("XML", "XML File"),
+    # XYZ File Format File Types
+    "xyz": ("XYZ", "XYZ File"),
+    "chemical/x-xyz": ("XYZ", "XYZ File"),
+    # ZIP File Types
+    "zip": ("ZIP", "Zip File"),
+    "application/zip": ("ZIP", "Zip File"),
+    "multipart/x-zip": ("ZIP", "Zip File"),
+    "application/x-compressed": ("ZIP", "Zip File"),
+    "application/x-zip-compressed": ("ZIP", "Zip File"),
+}
 
 
 def _munge_to_length(string: str, min_length: int, max_length: int) -> str:
@@ -248,6 +468,116 @@ def get_email_from_str(in_str: str) -> str:
         return res.group(0)
 
 
+def get_filename_and_extension(resource: dict) -> Tuple[str, str]:
+    """
+    Attempt to extract a file name and extension from a provided resource.
+    """
+    url = resource.get("url").rstrip("/")
+    if "?" in url:
+        return "", ""
+    if "URL" in url:
+        return "", ""
+    url = urllib.parse.urlparse(url).path
+    split = url.split("/")
+    last_part = split[-1]
+    ending = last_part.split(".")[-1].lower()
+    if len(ending) in [2, 3, 4] and len(last_part) > 4 and len(split) > 1:
+        return last_part, ending
+    return "", ""
+
+
+def change_resource_details(resource: dict) -> None:
+    """
+    Pull the provided file name, format, and description.
+    """
+    formats = list(RESOURCE_MAPPING.keys())
+    resource_format = resource.get("format", "").lower().lstrip(".")
+    filename, extension = get_filename_and_extension(resource)
+    if not resource_format:
+        resource_format = extension
+    if resource.get("name", "") in ["Unnamed resource", "", None]:
+        resource["no_real_name"] = True
+    if resource_format in formats:
+        resource["format"] = RESOURCE_MAPPING[resource_format][0]
+        if resource.get("name", "") in ["Unnamed resource", "", None]:
+            resource["name"] = RESOURCE_MAPPING[resource_format][1]
+            if filename:
+                resource["name"] = resource["name"]
+    elif resource.get("name", "") in ["Unnamed resource", "", None]:
+        if extension and not resource_format:
+            resource["format"] = extension.upper()
+        resource["name"] = "Web Resource"
+
+    if filename and not resource.get("description"):
+        resource["description"] = filename
+
+
+def guess_resource_format(url: str, use_mimetypes: bool = True) -> Union[str, None]:
+    """
+    Given a URL try to guess the best format to assign to the resource
+
+    The function looks for common patterns in popular geospatial services and
+    file extensions, so it may not be 100% accurate. It just looks at the
+    provided URL, it does not attempt to perform any remote check.
+
+    if 'use_mimetypes' is True (default value), the mimetypes module will be
+    used if no match was found before.
+
+    Returns None if no format could be guessed.
+
+    """
+    url = url.lower().strip()
+
+    resource_types = {
+        # OGC
+        "wms": (
+            "service=wms",
+            "geoserver/wms",
+            "mapserver/wmsserver",
+            "com.esri.wms.Esrimap",
+            "service/wms",
+        ),
+        "wfs": (
+            "service=wfs",
+            "geoserver/wfs",
+            "mapserver/wfsserver",
+            "com.esri.wfs.Esrimap",
+        ),
+        "wcs": (
+            "service=wcs",
+            "geoserver/wcs",
+            "imageserver/wcsserver",
+            "mapserver/wcsserver",
+        ),
+        "sos": ("service=sos",),
+        "csw": ("service=csw",),
+        # ESRI
+        "kml": ("mapserver/generatekml",),
+        "arcims": ("com.esri.esrimap.esrimap",),
+        "arcgis_rest": ("arcgis/rest/services",),
+    }
+
+    for resource_type, parts in resource_types.items():
+        if any(part in url for part in parts):
+            return resource_type
+
+    file_types = {
+        "kml": ("kml",),
+        "kmz": ("kmz",),
+        "gml": ("gml",),
+    }
+
+    for file_type, extensions in file_types.items():
+        if any(url.endswith(extension) for extension in extensions):
+            return file_type
+
+    resource_format, encoding = mimetypes.guess_type(url)
+    if resource_format:
+        return resource_format
+
+    return None
+
+
 def create_ckan_resources(metadata: dict) -> list[dict]:
     output = []
 
@@ -260,9 +590,15 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
             if dist.get(url_key, None) is None:
                 continue
             resource = {"url": dist[url_key]}
+            # set mimetype if provided or discover it
             if "mimetype" in dist:
                 resource["mimetype"] = dist["mediaType"]
+            else:
+                resource["mimetype"] = guess_resource_format(dist[url_key])
 
+            # if we know the mimetype add the other details
+            if resource["mimetype"]:
+                change_resource_details(resource=resource)
         output.append(resource)
 
     return output

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -492,6 +492,7 @@ def get_filename_and_extension(resource: dict) -> Tuple[str, str]:
 def change_resource_details(resource: dict) -> None:
     """
     Pull the provided file name, format, and description.
+    Note this function works by manipulating the original input.
     Original Code from:
     https://github.com/GSA/ckanext-geodatagov/blob/4510c5be2bb9ecc16de8bae082fef4d970f10f55/ckanext/geodatagov/plugin.py#L357
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Generator, List
-from unittest.mock import patch, Mock
-
+from unittest.mock import Mock, patch
 
 import pytest
 from dotenv import load_dotenv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,13 @@ def fixtures_json():
         return json.load(file)
 
 
+@pytest.fixture
+def dol_distribution_json():
+    file = Path(__file__).parents[0] / "distribution-examples/dol-example.json"
+    with open(file, "r") as file:
+        return json.load(file)
+
+
 ## ORGS
 @pytest.fixture
 def organization_data(fixtures_json) -> dict:
@@ -156,6 +163,7 @@ def source_data_waf_csdgm(organization_data: dict) -> dict:
         "source_type": "waf",
         "notification_frequency": "always",
     }
+
 
 @pytest.fixture
 def source_data_waf_iso19115_2(organization_data: dict) -> dict:
@@ -765,12 +773,12 @@ def iso19115_1_transform() -> dict:
         "primaryITInvestmentUII": "{4c6928d8-6ac2-4909-8b3d-a29e2805ce2d}",
     }
 
+
 @pytest.fixture
 def mock_requests_get_ms_iis_waf(monkeypatch):
     """Fixture to mock requests.get with ms-iis-waf HTML content"""
     import requests
 
-    
     def mock_get(url, *args, **kwargs):
         """Mock function to return a predefined HTML response"""
         mock_response = Mock()
@@ -780,9 +788,9 @@ def mock_requests_get_ms_iis_waf(monkeypatch):
         file_path = Path(__file__).parent / "waf-html-examples/ms-iis-waf.html"
         with open(file_path, "r", encoding="utf-8") as file:
             mock_response.text = file.read()
-        
+
         # Set UTF-8 content
-        mock_response.content = mock_response.text.encode('utf-8')
+        mock_response.content = mock_response.text.encode("utf-8")
 
         return mock_response
 

--- a/tests/distribution-examples/dol-example.json
+++ b/tests/distribution-examples/dol-example.json
@@ -1,0 +1,88 @@
+{
+    "@type": "dcat:Dataset",
+    "accessLevel": "public",
+    "contactPoint": {
+        "@type": "vcard:Contact",
+        "fn": "Department of Licensing",
+        "hasEmail": "mailto:no-reply@data.wa.gov"
+    },
+    "description": "This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Electric Vehicles (PHEVs) that are currently registered through Washington State Department of Licensing (DOL).",
+    "distribution": [
+        {
+            "@type": "dcat:Distribution",
+            "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD",
+            "mediaType": "text/csv"
+        },
+        {
+            "@type": "dcat:Distribution",
+            "describedBy": "https://data.wa.gov/api/views/f6w7-q2d2/columns.rdf",
+            "describedByType": "application/rdf+xml",
+            "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.rdf?accessType=DOWNLOAD",
+            "mediaType": "application/rdf+xml"
+        },
+        {
+            "@type": "dcat:Distribution",
+            "describedBy": "https://data.wa.gov/api/views/f6w7-q2d2/columns.json",
+            "describedByType": "application/json",
+            "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.json?accessType=DOWNLOAD",
+            "mediaType": "application/json"
+        },
+        {
+            "@type": "dcat:Distribution",
+            "describedBy": "https://data.wa.gov/api/views/f6w7-q2d2/columns.xml",
+            "describedByType": "application/xml",
+            "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.xml?accessType=DOWNLOAD",
+            "mediaType": "application/xml"
+        }
+    ],
+    "identifier": "https://data.wa.gov/api/views/f6w7-q2d2",
+    "issued": "2023-10-19",
+    "keyword": [
+        "bev",
+        "bevs",
+        "bolt",
+        "car",
+        "cars",
+        "chevrolet",
+        "chevy",
+        "clean energy",
+        "department of licensing",
+        "dol",
+        "dol_open_data",
+        "electric",
+        "energy",
+        "environment",
+        "ev",
+        "evs",
+        "green report",
+        "hybrid",
+        "hybrids",
+        "leaf",
+        "model 3",
+        "nhtsa",
+        "nissan",
+        "phev",
+        "phevs",
+        "plug-in",
+        "plug-ins",
+        "population",
+        "rao_ev",
+        "rao_open_data",
+        "rao_veh",
+        "tesla",
+        "vehicle",
+        "vehicles",
+        "volt"
+    ],
+    "landingPage": "https://data.wa.gov/d/f6w7-q2d2",
+    "license": "http://opendatacommons.org/licenses/odbl/1.0/",
+    "modified": "2025-01-16",
+    "publisher": {
+        "@type": "org:Organization",
+        "name": "data.wa.gov"
+    },
+    "theme": [
+        "Transportation"
+    ],
+    "title": "Electric Vehicle Population Data"
+}

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -5,6 +5,7 @@ from deepdiff import DeepDiff
 
 from harvester.harvest import HarvestSource, Record
 from harvester.utils.general_utils import dataset_to_hash, sort_dataset
+from harvester.utils.ckan_utils import create_ckan_resources
 
 # ruff: noqa: E501
 
@@ -125,7 +126,12 @@ class TestCKANLoad:
             "title": "Commitment of Traders",
             "resources": [
                 {
-                    "url": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/index.htm"
+                    "url": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/index.htm",
+                    "mimetype": "text/html",
+                    "no_real_name": True,
+                    "format": "HTML",
+                    "name": "Web Page",
+                    "description": "index.htm",
                 }
             ],
             "tags": [
@@ -161,3 +167,37 @@ class TestCKANLoad:
 
         test_record.ckanify_dcatus()
         assert DeepDiff(test_record.ckanified_metadata, expected_result) == {}
+
+    def test_create_ckan_resources(self, dol_distribution_json):
+        """
+        Test that we are accurately parsing information from the
+        distribution sections.
+        """
+        expected_resources = [
+            {
+                "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD",
+                "mimetype": "text/csv",
+                "no_real_name": True,
+                "name": "Web Resource",
+            },
+            {
+                "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.rdf?accessType=DOWNLOAD",
+                "mimetype": "application/rdf+xml",
+                "no_real_name": True,
+                "name": "Web Resource",
+            },
+            {
+                "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.json?accessType=DOWNLOAD",
+                "mimetype": "application/json",
+                "no_real_name": True,
+                "name": "Web Resource",
+            },
+            {
+                "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.xml?accessType=DOWNLOAD",
+                "mimetype": "application/xml",
+                "no_real_name": True,
+                "name": "Web Resource",
+            },
+        ]
+        resources = create_ckan_resources(dol_distribution_json)
+        assert resources == expected_resources

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from deepdiff import DeepDiff
 
 from harvester.harvest import HarvestSource, Record
-from harvester.utils.general_utils import dataset_to_hash, sort_dataset
 from harvester.utils.ckan_utils import create_ckan_resources
+from harvester.utils.general_utils import dataset_to_hash, sort_dataset
 
 # ruff: noqa: E501
 


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5083

## About

- We now are able to detect the `mimetype` from the `downloadURL`
- We also now populate other pieces of information from given the [Resource Mapping](https://github.com/GSA/ckanext-geodatagov/blob/4510c5be2bb9ecc16de8bae082fef4d970f10f55/ckanext/geodatagov/plugin.py#L59-L282) (`name`, `no_real_name`, and `description` _(based on previous criteria)_) 

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
