### PR TITLE
Dont fail the test job if coverage upload fails

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Report test coverage
         uses: MishaKav/pytest-coverage-comment@main
+        continue-on-error: true
         with:
           multiple-files: |
             Unit tests, pytest-coverage-unit.txt, pytest-unit.xml


### PR DESCRIPTION
# Pull Request

By design, Dependabot doesn't have a Github token with write-access so it can't upload test coverage results on its PRs. We don't need to fail the job just because we can't upload the test results. This changes the workflow so that success on the coverage upload is not required.


## PR TASKS

- [ ] Code well documented
- [ ] Files linted
