### PR TITLE
only get json when expected

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -627,9 +627,9 @@ class Record:
 
         mdt_url = os.getenv("MDTRANSLATOR_URL")
         resp = requests.post(mdt_url, json=data)
-        data = resp.json()
 
         if resp.status_code == 422:
+            data = resp.json()
             self.mdt_msgs = prepare_transform_msg(data)
             raise TransformationException(
                 f"record failed to transform: {self.mdt_msgs}",
@@ -637,11 +637,18 @@ class Record:
                 self.id,
             )
 
-        if 200 <= resp.status_code < 300:
+        elif 200 <= resp.status_code < 300:
+            data = resp.json()
             logger.info(
                 f"successfully transformed record: {self.identifier} db id: {self.id}"
             )
             self.transformed_data = json.loads(data["writerOutput"])
+        else:
+            raise TransformationException(
+                f"record failed to transform because of unexpected status code: {resp.status_code}",
+                self.harvest_source.job_id,
+                self.id,
+            )
 
     def validate(self) -> None:
         logger.info(f"validating {self.identifier}")


### PR DESCRIPTION
# Pull Request

related to [5176](https://github.com/GSA/data.gov/issues/5176) 
@btylerburton this fixes the issue with the job throwing an exception on record transformation

## About

mdtranslator crashed because of out-of-memory. this obviously caused an issue with transformation in the harvest runner which led me to finding out about this.  we should only be calling `.json()` if the response was okay.

## PR TASKS

- [ ] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
