### PR TITLE
Start scheduled jobs more frequently

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -4,7 +4,7 @@ name: 3 - Restart Apps
 on:
   workflow_dispatch:
   schedule:
-    - cron: '11/30 * * * *'
+    - cron: '11/10 * * * *'
 
 permissions:
     contents: read


### PR DESCRIPTION
# Pull Request

Our Github action was restarting the harvester app every 30 minutes. Since this is the only time we ever schedule new jobs for harvesting, it was limiting how many harvest jobs we can do in a given day. This PR makes the restarts happen every 10 minutes.

## About

The median harvest job takes 3 minutes, so at least half the time we were wasting 27 minutes in each cycle not running any harvest jobs. We still don't schedule more than `HARVEST_RUNNER_MAX_TASKS` at the same time, so doing this restart more frequently won't lead to any more tasks running at a given time.

This change is already on `develop` but scheduled workflows only run from `main`.