### PR TITLE
remove-sort-param

### DIFF
--- a/scripts/eval-harvest-state/compare_datasets_count.py
+++ b/scripts/eval-harvest-state/compare_datasets_count.py
@@ -56,7 +56,6 @@ def fetch_all_organizations(base_url):
     while True:
         url = f"{base_url}/api/3/action/organization_list"
         params = {
-            'sort': 'package_count',
             'include_dataset_count': 'true',
             'all_fields': 'true',
             'limit': limit,


### PR DESCRIPTION
Removing the sort=package_count parameter ensures that organizations with zero datasets are included in the API response.