### PR TITLE
Improve harvester metrics page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1112,10 +1112,15 @@ def view_metrics():
             per_page=pagination.per_page,
             order_by="desc",
         )
+        failures = db.pget_harvest_job_errors(
+            facets="type = 'FailedJobCleanup'",
+            order_by="desc",
+        )
         data = {
             "htmx_vars": htmx_vars,
             "jobs": jobs,
-            "new_jobs_in_past": len(db.get_new_harvest_jobs_in_past()),
+            "new_jobs_in_past": db.get_new_harvest_jobs_in_past(),
+            "failures": failures,
             "current_time": current_time,
             "window_start": start_time,
         }

--- a/app/routes.py
+++ b/app/routes.py
@@ -1115,6 +1115,7 @@ def view_metrics():
         data = {
             "htmx_vars": htmx_vars,
             "jobs": jobs,
+            "new_jobs_in_past": len(db.get_new_harvest_jobs_in_past()),
             "current_time": current_time,
             "window_start": start_time,
         }

--- a/app/templates/components/job-table/job_table.j2
+++ b/app/templates/components/job-table/job_table.j2
@@ -1,0 +1,51 @@
+{% macro job_table(jobs, caption) -%}
+<div class="usa-table-container--scrollable" tabindex="0">
+    <table class="usa-table usa-table--striped">
+        <caption>{{ caption }}</caption>
+        <thead>
+            <tr>
+                <th scope="col">Job Id</th>
+                <th scope="col">Source Id</th>
+                <th scope="col">Status</th>
+                <th scope="col">Created</th>
+                <th scope="col">Records Added</th>
+                <th scope="col">Records Updated</th>
+                <th scope="col">Records Deleted</th>
+                <th scope="col">Records Errored</th>
+            </tr>
+        </thead>
+        <tbody id="paginated_harvest_jobs">
+            {% for job in jobs %}
+            <tr>
+                <td data-sort-value="{{ job.id }}">
+                    <a href="{{ url_for('main.view_harvest_job', job_id=job.id) }}">
+                        {{ job.id[:8] }}...
+                    </a>
+                </td>
+                <td data-sort-value="{{ job.harvest_source_id }}">
+                    <a href="{{ url_for('main.view_harvest_source', source_id=job.harvest_source_id) }}">
+                        {{ job.harvest_source_id[:8] }}...
+                    </a>
+                </td>
+                <td>
+                    <span class="usa-tag {% if job.status == 'error' %}usa-tag--error
+                                        {% elif job.status == 'in_progress' %}usa-tag--warning
+                                        {% elif job.status == 'complete' %}usa-tag--success
+                                        {% else %}usa-tag--base{% endif %}">
+                        {{ job.status }}
+                    </span>
+                </td>
+                <td>{{ job.date_created.strftime('%Y-%m-%d %H:%M:%S')
+                    }}</td>
+                <td>{{ job.records_added}}</td>
+                <td>{{ job.records_updated}}</td>
+                <td>{{ job.records_deleted}}</td>
+                <td>{{ job.records_errored}}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>
+</div>
+{% endmacro -%}
+

--- a/app/templates/metrics_dashboard.html
+++ b/app/templates/metrics_dashboard.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% import 'components/job-table/job_table.j2' as job_table %}
+
 {% block title %}
 <title>Metrics Dashboard</title>
 {% endblock %}
@@ -16,54 +18,7 @@
         {% if data.jobs %}
         {% block htmx_paginated %}
         <div id="paginated__harvest-jobs">
