### PR TITLE
add resource name and description

### DIFF
--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -437,7 +437,8 @@ def create_ckan_extras(
             output.append({"key": "old-spatial", "value": metadata["spatial"]})
             data["value"] = translate_spatial(metadata["spatial"])
         else:
-            if isinstance(val, list):  # TODO: confirm this is what we want.
+            # TODO: confirm this is what we want.
+            if isinstance(val, list) and len(val) > 0:
                 val = val[0]
             data["value"] = val
         output.append(data)
@@ -614,11 +615,15 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
         return output
 
     for dist in metadata["distribution"]:
+        resource = {
+            "description": dist.get("description", ""),
+            "name": dist.get("title", ""),
+        }
         url_keys = ["downloadURL", "accessURL"]
         for url_key in url_keys:
             if dist.get(url_key, None) is None:
                 continue
-            resource = {"url": dist[url_key]}
+            resource["url"] = dist[url_key]
             # set mimetype if provided or discover it
             if "mimetype" in dist:
                 resource["mimetype"] = dist["mediaType"]

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -615,10 +615,11 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
         return output
 
     for dist in metadata["distribution"]:
-        resource = {
-            "description": dist.get("description", ""),
-            "name": dist.get("title", ""),
-        }
+        resource = {}
+        if "description" in dist:
+            resource["description"] = dist["description"]
+        if "title" in dist:
+            resource["name"] = dist["title"]
         url_keys = ["downloadURL", "accessURL"]
         for url_key in url_keys:
             if dist.get(url_key, None) is None:

--- a/tests/distribution-examples/dol-example.json
+++ b/tests/distribution-examples/dol-example.json
@@ -11,28 +11,36 @@
         {
             "@type": "dcat:Distribution",
             "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD",
-            "mediaType": "text/csv"
+            "mediaType": "text/csv",
+            "description": "CSV resource for battery electric vehicles in WA",
+            "title": "Battery Electric Vehicle CSV File"
         },
         {
             "@type": "dcat:Distribution",
             "describedBy": "https://data.wa.gov/api/views/f6w7-q2d2/columns.rdf",
             "describedByType": "application/rdf+xml",
             "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.rdf?accessType=DOWNLOAD",
-            "mediaType": "application/rdf+xml"
+            "mediaType": "application/rdf+xml",
+            "description": "RDF resource for plug-in hybrid electric vehicles in WA",
+            "title": "Plug-in Hybrid Electric Vehicles RDF file"
         },
         {
             "@type": "dcat:Distribution",
             "describedBy": "https://data.wa.gov/api/views/f6w7-q2d2/columns.json",
             "describedByType": "application/json",
             "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.json?accessType=DOWNLOAD",
-            "mediaType": "application/json"
+            "mediaType": "application/json",
+            "description": "JSON resource for BEVs & PHEVs in WA",
+            "title": "BEVs & PHEVs JSON file"
         },
         {
             "@type": "dcat:Distribution",
             "describedBy": "https://data.wa.gov/api/views/f6w7-q2d2/columns.xml",
             "describedByType": "application/xml",
             "downloadURL": "https://data.wa.gov/api/views/f6w7-q2d2/rows.xml?accessType=DOWNLOAD",
-            "mediaType": "application/xml"
+            "mediaType": "application/xml",
+            "description": "XML resource for electric and hybrid vehicles in WA",
+            "title": "Electric and Hybrid Vehicles XML file"
         }
     ],
     "identifier": "https://data.wa.gov/api/views/f6w7-q2d2",

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -183,28 +183,28 @@ class TestCKANLoad:
         """
         expected_resources = [
             {
+                "description": "CSV resource for battery electric vehicles in WA",
+                "name": "Battery Electric Vehicle CSV File",
                 "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD",
                 "mimetype": "text/csv",
-                "no_real_name": True,
-                "name": "Web Resource",
             },
             {
+                "description": "RDF resource for plug-in hybrid electric vehicles in WA",
+                "name": "Plug-in Hybrid Electric Vehicles RDF file",
                 "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.rdf?accessType=DOWNLOAD",
                 "mimetype": "application/rdf+xml",
-                "no_real_name": True,
-                "name": "Web Resource",
             },
             {
+                "description": "JSON resource for BEVs & PHEVs in WA",
+                "name": "BEVs & PHEVs JSON file",
                 "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.json?accessType=DOWNLOAD",
                 "mimetype": "application/json",
-                "no_real_name": True,
-                "name": "Web Resource",
             },
             {
+                "description": "XML resource for electric and hybrid vehicles in WA",
+                "name": "Electric and Hybrid Vehicles XML file",
                 "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.xml?accessType=DOWNLOAD",
                 "mimetype": "application/xml",
-                "no_real_name": True,
-                "name": "Web Resource",
             },
         ]
         resources = create_ckan_resources(dol_distribution_json)


### PR DESCRIPTION
# Pull Request

Related to [#5141](https://github.com/GSA/data.gov/issues/5141)

## About
- bring in resource name and description values
- fix bug in extra creation

[catalog-next dataset](https://catalog-next-dev-admin-datagov.app.cloud.gov/dataset/u-s-hourly-precipitation-data)
[prod dataset](https://catalog.data.gov/dataset/u-s-hourly-precipitation-data2)

## PR TASKS

- [ ] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
