### PR TITLE
reduce bulky exception messages

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -47,6 +47,7 @@ from harvester.utils.general_utils import (
     prepare_transform_msg,
     sort_dataset,
     traverse_waf,
+    truncate_validation_message,
 )
 
 # requests data
@@ -784,11 +785,10 @@ class Record:
             self.harvest_source.reporter.update("validated")
         except Exception as e:
             self.status = "error"
-            self.validation_msg = str(e.message)
             self.valid = False
             self.harvest_source.reporter.update("errored")
             raise ValidationException(
-                repr(e),
+                truncate_validation_message(e),
                 self.harvest_source.job_id,
                 self.id,
             )
@@ -804,9 +804,8 @@ class Record:
             SynchronizeException,
             CKANDownException,
             CKANRejectionException,
-        ) as e:
+        ):
             self.status = "error"
-            self.validation_msg = str(e)
             self.harvest_source.reporter.update("errored")
 
     def update_self_in_db(self) -> bool:

--- a/harvester/lib/cf_handler.py
+++ b/harvester/lib/cf_handler.py
@@ -42,7 +42,7 @@ class CFHandler:
     def start_task(self, command, task_id):
         """Start a task on the currently running app's GUUID."""
         self.setup()
-        TASK_MEMORY = os.getenv("HARVEST_RUNNER_TASK_MEM", "1536")
+        TASK_MEMORY = os.getenv("HARVEST_RUNNER_TASK_MEM", "2056")
         TASK_DISK = os.getenv("HARVEST_RUNNER_TASK_DISK", "4096")
         return self.task_mgr.create(
             self._app_guuid(),

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -101,10 +101,7 @@ class CKANSyncTool:
             record.status = "error"
             if 400 <= e.response.status_code < 500:
                 raise CKANRejectionException(
-                    (
-                        f"CKAN rejected {record.action} for "
-                        f"{record.identifier} :: {repr(e)}"
-                    ),
+                    (f"CKAN rejected {record.action} for {record.identifier}"),
                     record.harvest_source.job_id,
                     record.id,
                 )
@@ -112,15 +109,15 @@ class CKANSyncTool:
                 raise CKANDownException(
                     (
                         f"CKAN is down or unreachable for {record.action} for "
-                        f"{record.identifier} :: {repr(e)}"
+                        f"{record.identifier}"
                     ),
                     record.harvest_source.job_id,
                     record.id,
                 )
-        except Exception as e:
+        except:
             record.status = "error"
             raise SynchronizeException(
-                f"failed to {record.action} for {record.identifier} :: {repr(e)}",
+                f"failed to {record.action} for {record.identifier}",
                 record.harvest_source.job_id,
                 record.id,
             )

--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -21,6 +21,28 @@ logger = logging.getLogger()
 FREQUENCY_ENUM = {"daily": 1, "weekly": 7, "biweekly": 14, "monthly": 30}
 
 
+def truncate_validation_message(e: Exception) -> str:
+    """
+    truncates the dcatus validation message to 150 characters using
+    " ...[truncated]... " as the substituted value within the
+    message.
+    """
+    msg = e.message
+    # limit the message size to be 150 characters
+    if len(msg) > 150:
+        msg = msg[:100] + " ...[truncated]... " + msg[-50:]
+
+    elem = ""
+    try:
+        if e.schema_path[0] == "properties":
+            elem = e.schema_path[1]
+            elem = "'" + elem + "':"
+    except Exception:
+        pass
+
+    return elem + msg
+
+
 def prepare_transform_msg(transform_data):
     # ruff: noqa: E731
     mask_info = lambda s: "WARNING" in s or "ERROR" in s

--- a/tests/integration/app/test_load_manager.py
+++ b/tests/integration/app/test_load_manager.py
@@ -316,7 +316,7 @@ class TestLoadManager:
         load_manager = LoadManager()
         load_manager.trigger_manual_job(source_data_dcatus["id"])
         start_task_mock = CFCMock.return_value.v3.tasks.create
-        assert start_task_mock.call_args.kwargs["memory_in_mb"] == "1536"
+        assert start_task_mock.call_args.kwargs["memory_in_mb"] == "2056"
         assert start_task_mock.call_args.kwargs["disk_in_mb"] == "4096"
 
         # clear out in progress jobs

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -70,9 +70,13 @@ class TestValidateDataset:
 
         # omitting the entire message for brevity
         # see the fixture for more details
-        assert e.value.msg.startswith(
-            "<ValidationError: '\"<p align=\\'center\\'"
-        ) and e.value.msg.endswith("is not valid under any of the given schemas'>")
+        expected = (
+            "'license':\"<p align='center' style='margin-top: 0px; "
+            "margin-bottom: 1.55rem; font-family: &quot;Avenir Next W0 "
+            '...[truncated]... .</p>" is not valid under any of the given schemas'
+        )
+
+        assert e.value.msg == expected
         assert test_record.valid is False
 
     def test_valid_transformed_iso(
@@ -123,7 +127,4 @@ class TestValidateDataset:
         # validator throws an exception when the dataset is invalid
         with pytest.raises(ValidationException) as e:
             test_iso_2_record.validate()
-        assert (
-            e.value.msg
-            == "<ValidationError: \"'contactPoint' is a required property\">"
-        )
+        assert e.value.msg == "'contactPoint' is a required property"


### PR DESCRIPTION
- truncate validation message & add test
- increase task memory
- remove full object represention from ckan responses
- fix tests

# Pull Request

Related to [5287](https://github.com/GSA/data.gov/issues/5287)

## About
- these changes are intended to reduce the size of bulk exceptions which can contribute to increased memory usage of datagov-harvest tasks. 

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