-            <div class="usa-table-container--scrollable" tabindex="0">
-                <table class="usa-table usa-table--striped">
-                    <caption>Recent Harvest Jobs</caption>
-                    <thead>
-                        <tr>
-                            <th scope="col">Job Id</th>
-                            <th scope="col">Source Id</th>
-                            <th scope="col">Status</th>
-                            <th scope="col">Created</th>
-                            <th scope="col">Records Added</th>
-                            <th scope="col">Records Updated</th>
-                            <th scope="col">Records Deleted</th>
-                            <th scope="col">Records Errored</th>
-                        </tr>
-                    </thead>
-                    <tbody id="paginated_harvest_jobs">
-                        {% for job in data.jobs %}
-                        <tr>
-                            <td data-sort-value="{{ job.id }}">
-                                <a href="{{ url_for('main.view_harvest_job', job_id=job.id) }}">
-                                    {{ job.id[:8] }}...
-                                </a>
-                            </td>
-                            <td data-sort-value="{{ job.harvest_source_id }}">
-                                <a href="{{ url_for('main.view_harvest_source', source_id=job.harvest_source_id) }}">
-                                    {{ job.harvest_source_id[:8] }}...
-                                </a>
-                            </td>
-                            <td>
-                                <span class="usa-tag {% if job.status == 'error' %}usa-tag--error
-                                                  {% elif job.status == 'in_progress' %}usa-tag--warning
-                                                  {% elif job.status == 'complete' %}usa-tag--success
-                                                  {% else %}usa-tag--base{% endif %}">
-                                    {{ job.status }}
-                                </span>
-                            </td>
-                            <td>{{ job.date_created.strftime('%Y-%m-%d %H:%M:%S')
-                                }}</td>
-                            <td>{{ job.records_added}}</td>
-                            <td>{{ job.records_updated}}</td>
-                            <td>{{ job.records_deleted}}</td>
-                            <td>{{ job.records_errored}}</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-                <div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>
-            </div>
+            {{ job_table.job_table(data.jobs, "Recent Harvest Jobs") }}
             {% if pagination.count > jobs|count %}
             {% include '/components/pagination/pagination.html' %}
             {% endif %}
@@ -84,7 +39,67 @@
 
 
     <section id="jobs-to-harvest">
