### PR TITLE
Cleanup failed jobs on start

### DIFF
--- a/database/interface.py
+++ b/database/interface.py
@@ -292,10 +292,7 @@ class HarvesterDBInterface:
     def get_in_progress_jobs(self):
         """Get harvest jobs that are in progress."""
         return list(
-            self.db.query(HarvestJob)
-            .filter(
-                HarvestJob.status == "in_progress"
-            )
+            self.db.query(HarvestJob).filter(HarvestJob.status == "in_progress")
         )
 
     def get_new_harvest_jobs_in_past(self, limit=None):

--- a/database/interface.py
+++ b/database/interface.py
@@ -289,17 +289,35 @@ class HarvesterDBInterface:
         )
         return harvest_jobs
 
-    def get_new_harvest_jobs_in_past(self):
-        harvest_jobs = (
+    def get_in_progress_jobs(self):
+        """Get harvest jobs that are in progress."""
+        return list(
+            self.db.query(HarvestJob)
+            .filter(
+                HarvestJob.status == "in_progress"
+            )
+        )
+
+    def get_new_harvest_jobs_in_past(self, limit=None):
+        """Get harvest jobs in the database that need to be run.
+
+        A job that needs to be run has status "new" and a date_created that is
+        before now. The jobs are returned in ascending order of date_created so that the
+        oldest jobs are given first.
+
+        If `limit` is given, it limits the number of returned jobs to at most that
+        number. The default is to return all the jobs.
+        """
+        return (
             self.db.query(HarvestJob)
             .filter(
                 HarvestJob.date_created < datetime.now(timezone.utc),
                 HarvestJob.status == "new",
             )
             .order_by(asc(HarvestJob.date_created))
+            .limit(limit)
             .all()
         )
-        return [job for job in harvest_jobs]
 
     def get_new_harvest_jobs_by_source_in_future(self, source_id):
         harvest_jobs = (

--- a/harvester/lib/cf_handler.py
+++ b/harvester/lib/cf_handler.py
@@ -99,7 +99,8 @@ class CFHandler:
         return [
             task
             for task in tasks
-            if task["state"] == "RUNNING" and task["name"].startswith("harvest-job-")
+            if task.get("state", "") == "RUNNING"
+            and task.get("name", "").startswith("harvest-job-")
         ]
 
     def num_running_app_tasks(self, app_guuid=None):

--- a/harvester/lib/cf_handler.py
+++ b/harvester/lib/cf_handler.py
@@ -2,6 +2,7 @@ import functools
 import json
 import logging
 import os
+import re
 
 from cloudfoundry_client.client import CloudFoundryClient
 
@@ -77,6 +78,7 @@ class CFHandler:
     @staticmethod
     def job_ids_from_tasks(task_list):
         """Convert a list of task dicts into a list of their job ids."""
+
         def _id_from_task(task):
             name = task["name"]
             try:
@@ -85,10 +87,9 @@ class CFHandler:
                 return None
 
         id_list = [_id_from_task(task) for task in task_list]
-        return [id_ for id_ in id_list if id_ is not None ]
+        return [id_ for id_ in id_list if id_ is not None]
 
-
-    def get_running_app_tasks(self, app_guid=None):
+    def get_running_app_tasks(self, app_guuid=None):
         """Get a list of running tasks for a specified app.
 
         There are other tasks in the list that aren't our harvest jobs

--- a/harvester/lib/cf_handler.py
+++ b/harvester/lib/cf_handler.py
@@ -74,13 +74,39 @@ class CFHandler:
             self.client.v3.apps._pagination(self.client.v3.apps.get(app_guuid, "tasks"))
         )
 
+    @staticmethod
+    def job_ids_from_tasks(task_list):
+        """Convert a list of task dicts into a list of their job ids."""
+        def _id_from_task(task):
+            name = task["name"]
+            try:
+                return re.match(r"harvest-job-(.*)-\w+", name)[1]
+            except TypeError:  # no match
+                return None
+
+        id_list = [_id_from_task(task) for task in task_list]
+        return [id_ for id_ in id_list if id_ is not None ]
+
+
+    def get_running_app_tasks(self, app_guid=None):
+        """Get a list of running tasks for a specified app.
+
+        There are other tasks in the list that aren't our harvest jobs
+        so we filter those out here.
+        """
+        tasks = self.get_all_app_tasks(app_guuid)
+        return [
+            task
+            for task in tasks
+            if task["state"] == "RUNNING" and task["name"].startswith("harvest-job-")
+        ]
+
     def num_running_app_tasks(self, app_guuid=None):
         """Count how many tasks are in the running state.
 
         If app_guid is not given, it will use the current app's GUUID.
         """
-        tasks = self.get_all_app_tasks(app_guuid)
-        return sum(1 for _ in filter(lambda task: task["state"] == "RUNNING", tasks))
+        return len(self.get_running_app_tasks(app_guuid))
 
     def read_recent_app_logs(self, app_guuid=None, task_id=None):
         """Get a string of recent logs.

--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -29,11 +29,47 @@ class LoadManager:
         self.jobs = []
         self.running_tasks = []
 
-    def start(self):
-        """Runs on Flask Admin start, roughly every 15min"""
-        if os.getenv("CF_INSTANCE_INDEX") != "0":
-            logger.info("CF_INSTANCE_INDEX is not set or not equal to zero")
-            return
+    def _handle_failed_job(self, job):
+        """Handle a HarvestJob that failed.
+
+        A failed job has status in_progress in the database but there isn't a
+        task running for it. Something happened to its task but we likely
+        don't know what. Minimally, set the state to `error` and record a job
+        error that we saw this.
+
+        The next job is scheduled on job start so we shouldn't need to schedule
+        anything else and we are choosing not to retry these.
+        """
+        interface.update_harvest_job(
+            job.id,
+            {
+                "status": "error",
+                "date_finished": get_datetime(),
+            },
+        )
+        interface.add_harvest_job_error(
+            {
+                "date_created": get_datetime(),
+                "type": "FailedJobCleanup",
+                "message": "In-progress job stopped running for an unknown reason.",
+                "harvest_job_id": job.id,
+            }
+        )
+
+    def _clean_old_jobs(self):
+        """Check for in_progress jobs in the database that aren't running."""
+        in_progress_jobs = interface.get_in_progress_jobs()
+        running_tasks = self.handler.get_running_app_tasks()
+        running_task_ids = set(self.handler.job_ids_from_tasks(running_tasks))
+
+        failed_jobs = [
+            job for job in in_progress_jobs if job.id not in running_harvest_ids
+        ]
+        for job in failed_jobs:
+            self._handle_failed_job(job)
+
+    def _start_new_jobs(self):
+        """Start new jobs to be done, up to the max tasks count."""
         self.running_tasks = self.handler.num_running_app_tasks()
         if self.running_tasks >= MAX_TASKS_COUNT:
             logger.info(
@@ -43,12 +79,21 @@ class LoadManager:
         else:
             slots = MAX_TASKS_COUNT - self.running_tasks
 
-        # invoke cf_task with next job(s)
-        # then mark that job(s) as running in the DB
-        self.jobs = interface.get_new_harvest_jobs_in_past()
-        for job in self.jobs[:slots]:
+        # invoke cf_task with next jobs
+        # then mark the job as running in the DB
+        self.jobs = interface.get_new_harvest_jobs_in_past(limit=slots)
+        for job in self.jobs:
             self.start_job(job.id)
             self.schedule_next_job(job.harvest_source_id)
+
+    def start(self):
+        """Runs on Flask Admin start, roughly every 15min"""
+        if os.getenv("CF_INSTANCE_INDEX") != "0":
+            logger.debug("CF_INSTANCE_INDEX is not set or not equal to zero")
+            return
+
+        self._clean_old_jobs()
+        self._start_new_jobs()
 
     def start_job(self, job_id, job_type="harvest"):
         """

--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -60,7 +60,7 @@ class LoadManager:
         """Check for in_progress jobs in the database that aren't running."""
         in_progress_jobs = interface.get_in_progress_jobs()
         running_tasks = self.handler.get_running_app_tasks()
-        running_task_ids = set(self.handler.job_ids_from_tasks(running_tasks))
+        running_harvest_ids = set(self.handler.job_ids_from_tasks(running_tasks))
 
         failed_jobs = [
             job for job in in_progress_jobs if job.id not in running_harvest_ids

--- a/tests/integration/app/test_load_manager.py
+++ b/tests/integration/app/test_load_manager.py
@@ -100,9 +100,9 @@ class TestLoadManager:
         mock_good_cf_index,
     ):
         CFCMock.return_value.v3.apps._pagination.return_value = [
-            {"state": "RUNNING"},
-            {"state": "RUNNING"},
-            {"state": "RUNNING"},
+            {"state": "RUNNING", "name": "harvest-job-"},
+            {"state": "RUNNING", "name": "harvest-job-"},
+            {"state": "RUNNING", "name": "harvest-job-"},
         ]
 
         load_manager = LoadManager()
@@ -125,9 +125,9 @@ class TestLoadManager:
         load_manager.start()
 
         # assert logger called with correct args
-        assert logger_mock.info.call_count == 1
+        assert logger_mock.debug.call_count == 1
         assert (
-            logger_mock.info.call_args[0][0]
+            logger_mock.debug.call_args[0][0]
             == "CF_INSTANCE_INDEX is not set or not equal to zero"
         )
 

--- a/tests/unit/test_cf_tasks.py
+++ b/tests/unit/test_cf_tasks.py
@@ -21,14 +21,35 @@ class TestCFTasking:
         tasks = CFUtil.get_all_app_tasks()
         assert len(tasks) > 0
 
-    def test_get_all_running_app_tasks(self, CFClientMock, dhl_cf_task_data):
+    def test_get_running_app_tasks(self, CFClientMock):
         CFUtil = CFHandler("url", "user", "password")
         CFClientMock.return_value.v3.apps._pagination.return_value = [
-            {"state": "RUNNING"},
-            {"state": "SUCCEEDED"},
+            {"state": "RUNNING", "name": "harvest-job-"},
+            {"state": "RUNNING", "name": "cf_task_func_spec"},
+            {"state": "SUCCEEDED", "name": "harvest-job-"},
+        ]
+        running_tasks = CFUtil.get_running_app_tasks()
+        assert len(running_tasks) == 1
+
+    def test_num_running_app_tasks(self, CFClientMock):
+        CFUtil = CFHandler("url", "user", "password")
+        CFClientMock.return_value.v3.apps._pagination.return_value = [
+            {"state": "RUNNING", "name": "harvest-job-"},
+            {"state": "SUCCEEDED", "name": "harvest-job-"},
         ]
         running_tasks = CFUtil.num_running_app_tasks()
         assert running_tasks == 1
+
+    def test_job_ids_from_tasks(self, CFClientMock):
+        CFUtil = CFHandler("url", "user", "password")
+        job_ids = CFUtil.job_ids_from_tasks(
+            [
+                {"name": "harvest-job-this_id-harvest"},
+                {"name": "not-our-format-of-name-so-no-id"},
+            ]
+        )
+        assert len(job_ids) == 1
+        assert job_ids[0] == "this_id"
 
     def test_cancel_task(self, CFClientMock, dhl_cf_task_data):
         CFUtil = CFHandler("url", "user", "password")


### PR DESCRIPTION
# Pull Request

In GSA/data.gov#5264 we want our job runner to also check and make sure that there is agreement between the database's perspective on which jobs are running and the CloudFoundry system's running tasks. This PR adds code to the load_manager's startup routine to compare the `in_progress` jobs from the database with the `RUNNING` tasks in CloudFoundry and if there are any that are no longer `RUNNING`, then mark them as errors in the database.

## About

The ticket mentions trying to get good error messages for why the job might have failed, but our `get_recent_logs` doesn't appear to have very helpful information on that, so this PR just gives a generic error message in the database for every failed job that it finds. If we find that we need it in the future, we could make an enhancement request to improve that error message.

Our CF tasks use a particular `name` value `harvest-job-...-...` to identify themselves. This functionality relies on that name so some of the tests change to account for that. Also, drive-by cleanup on some of the database interface methods around jobs and tasks.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted