### PR TITLE
Use internal routes for MDTranslator

### DIFF
--- a/vars.development.yml
+++ b/vars.development.yml
@@ -10,7 +10,7 @@ CKAN_API_URL: https://catalog-next-dev-admin-datagov.app.cloud.gov
 
 HARVEST_RUNNER_APP_GUID: 40dba74b-4916-447e-914b-77525de5e608
 
-MDTRANSLATOR_URL: https://mdtranslator.app.cloud.gov/translates
+MDTRANSLATOR_URL: http://mdtranslator-development.apps.internal:8080/translates
 
 # Login.gov
 CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:datagov-dev-harvest-admin

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -4,6 +4,7 @@ admin_instances: 2
 admin_memory_quota: 3G
 CF_API_URL: https://api.fr.cloud.gov
 CKAN_API_URL: https://catalog-stage.data.gov
+MDTRANSLATOR_URL: http://mdtranslator-staging.apps.internal:8080/translates
 HARVEST_RUNNER_APP_GUID: null
 CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:datagov-staging-harvest-admin
 ISSUER: https://idp.int.identitysandbox.gov


### PR DESCRIPTION
# Pull Request

#5179 asks for an access-control solution for our MDTranslator service. I set up an internal route `mdtranslator-development.apps.internal` for MDTranslator and removed the old `mdtranslator.app.cloud.gov` route. Then, adjusting the `MDTRANSLATOR_URL` environment variable is all that is needed to use the new route.

## About

The staging version of this is aspirational: that route does not exist and nor does the application. When we start deploying in new environments, we have to do the equivalent of

```bash
$ cf map-route mdtranslator apps.internal --hostname mdtranslator-staging
$  cf add-network-policy datagov-harvest-admin mdtranslator
$  cf add-network-policy datagov-harvest-runner mdtranslator
```

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted