### PR TITLE
Update spatial schema

### DIFF
--- a/schemas/federal_dataset.json
+++ b/schemas/federal_dataset.json
@@ -379,6 +379,21 @@
           "minLength": 1
         },
         {
+          "type": "object",
+          "properties": {
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "type": {
+              "type": "string",
+              "pattern": "^(?!envelope$).+$"
+            }
+          }
+        },
+        {
           "type": "null"
         }
       ]

--- a/schemas/federal_dataset.json
+++ b/schemas/federal_dataset.json
@@ -384,12 +384,14 @@
             "coordinates": {
               "type": "array",
               "items": {
-                "type": "number"
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
               }
             },
             "type": {
-              "type": "string",
-              "pattern": "^(?!envelope$).+$"
+              "type": "string"
             }
           }
         },

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -228,7 +228,6 @@ class TestCKANLoad:
         record = internal_compare_data["records"][0]
         # force in "spatial" attr as string
         record["spatial"] = "United States"
-        harvest_source.validator.is_valid(record)
         assert harvest_source.validator.is_valid(record)
 
     def test_dcatus1_1_federal_validator_success_spatial_object(

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -235,11 +235,8 @@ class TestCKANLoad:
         record = internal_compare_data["records"][0]
         # force in "spatial" attr as string
         record["spatial"] = "United States"
-        try:
-            harvest_source.validator.validate(record)
-        except ValidationError as e:
-            print(e)
-            assert False
+        harvest_source.validator.validate(record)
+        assert True
 
     def test_dcatus1_1_federal_validator_success_spatial_object(
         self,
@@ -268,11 +265,8 @@ class TestCKANLoad:
             "coordinates": [[-81.0563, 34.9991], [-80.6033, 35.4024]],
             "type": "envelope",
         }
-        try:
-            harvest_source.validator.validate(record)
-        except ValidationError as e:
-            print(e)
-            assert False
+        harvest_source.validator.validate(record)
+        assert True
 
     def test_dcatus1_1_federal_validator_fails(
         self,

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -1,15 +1,14 @@
 from itertools import groupby
 from unittest.mock import patch
-import json
-import pytest
 
+import pytest
 from deepdiff import DeepDiff
+from jsonschema.exceptions import ValidationError
 
 from harvester.harvest import HarvestSource, Record
 from harvester.utils.ckan_utils import create_ckan_resources
 from harvester.utils.general_utils import dataset_to_hash, sort_dataset
 
-from jsonschema.exceptions import ValidationError
 # ruff: noqa: E501
 
 

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -212,9 +212,7 @@ class TestCKANLoad:
 
     def test_dcatus1_1_federal_validator_success_spatial_string(
         self,
-        interface,
-        organization_data,
-        source_data_dcatus,
+        interface_with_fixture_json,
         job_data_dcatus,
         internal_compare_data,
     ):
@@ -223,26 +221,19 @@ class TestCKANLoad:
         dcatus1.1: federal as their schema and contains a "spatial"
         attribute as a string that it passes validation.
         """
-        # Set up for the harvest source
-        interface.add_organization(organization_data)
-        interface.add_harvest_source(source_data_dcatus)
-        harvest_job = interface.add_harvest_job(job_data_dcatus)
-
         # Set up the harvest source
-        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source = HarvestSource(job_data_dcatus["id"])
         # Confirm the correct schema type is used in the example
         assert harvest_source.schema_type == "dcatus1.1: federal"
         record = internal_compare_data["records"][0]
         # force in "spatial" attr as string
         record["spatial"] = "United States"
-        harvest_source.validator.validate(record)
-        assert True
+        harvest_source.validator.is_valid(record)
+        assert harvest_source.validator.is_valid(record)
 
     def test_dcatus1_1_federal_validator_success_spatial_object(
         self,
-        interface,
-        organization_data,
-        source_data_dcatus,
+        interface_with_fixture_json,
         job_data_dcatus,
         internal_compare_data,
     ):
@@ -253,11 +244,7 @@ class TestCKANLoad:
         and "coordinates" as an array of numbers
         that it passes validation.
         """
-        interface.add_organization(organization_data)
-        interface.add_harvest_source(source_data_dcatus)
-        harvest_job = interface.add_harvest_job(job_data_dcatus)
-
-        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source = HarvestSource(job_data_dcatus["id"])
         assert harvest_source.schema_type == "dcatus1.1: federal"
         record = internal_compare_data["records"][0]
         # force in "spatial" attr as json object
@@ -266,13 +253,11 @@ class TestCKANLoad:
             "type": "envelope",
         }
         harvest_source.validator.validate(record)
-        assert True
+        assert harvest_source.validator.is_valid(record)
 
     def test_dcatus1_1_federal_validator_fails(
         self,
-        interface,
-        organization_data,
-        source_data_dcatus,
+        interface_with_fixture_json,
         job_data_dcatus,
         internal_compare_data,
     ):
@@ -282,15 +267,12 @@ class TestCKANLoad:
         attribute that isn't a string or json object that meets
         the defined criteria, fails validation.
         """
-        interface.add_organization(organization_data)
-        interface.add_harvest_source(source_data_dcatus)
-        harvest_job = interface.add_harvest_job(job_data_dcatus)
-
-        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source = HarvestSource(job_data_dcatus["id"])
         assert harvest_source.schema_type == "dcatus1.1: federal"
 
         record = internal_compare_data["records"][0]
         # force in "spatial" attr as array of strings
         record["spatial"] = ["United States"]
+        assert harvest_source.validator.is_valid(record) is False
         with pytest.raises(ValidationError):
             harvest_source.validator.validate(record)

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -251,7 +251,6 @@ class TestCKANLoad:
             "coordinates": [[-81.0563, 34.9991], [-80.6033, 35.4024]],
             "type": "envelope",
         }
-        harvest_source.validator.validate(record)
         assert harvest_source.validator.is_valid(record)
 
     def test_dcatus1_1_federal_validator_fails(


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5055

## About

- Adds validation schema for Json objects within `spatial` for federal schemas (`dcatus1.1: federal`)
    - Anticipated json objects matching the `type` (string) and `coordinates` (array of arrays of numbers _[list of lists of floats]_)
- Adds tests to test for the supported formats for spatial.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
