### PR TITLE
Create services should wait while the DB is being created

### DIFF
--- a/create_cloudgov_services.sh
+++ b/create_cloudgov_services.sh
@@ -9,15 +9,15 @@ app_name=${1:-datagov-harvest}
 # Get the current space and trim leading whitespace
 space=$(cf target | grep space | cut -d : -f 2 | xargs)
 
-# Production and staging should use bigger DB instances
-if [ "$space" = "prod" ] || [ "$space" = "staging" ]; then
-    cf service "${app_name}-db"    > /dev/null 2>&1 || cf create-service aws-rds xlarge-gp-psql "${app_name}-db" --wait&
-else
-    cf service "${app_name}-db"    > /dev/null 2>&1 || cf create-service aws-rds medium-gp-psql "${app_name}-db" --wait&
-fi
-
 # create email service
 cf service "${app_name}-smtp"  > /dev/null 2>&1 || cf create-service datagov-smtp base "${app_name}-smtp" -b "ssb-smtp-gsa-datagov-${space}"
 
 # create the secrets service if necessary
 cf service "${app_name}-secrets"  > /dev/null 2>&1 || cf cups "${app_name}-secrets"
+
+# Production and staging should use bigger DB instances
+if [ "$space" = "prod" ] || [ "$space" = "staging" ]; then
+    cf service "${app_name}-db"    > /dev/null 2>&1 || cf create-service --wait aws-rds xlarge-gp-psql "${app_name}-db"
+else
+    cf service "${app_name}-db"    > /dev/null 2>&1 || cf create-service --wait aws-rds medium-gp-psql "${app_name}-db"
+fi


### PR DESCRIPTION
# Pull Request

In pairing we discovered that our development deploy from scratch failed because the services had not been created when the app tried to start. This makes the database service creation happen last and wait until it succeeds. All of the other service creations should succeed by then too.