### PR TITLE
use gevent instead of gthread

### DIFF
--- a/harvest-admin-start.sh
+++ b/harvest-admin-start.sh
@@ -9,4 +9,4 @@ if [ "$CF_INSTANCE_INDEX" = "0" -o -z "$CF_INSTANCE_INDEX" ]; then
     flask db upgrade 
 fi
 
-exec newrelic-admin run-program gunicorn "wsgi:application" --config "$DIR/gunicorn.conf.py" -b "0.0.0.0:$PORT" --chdir $DIR --timeout 120 --worker-class gthread --workers 3 --forwarded-allow-ips='*' --preload
+exec newrelic-admin run-program gunicorn "wsgi:application" --config "$DIR/gunicorn.conf.py" -b "0.0.0.0:$PORT" --chdir $DIR --timeout 120 --worker-class gevent --workers 3 --forwarded-allow-ips='*' --preload


### PR DESCRIPTION
# Pull Request

In GSA/data.gov#5279 we were seeing problems with SSL errors with our database connections. We had changed our Gunicorn workers from `gevent` to `gthread` which appears to have had a conflict with how we set up our database connections. This PR moves us back to `gevent` workers.

## About

The `gevent` workers do give warnings on startup about "late monkey-patching". This is related to running the app under NewRelic. NewRelic support says that these warnings are false positives and no problems will be caused by doing it this way <https://support.newrelic.com/s/hubtopic/aAX8W0000008aE0/seeing-monkeypatching-error-while-running-newrelicadmin-with-python-37-geven>. 

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
