### PR TITLE
Fix bug for old-spatial being changed.

### DIFF
--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -424,8 +424,8 @@ def create_ckan_extras(
                 }
             )
         elif extra == "spatial":
-            data["value"] = translate_spatial(metadata["spatial"])
             output.append({"key": "old-spatial", "value": metadata["spatial"]})
+            data["value"] = translate_spatial(metadata["spatial"])
         else:
             if isinstance(val, list):  # TODO: confirm this is what we want.
                 val = val[0]
@@ -737,10 +737,15 @@ def munge_spatial(spatial_value: str) -> str:
     return ""
 
 
-def translate_spatial(spatial_value) -> str:
+def translate_spatial(input) -> str:
     # is it already JSON? If so stringify it
-    if isinstance(spatial_value, dict):
-        spatial_value = json.dumps(spatial_value)
+    if isinstance(input, dict):
+        spatial_value = json.dumps(input)
+    elif isinstance(input, str):
+        spatial_value = input
+    else:
+        # This shouldn't happen due to validation, but just in case
+        return ""
     # Is it already valid geojson (or geojson that can be cleaned up)?
     # If so, return it.
     validated_geojson = validate_geojson(spatial_value)

--- a/tests/distribution-examples/dol-example.json
+++ b/tests/distribution-examples/dol-example.json
@@ -81,6 +81,7 @@
         "@type": "org:Organization",
         "name": "data.wa.gov"
     },
+    "spatial": "United States",
     "theme": [
         "Transportation"
     ],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from harvester.utils.ckan_utils import (
+    create_ckan_extras,
     munge_spatial,
     munge_tag,
     munge_title_to_name,
@@ -171,13 +172,42 @@ class TestCKANUtils:
         assert translate_spatial("-88.9718,36.52033") == (
             '{"type": "Point", "coordinates": [-88.9718, 36.52033]}'
         )
-    
+
     def test_translate_spatial_input_unchanged(self):
         metadata = {
             "spatial": "1.0,2.0,3.5,5.5",
         }
         translate_spatial(metadata["spatial"])
         assert metadata["spatial"] == "1.0,2.0,3.5,5.5"
+
+    def test_create_ckan_extras(self, dol_distribution_json, source_data_dcatus_orm):
+        extras = create_ckan_extras(
+            dol_distribution_json, source_data_dcatus_orm, "1234"
+        )
+
+        assert extras == [
+            {"key": "resource-type", "value": "Dataset"},
+            {"key": "harvest_object_id", "value": "1234"},
+            {"key": "source_datajson_identifier", "value": True},
+            {
+                "key": "harvest_source_id",
+                "value": "2f2652de-91df-4c63-8b53-bfced20b276b",
+            },
+            {"key": "harvest_source_title", "value": "Test Source"},
+            {"key": "accessLevel", "value": "public"},
+            {"key": "identifier", "value": "https://data.wa.gov/api/views/f6w7-q2d2"},
+            {"key": "modified", "value": "2025-01-16"},
+            {"key": "publisher_hierarchy", "value": "data.wa.gov"},
+            {"key": "publisher", "value": "data.wa.gov"},
+            {"key": "old-spatial", "value": "United States"},
+            {
+                "key": "spatial",
+                "value": '{"type":"MultiPolygon","coordinates":'
+                "[[[[-124.733253,24.544245],[-124.733253,49.388611],"
+                "[-66.954811,49.388611],[-66.954811,24.544245],[-124.733253,24.544245]]]]}",
+            },
+            {"key": "identifier", "value": "https://data.wa.gov/api/views/f6w7-q2d2"},
+        ]
 
 
 # Point example

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -171,6 +171,13 @@ class TestCKANUtils:
         assert translate_spatial("-88.9718,36.52033") == (
             '{"type": "Point", "coordinates": [-88.9718, 36.52033]}'
         )
+    
+    def test_translate_spatial_input_unchanged(self):
+        metadata = {
+            "spatial": "1.0,2.0,3.5,5.5",
+        }
+        translate_spatial(metadata["spatial"])
+        assert metadata["spatial"] == "1.0,2.0,3.5,5.5"
 
 
 # Point example


### PR DESCRIPTION
old-spatial metadata value was being changed and causing old-spatial and spatial to match. This adds a test case and fixes that bug.

# Pull Request

Related to https://github.com/GSA/data.gov/issues/5084

## About

Weird thing about this. We found that when the DCAT-US file was harvested onto catalog-next, there seemed to be a bug around old-spatial. The old-spatial and spatial fields had the same value (they shouldn't in this test case, old-spatial should read "United States"). It seemed obvious that the field was getting manipulated in the wrong way.

However, when creating a "failing" test (to reproduce this error), I couldn't reproduce it. Tests immediately passed. I tried to make the safe changes I would make had everything worked as I would have expected. And of course I added the tests.

This should be tested out against development, and rerun the [test harvest](https://datagov-harvest-admin-dev.app.cloud.gov/harvest_source/41f2a5f0-cacb-4b41-9f49-07cfcc5287b7) (after clearing) to see if the problem is resolved, or something deeper is going on.

![image](https://github.com/user-attachments/assets/c79ad437-a6b1-4c01-97fb-6a89870ff0eb)


## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
