### PR TITLE
Fix metrics pagination by importing inside block

### DIFF
--- a/app/templates/metrics_dashboard.html
+++ b/app/templates/metrics_dashboard.html
@@ -18,6 +18,7 @@
         {% if data.jobs %}
         {% block htmx_paginated %}
         <div id="paginated__harvest-jobs">
+            {% import 'components/job-table/job_table.j2' as job_table %}
             {{ job_table.job_table(data.jobs, "Recent Harvest Jobs") }}
             {% if pagination.count > jobs|count %}
             {% include '/components/pagination/pagination.html' %}


### PR DESCRIPTION
# Pull Request

I made a bug on the metrics page with pagination by using a Jinja macro inside of the block that our HTMX pagination code renders. Rendering just the block fails because the macro hasn't been imported there. This repeats the import inside the block so that the HTMX call can succeed.

## About

The template fragment rendering extension we use for HTMX means that we have to keep track of these imports manually. If we use more refactoring of Jinja macros, we might see more bugs like this.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
