### PR TITLE
Fix task creation argument order

### DIFF
--- a/harvester/lib/cf_handler.py
+++ b/harvester/lib/cf_handler.py
@@ -21,9 +21,15 @@ class CFHandler:
 
     def start_task(self, app_guuid, command, task_id):
         self.setup()
-        TASK_MEMORY = os.getenv("HARVEST_RUNNER_TASK_MEM", "4096")
-        TASK_DISK = os.getenv("HARVEST_RUNNER_TASK_DISK", "1536")
-        return self.task_mgr.create(app_guuid, command, task_id, TASK_MEMORY, TASK_DISK)
+        TASK_MEMORY = os.getenv("HARVEST_RUNNER_TASK_MEM", "1536")
+        TASK_DISK = os.getenv("HARVEST_RUNNER_TASK_DISK", "4096")
+        return self.task_mgr.create(
+            app_guuid,
+            command=command,
+            name=task_id,
+            memory_in_mb=TASK_MEMORY,
+            disk_in_mb=TASK_DISK,
+        )
 
     def stop_task(self, task_id):
         self.setup()

--- a/tests/integration/app/test_load_manager.py
+++ b/tests/integration/app/test_load_manager.py
@@ -69,11 +69,13 @@ class TestLoadManager:
         assert start_task_mock.call_count == 1
         ## assert command
         assert (
-            start_task_mock.call_args[0][1]
+            start_task_mock.call_args.kwargs["command"]
             == f"python harvester/harvest.py {job.id} harvest"  # using default job type
         )
         ## assert task_id
-        assert start_task_mock.call_args[0][2] == f"harvest-job-{job.id}-harvest"
+        assert (
+            start_task_mock.call_args.kwargs["name"] == f"harvest-job-{job.id}-harvest"
+        )
         assert job.status == "in_progress"
 
         # assert schedule_next_job ops
@@ -247,8 +249,8 @@ class TestLoadManager:
         load_manager = LoadManager()
         load_manager.trigger_manual_job(source_data_dcatus["id"])
         start_task_mock = CFCMock.return_value.v3.tasks.create
-        assert start_task_mock.call_args[0][3] == "4096"
-        assert start_task_mock.call_args[0][4] == "1536"
+        assert start_task_mock.call_args.kwargs["memory_in_mb"] == "1536"
+        assert start_task_mock.call_args.kwargs["disk_in_mb"] == "4096"
 
         # clear out in progress jobs
         source_id = source_data_dcatus["id"]
@@ -263,8 +265,8 @@ class TestLoadManager:
 
         load_manager.trigger_manual_job(source_data_dcatus["id"])
         start_task_mock = CFCMock.return_value.v3.tasks.create
-        assert start_task_mock.call_args[0][3] == "1234"
-        assert start_task_mock.call_args[0][4] == "1234"
+        assert start_task_mock.call_args.kwargs["memory_in_mb"] == "1234"
+        assert start_task_mock.call_args.kwargs["disk_in_mb"] == "1234"
 
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
     def test_trigger_cancel_job(


### PR DESCRIPTION
# Pull Request

We were using positional arguments to call the CF tasks `create` method and we mixed up the order so that the disk quota was being used for the memory quota and vice-versa. This switches to using keyword arguments to fix it, and fixes the test mock assertions to match.

## About

This doesn't change the limits that were being used, it uses the same numbers that were actually being given as limits in development. 

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
