### PR TITLE
Use the SMTP service again

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -31,7 +31,7 @@ applications:
     services:
       - ((app_name))-db
       - ((app_name))-secrets
-      # - ((app_name))-smtp
+      - ((app_name))-smtp
     instances: 0
     health-check-type: process
     no-route: true


### PR DESCRIPTION
# Pull Request

This adds back the SMTP service that the harvest runner uses to send email about harvest success or error.

## About

The actual `datagov-harvest-smtp` service in `development` has been created manually

