### PR TITLE
Fix and test showing only recent failed jobs

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1111,8 +1111,9 @@ def view_metrics():
             per_page=pagination.per_page,
             order_by="desc",
         )
+        errors_time_filter = f"harvest_job_error.date_created >= '{start_time.isoformat()}' AND harvest_job_error.date_created <= '{current_time}'"
         failures = db.pget_harvest_job_errors(
-            facets=time_filter + " AND type = 'FailedJobCleanup'",
+            facets=errors_time_filter + " AND type = 'FailedJobCleanup'",
             order_by="desc",
         )
         data = {

--- a/app/routes.py
+++ b/app/routes.py
@@ -1113,7 +1113,7 @@ def view_metrics():
             order_by="desc",
         )
         failures = db.pget_harvest_job_errors(
-            facets="type = 'FailedJobCleanup'",
+            facets=time_filter + " AND type = 'FailedJobCleanup'",
             order_by="desc",
         )
         data = {

--- a/tests/integration/app/test_metrics.py
+++ b/tests/integration/app/test_metrics.py
@@ -11,19 +11,20 @@ def failed_job_error(interface, job):
     error = interface.add_harvest_job_error(
         {
             "type": "FailedJobCleanup",
-            "harvest_job_id": new_job.id,
+            "harvest_job_id": job.id,
             "date_created": datetime.now() - timedelta(hours=12),
         }
     )
     yield error
 
+
 @pytest.fixture()
-def old_failed_job_error(interface, new_job):
+def old_failed_job_error(interface, job):
     """An error for a failed job more than 24 hours old."""
     error = interface.add_harvest_job_error(
         {
             "type": "FailedJobCleanup",
-            "harvest_job_id": new_job.id,
+            "harvest_job_id": job.id,
             "date_created": datetime.now() - timedelta(hours=25),
         }
     )
@@ -36,6 +37,11 @@ class TestMetricsPage:
         """Failed jobs table has rows."""
         resp = client.get("/metrics/")
         assert f'<a href="/harvest_job/{failed_job_error.harvest_job_id}">' in resp.text
+
+    def test_metrics_old_failed_jobs(self, client, old_failed_job_error):
+        """The failed jobs table doesn't contain old jobs."""
+        resp = client.get("/metrics/")
+        assert "No failed jobs" in resp.text
 
     def test_metrics_failed_source_name(self, client, job, failed_job_error):
         """Failed jobs table links to source by name."""

--- a/tests/integration/app/test_metrics.py
+++ b/tests/integration/app/test_metrics.py
@@ -6,15 +6,31 @@ import pytest
 
 
 @pytest.fixture()
-def failed_job_error(interface, organization_data, source_data_dcatus, job_data_new):
+def new_job(interface, organization_data, source_data_dcatus, job_data_new):
     interface.add_organization(organization_data)
     interface.add_harvest_source(source_data_dcatus)
-    job = interface.add_harvest_job(job_data_new)
+    yield interface.add_harvest_job(job_data_new)
+
+@pytest.fixture()
+def failed_job_error(interface, new_job):
+    """An error for a failed job."""
     error = interface.add_harvest_job_error(
         {
             "type": "FailedJobCleanup",
-            "harvest_job_id": job.id,
+            "harvest_job_id": new_job.id,
             "date_created": datetime.now() - timedelta(hours=12),
+        }
+    )
+    yield error
+
+@pytest.fixture()
+def old_failed_job_error(interface, new_job):
+    """An error for a failed job more than 24 hours old."""
+    error = interface.add_harvest_job_error(
+        {
+            "type": "FailedJobCleanup",
+            "harvest_job_id": new_job.id,
+            "date_created": datetime.now() - timedelta(hours=25),
         }
     )
     yield error
@@ -26,3 +42,8 @@ class TestMetricsPage:
         """Test that the failed jobs table has rows."""
         resp = client.get("/metrics/")
         assert f'<a href="/harvest_job/{failed_job_error.harvest_job_id}">' in resp.text
+
+    def test_metrics_old_failed_jobs(self, client, old_failed_job_error):
+        """The failed jobs table doesn't contain old jobs."""
+        resp = client.get("/metrics/")
+        assert "No failed jobs" in resp.text


### PR DESCRIPTION
# Pull Request

The intention was to only have the failed jobs from the last 24 hours shown on the metrics page, but if you don't test for it, it doesn't exist, and we were putting all the jobs on there instead. This PR adds the appropriate filter and a test case for the behavior.

## About

It's surprisingly easy to write fixtured app tests in Pytest without involving Playwright.

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
