### PR TITLE
Turn max-tasks down to 5 to reduce memory pressure

### DIFF
--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -11,7 +11,7 @@ CF_SERVICE_USER = os.getenv("CF_SERVICE_USER")
 CF_SERVICE_AUTH = os.getenv("CF_SERVICE_AUTH")
 HARVEST_RUNNER_APP_GUID = os.getenv("HARVEST_RUNNER_APP_GUID")
 
-MAX_TASKS_COUNT = 25
+MAX_TASKS_COUNT = 5
 
 interface = HarvesterDBInterface()
 


### PR DESCRIPTION
# Pull Request

Now that we're harvesting more, we need to be more conservative on how many tasks we let the runners start at once to save on memory.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
