### PR TITLE
Create secrets service too if it doesn't exist

### DIFF
--- a/create_cloudgov_services.sh
+++ b/create_cloudgov_services.sh
@@ -18,3 +18,6 @@ fi
 
 # create email service
 cf service "${app_name}-smtp"  > /dev/null 2>&1 || cf create-service datagov-smtp base "${app_name}-smtp" -b "ssb-smtp-gsa-datagov-${space}"
+
+# create the secrets service if necessary
+cf service "${app_name}-secrets"  > /dev/null 2>&1 || cf cups "${app_name}-secrets"


### PR DESCRIPTION
# Pull Request

One more deployment fix, another service needed to be created.

## About

This creates the secrets service, but does not add any of the secrets to it. Manually running `cf uups -p ...` will still be required.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
