### PR TITLE
Adds the `landingPage` to the resources from the DCATUS

### DIFF
--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -759,6 +759,11 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
     if "distribution" not in metadata or metadata["distribution"] is None:
         return output
 
+    if "landingPage" in metadata:
+        metadata["distribution"].append(
+            {"accessURL": metadata["landingPage"], "mediaType": "text/html"}
+        )
+
     for dist in metadata["distribution"]:
         resource = {}
         if "description" in dist:

--- a/tests/badges/integration/coverage.svg
+++ b/tests/badges/integration/coverage.svg
@@ -5,7 +5,7 @@
     width="92.5"
     height="20"
     role="img"
-    aria-label="coverage: 85%"
+    aria-label="coverage: 86%"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>coverage: 85%</title>
+    <title>coverage: 86%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(60.0 0)">
             <rect width="32.5" fill="#a4a61d"/>
-            <text x="16.25" y="10.0" class="shadow">85%</text>
-            <text x="16.25" y="10.0">85%</text>
+            <text x="16.25" y="10.0" class="shadow">86%</text>
+            <text x="16.25" y="10.0">86%</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/integration/tests.svg
+++ b/tests/badges/integration/tests.svg
@@ -5,7 +5,7 @@
     width="70.0"
     height="20"
     role="img"
-    aria-label="tests: 104"
+    aria-label="tests: 106"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 104</title>
+    <title>tests: 106</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="32.5" fill="#4c1"/>
-            <text x="16.25" y="10.0" class="shadow">104</text>
-            <text x="16.25" y="10.0">104</text>
+            <text x="16.25" y="10.0" class="shadow">106</text>
+            <text x="16.25" y="10.0">106</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/unit/tests.svg
+++ b/tests/badges/unit/tests.svg
@@ -5,7 +5,7 @@
     width="62.5"
     height="20"
     role="img"
-    aria-label="tests: 55"
+    aria-label="tests: 56"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 55</title>
+    <title>tests: 56</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="25.0" fill="#4c1"/>
-            <text x="12.5" y="10.0" class="shadow">55</text>
-            <text x="12.5" y="10.0">55</text>
+            <text x="12.5" y="10.0" class="shadow">56</text>
+            <text x="12.5" y="10.0">56</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/integration/harvest/test_ckan_load.py
+++ b/tests/integration/harvest/test_ckan_load.py
@@ -219,6 +219,12 @@ class TestCKANLoad:
                 "url": "https://data.wa.gov/api/views/f6w7-q2d2/rows.xml?accessType=DOWNLOAD",
                 "mimetype": "application/xml",
             },
+            {
+                "url": "https://data.wa.gov/d/f6w7-q2d2",
+                "mimetype": "text/html",
+                "no_real_name": True,
+                "name": "Web Resource",
+            },
         ]
         resources = create_ckan_resources(dol_distribution_json)
         assert resources == expected_resources


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5243

## About

- checks if `landingPage` exists in the metadata (typically in DCATUS) and if it exist adds it as a resource.
- Additional change: if adding landing page the `mimetype` is assumed to be `text/html`

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
