### PR TITLE
Refactors db_session creation

### DIFF
--- a/database/interface.py
+++ b/database/interface.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from datetime import datetime, timezone
 from functools import wraps
 
@@ -21,7 +20,6 @@ from .models import (
     db,
 )
 
-DATABASE_URI = os.getenv("DATABASE_URI")
 PAGINATE_ENTRIES_PER_PAGE = 10
 PAGINATE_START_PAGE = 0
 
@@ -81,11 +79,14 @@ def count_wrapper(fn):
 
 
 class HarvesterDBInterface:
-
     def __init__(self, session=None):
-        # Flask-SQLAlchemy provides a request-scoped database session
-        # so use it here
-        self.db = db.session
+        if session:
+            ## For the Harvest Runner we create our own session and pass it in
+            self.db = session
+        else:
+            # Flask-SQLAlchemy provides a request-scoped database session
+            # so use it here
+            self.db = db.session
 
     @staticmethod
     def _to_dict(obj):

--- a/database/interface.py
+++ b/database/interface.py
@@ -80,7 +80,7 @@ def count_wrapper(fn):
 
 class HarvesterDBInterface:
     def __init__(self, session=None):
-        if session:
+        if session is not None:
             ## For the Harvest Runner we create our own session and pass it in
             self.db = session
         else:

--- a/harvester/__init__.py
+++ b/harvester/__init__.py
@@ -5,12 +5,27 @@ from dotenv import load_dotenv
 
 from config.logger_config import LOGGING_CONFIG
 from database.interface import HarvesterDBInterface
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 load_dotenv()
 
 logging.config.dictConfig(LOGGING_CONFIG)
 
-db_interface = HarvesterDBInterface()
+DATABASE_URI = os.getenv("DATABASE_URI")
+
+# create a scopedsession for our harvest runner
+engine = create_engine(
+    DATABASE_URI,
+    pool_size=10,
+    max_overflow=20,
+    pool_timeout=60,
+    pool_recycle=1800,
+)
+session_factory = sessionmaker(bind=engine, autoflush=True)
+session = scoped_session(session_factory)
+
+db_interface = HarvesterDBInterface(session=session)
 
 SMTP_CONFIG = {
     "server": os.getenv("HARVEST_SMTP_SERVER"),

--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -82,7 +82,8 @@ class LoadManager:
             return f"No task with job_id: {job_id}"
 
         if job_task[0][1] != "RUNNING":
-            return f"Harvest job {job_id} is not running"
+            updated_job = interface.update_harvest_job(job_id, {"status": "complete"})
+            return f"Task for job {job_id} is not running. Job marked as complete."
 
         self.handler.stop_task(job_task[0][0])
 

--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -83,7 +83,9 @@ class LoadManager:
 
         if job_task[0][1] != "RUNNING":
             updated_job = interface.update_harvest_job(job_id, {"status": "complete"})
-            return f"Task for job {job_id} is not running. Job marked as complete."
+            return (
+                f"Task for job {updated_job.id} is not running. Job marked as complete."
+            )
 
         self.handler.stop_task(job_task[0][0])
 


### PR DESCRIPTION
- Refactors db_session creation so harvest process creates its own engine outside flask context;
- updates stuck jobs when cancelled even when they're not currently running; 
- marks failed translations as invalid and gates them from creating secondary validation errors; 
- adds new full flow test for WAF collection

# Pull Request

Related to https://github.com/GSA/data.gov/issues/5193

## About

<!-- any pertinent notes -->

## PR TASKS

- [X] Code well documented
- [X] Tests written, run and passed
- [X] Files linted