-      <h2>Scheduled Jobs Still to Harvest: {{data.new_jobs_in_past}}</h2>
+      <h2>Scheduled Jobs Still to Harvest: {{ data.new_jobs_in_past | length }}</h2>
+
+      {% if data.new_jobs_in_past %}
+      {{ job_table.job_table(data.new_jobs_in_past, "Scheduled jobs still to harvest") }}
+      {% else %}
+        <div class="usa-alert usa-alert--info">
+            <div class="usa-alert__body">
+                <p class="usa-alert__text">
+                    No scheduled jobs still to harvest.
+                </p>
+            </div>
+        </div>
+      {% endif %}
+    </section>
+
+
+    <section id="recent-failed-jobs">
+      <h2>Recent Failed jobs</h2>
+
+        <p class="text-muted">
+            Showing jobs from {{ data.window_start.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+            to {{ data.current_time.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+        </p>
+
+      {% if data.failures %}
+      <div class="usa-table-container--scrollable" tabindex="0">
+          <table class="usa-table usa-table--striped">
+              <caption>Recent failed jobs</caption>
+              <thead>
+                  <tr>
+                      <th scope="col">Job Id</th>
+                      <th scope="col">Created</th>
+                      <th scope="col">Message</th>
+                  </tr>
+              </thead>
+              <tbody id="paginated_harvest_jobs">
+                  {% for error in data.failures %}
+                  <tr>
+                      <td data-sort-value="{{ error.harvest_job_id }}">
+                          <a href="{{ url_for('main.view_harvest_job', job_id=error.harvest_job_id) }}">
+                              {{ error.harvest_job_id[:8] }}...
+                          </a>
+                      </td>
+                      <td>{{ error.date_created.strftime('%Y-%m-%d %H:%M:%S')
+                          }}</td>
+                      <td>{{ error.message}}</td>
+                  </tr>
+                  {% endfor %}
+              </tbody>
+          </table>
+          <div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>
+      </div>
+      {% else %}
+        <div class="usa-alert usa-alert--info">
+            <div class="usa-alert__body">
+                <p class="usa-alert__text">
+                    No failed jobs from the last 24 hours.
+                </p>
+            </div>
+        </div>
+      {% endif %}
     </section>
 </div>
     {% endblock %}

--- a/app/templates/metrics_dashboard.html
+++ b/app/templates/metrics_dashboard.html
@@ -81,4 +81,10 @@
         </div>
         {% endif %}
     </div>
+
+
+    <section id="jobs-to-harvest">
+      <h2>Scheduled Jobs Still to Harvest: {{data.new_jobs_in_past}}</h2>
+    </section>
+</div>
     {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,6 @@ def dbapp(app):
         db.session.add(us)
         db.session.commit()
         yield app
-        db.drop_all()
 
 
 @pytest.fixture()
@@ -301,6 +300,11 @@ def source_data_dcatus_invalid_records(organization_data) -> dict:
 @pytest.fixture
 def job_data_dcatus(fixtures_json) -> dict:
     return fixtures_json["job"][0]
+
+
+@pytest.fixture
+def job_data_new(fixtures_json) -> dict:
+    return [job for job in fixtures_json["job"] if job["status"] == "new"][0]
 
 
 @pytest.fixture

--- a/tests/integration/app/test_metrics.py
+++ b/tests/integration/app/test_metrics.py
@@ -1,0 +1,28 @@
+"""Test our metrics page in Flask."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+
+@pytest.fixture()
+def failed_job_error(interface, organization_data, source_data_dcatus, job_data_new):
+    interface.add_organization(organization_data)
+    interface.add_harvest_source(source_data_dcatus)
+    job = interface.add_harvest_job(job_data_new)
+    error = interface.add_harvest_job_error(
+        {
+            "type": "FailedJobCleanup",
+            "harvest_job_id": job.id,
+            "date_created": datetime.now() - timedelta(hours=12),
+        }
+    )
+    yield error
+
+
+class TestMetricsPage:
+
+    def test_metrics_failed_table(self, client, failed_job_error):
+        """Test that the failed jobs table has rows."""
+        resp = client.get("/metrics/")
+        assert f'<a href="/harvest_job/{failed_job_error.harvest_job_id}">' in resp.text

--- a/tests/playwright/test_metrics.py
+++ b/tests/playwright/test_metrics.py
@@ -1,0 +1,17 @@
+import pytest
+
+from playwright.sync_api import expect
+
+
+@pytest.fixture()
+def upage(unauthed_page):
+    unauthed_page.goto("/metrics/")
+    yield unauthed_page
+
+
+class TestMetricsUnauthed:
+
+    def test_new_jobs(self, upage):
+        expect(upage.locator("#jobs-to-harvest")).to_contain_text(
+            "scheduled jobs still to harvest:", ignore_case=True
+        )

--- a/tests/playwright/test_metrics.py
+++ b/tests/playwright/test_metrics.py
@@ -1,17 +1,38 @@
+from datetime import datetime, timedelta
+
 import pytest
 
 from playwright.sync_api import expect
 
 
 @pytest.fixture()
-def upage(unauthed_page):
+def upage(
+    unauthed_page, interface, organization_data, source_data_dcatus, job_data_new
+):
+    interface.add_organization(organization_data)
+    interface.add_harvest_source(source_data_dcatus)
+    job = interface.add_harvest_job(job_data_new)
+
     unauthed_page.goto("/metrics/")
     yield unauthed_page
 
 
 class TestMetricsUnauthed:
 
-    def test_new_jobs(self, upage):
-        expect(upage.locator("#jobs-to-harvest")).to_contain_text(
-            "scheduled jobs still to harvest:", ignore_case=True
-        )
+    def test_new_jobs_exist(self, upage):
+        """has scheduled jobs table"""
+        expect(upage.locator("#jobs-to-harvest")).to_be_visible()
+
+    def test_new_jobs_table(self, upage, interface):
+        """scheduled jobs table has rows
+
+        fixture data has one new job
+        """
+        upage.goto("/metrics/")
+        jobs_section = upage.locator("#jobs-to-harvest")
+        print(jobs_section.inner_html())
+        expect(jobs_section.locator("tbody tr")).to_have_count(1)
+
+    def test_failed_jobs_exist(self, upage):
+        """has failed jobs section"""
+        expect(upage.locator("#recent-failed-jobs")).to_be_visible()

--- a/tests/playwright/test_metrics.py
+++ b/tests/playwright/test_metrics.py
@@ -1,7 +1,4 @@
-from datetime import datetime, timedelta
-
 import pytest
-
 from playwright.sync_api import expect
 
 
@@ -11,7 +8,7 @@ def upage(
 ):
     interface.add_organization(organization_data)
     interface.add_harvest_source(source_data_dcatus)
-    job = interface.add_harvest_job(job_data_new)
+    interface.add_harvest_job(job_data_new)
 
     unauthed_page.goto("/metrics/")
     yield unauthed_page


### PR DESCRIPTION
# Pull Request

In GSA/data.gov#5289 we asked for some improvements on the `/metrics` page in the Harvester web app. This PR adds two new sections to that page, one with the scheduled jobs that have not yet been harvested, and one for any jobs that have been noticed as having no CloudFoundry tasks even though they were in progress in our database.

## About

The implementation is minimal. I didn't add any pagination or filtering to the two new tables. Playwright tests were added for this page, as well as an integration test that was easier to write than a corresponding Playwright test that I couldn't get to work. A Jinja component was extracted to be re-used twice on the page, but I didn't go looking for other places to use the new component.

![Screenshot 2025-06-26 at 10 44 54 AM](https://github.com/user-attachments/assets/5232098e-8df9-4d8b-af12-b2439badcb5b)


## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
