### PR TITLE
make all ISO records accessLevel public

### DIFF
--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -581,6 +581,9 @@ def create_ckan_extras(
     for extra in extras:
         if extra not in metadata:
             continue
+        # setting all ISO records to be public
+        if extra == "accessLevel" and harvest_source.schema_type.startswith("iso"):
+            metadata[extra] = "public"
         data = {"key": extra, "value": None}
         val = metadata[extra]
         if extra == "publisher":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,11 @@ def source_data_waf_iso19115_2(organization_data: dict) -> dict:
 
 
 @pytest.fixture
+def source_data_iso19115_2_orm(source_data_waf_iso19115_2: dict) -> HarvestSource:
+    return HarvestSource(**source_data_waf_iso19115_2)
+
+
+@pytest.fixture
 def source_data_dcatus_invalid(organization_data: dict) -> dict:
     return {
         "id": "2bfcb047-70dc-435a-a46c-4dec5df7532d",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -261,6 +261,18 @@ class TestCKANUtils:
             {"key": "programCode", "value": "015:001"},
         ]
 
+    def test_create_iso_ckan_extras(
+        self, iso19115_2_transform, source_data_iso19115_2_orm
+    ):
+        iso19115_2_transform["accessLevel"] = "non-public"
+
+        extras = create_ckan_extras(
+            iso19115_2_transform, source_data_iso19115_2_orm, "1234"
+        )
+
+        access_level = list(filter(lambda e: e["key"] == "accessLevel", extras))[0]
+        assert access_level["value"] == "public"
+
 
 # Point example
 # "{\"type\": \"Point\", \"coordinates\": [-87.08258, 24.9579]}"


### PR DESCRIPTION
# Pull Request

Related to [#5233](https://github.com/GSA/data.gov/issues/5233)

## About
- accessLevel as an extra in a ckan package determines whether it's public or not. all of our iso records are already public. see [comment](https://github.com/GSA/data.gov/issues/5231#issuecomment-2859971320)

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [ ] Files linted
