### PR TITLE
update mediatype processing

### DIFF
--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -762,7 +762,7 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
                 continue
             resource["url"] = dist[url_key]
             # set mimetype if provided or discover it
-            if "mimetype" in dist:
+            if "mediaType" in dist:
                 resource["mimetype"] = dist["mediaType"]
             else:
                 resource["mimetype"] = guess_resource_format(dist[url_key])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -726,7 +726,29 @@ def iso19115_2_transform() -> dict:
         },
         "identifier": "gov.noaa.nmfs.inport:47598",
         "accessLevel": "non-public",
-        "distribution": [],
+        "distribution": [
+            {
+                "@type": "dcat:Distribution",
+                "description": "NOAA Data Management Plan for this record on InPort.",
+                "downloadURL": "https://www.fisheries.noaa.gov/inportserve/waf/noaa/nos/ocm/dmp/pdf/47598.pdf",
+                "title": "NOAA Data Management Plan (DMP)",
+                "mediaType": "placeholder/value",
+            },
+            {
+                "@type": "dcat:Distribution",
+                "description": "Global Change Master Directory (GCMD). 2024. GCMD Keywords, Version 19. Greenbelt, MD: Earth Science Data and Information System, Earth Science Projects Division, Goddard Space Flight Center (GSFC), National Aeronautics and Space Administration (NASA). URL (GCMD Keyword Forum Page): https://forum.earthdata.nasa.gov/app.php/tag/GCMD+Keywords",
+                "downloadURL": "https://forum.earthdata.nasa.gov/app.php/tag/GCMD%2BKeywords",
+                "title": "GCMD Keyword Forum Page",
+                "mediaType": "placeholder/value",
+            },
+            {
+                "@type": "dcat:Distribution",
+                "description": "View the complete metadata record on InPort for more information about this dataset.",
+                "downloadURL": "https://www.fisheries.noaa.gov/inport/item/47598",
+                "title": "Full Metadata Record",
+                "mediaType": "placeholder/value",
+            },
+        ],
         "license": "https://creativecommons.org/publicdomain/zero/1.0/",
         "rights": "otherRestrictions, unclassified",
         "spatial": "-70.482,41.544,-70.555,41.64",
@@ -808,6 +830,11 @@ def iso19115_1_transform() -> dict:
         "publisher": {
             "@type": "org:Organization",
             "name": "U.S. EPA Office of Environmental Information (OEI) - Office of Information Analysis and Access (OIAA)",
+        },
+        "contactPoint": {
+            "@type": "vcard:Contact",
+            "fn": "U.S. Environmental Protection Agency, Office of Research and Development-Sustainable and Healthy Communities Research Program, EnviroAtlas",
+            "hasEmail": "mailto:EnviroAtlas@epa.gov",
         },
         "identifier": "{4c6928d8-6ac2-4909-8b3d-a29e2805ce2d}",
         "accessLevel": "non-public",

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -82,6 +82,10 @@ class TestValidateDataset:
         iso2_test_record = harvest_source.external_records[iso2_name]
         iso2_test_record.transform()
 
+        # we increased our contactPoint options in mdtranslator
+        # so this actually gets pulled so deleting it here
+        del iso2_test_record.transformed_data["contactPoint"]
+
         # validator throws an exception when the dataset is invalid
         with pytest.raises(ValidationException) as e:
             iso2_test_record.validate()

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -131,13 +131,12 @@ class TestHarvestJobFullFlow:
         # assert job rollup
         assert harvest_job.status == "complete"
         assert harvest_job.records_total == 3
-        assert len(harvest_job.record_errors) == 2
-        assert harvest_job.records_errored == 2
+        assert len(harvest_job.record_errors) == 1
+        assert harvest_job.records_errored == 1
 
         # assert error insertion order
         errors = interface.get_harvest_record_errors_by_job(job_id)
         assert errors[0][0].type == "TransformationException"
-        assert errors[1][0].type == "ValidationException"
 
         # assert harvest_record_id & type match
         for error in errors:


### PR DESCRIPTION
- pull mediatype instead of mimetype for dcatus to ckan package
- update tests impacted by transformation app changes

# Pull Request

Related to [#5198](https://github.com/GSA/data.gov/issues/5198)

## About
- mimetype doesn't exist in dcatus distributions so need to replace it with "mediaType"
- we pull distributions & contactPoint from more places in the ISO doc so need to update fixtures. this also impacted the number of record errors in `test_harvest_job_full_flow.py`

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
