### PR TITLE
Use the ORM to replace some IDs with names

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -727,7 +727,7 @@ def view_harvest_source(source_id: str):
         }
         source = db.get_harvest_source(source_id)
         data = {
-            "source": db._to_dict(source),
+            "source": source,
             "summary_data": summary_data,
             "jobs": jobs,
             "chart_data": chart_data,
@@ -903,13 +903,12 @@ def view_harvest_job(job_id=None):
         else:
             data = {
                 "job": job,
-                "job_dict": db._to_dict(job) if job else {},
                 "record_errors": record_errors_dict,
                 "htmx_vars": htmx_vars,
             }
             if job and job.status == "in_progress":
                 data["percent_complete"] = process_job_complete_percentage(
-                    data["job_dict"]
+                    job.to_dict()
                 )
 
             return render_template(

--- a/app/templates/components/job-table/job_table.j2
+++ b/app/templates/components/job-table/job_table.j2
@@ -5,7 +5,7 @@
         <thead>
             <tr>
                 <th scope="col">Job Id</th>
-                <th scope="col">Source Id</th>
+                <th scope="col">Source</th>
                 <th scope="col">Status</th>
                 <th scope="col">Created</th>
                 <th scope="col">Records Added</th>
@@ -22,9 +22,9 @@
                         {{ job.id[:8] }}...
                     </a>
                 </td>
-                <td data-sort-value="{{ job.harvest_source_id }}">
-                    <a href="{{ url_for('main.view_harvest_source', source_id=job.harvest_source_id) }}">
-                        {{ job.harvest_source_id[:8] }}...
+                <td data-sort-value="{{ job.source.name }}">
+                    <a href="{{ url_for('main.view_harvest_source', source_id=job.source.id) }}">
+                        {{ job.source.name }}
                     </a>
                 </td>
                 <td>

--- a/app/templates/metrics_dashboard.html
+++ b/app/templates/metrics_dashboard.html
@@ -70,6 +70,7 @@
               <thead>
                   <tr>
                       <th scope="col">Job Id</th>
+                      <th scope="col">Source</th>
                       <th scope="col">Created</th>
                       <th scope="col">Message</th>
                   </tr>
@@ -77,9 +78,14 @@
               <tbody id="paginated_harvest_jobs">
                   {% for error in data.failures %}
                   <tr>
-                      <td data-sort-value="{{ error.harvest_job_id }}">
-                          <a href="{{ url_for('main.view_harvest_job', job_id=error.harvest_job_id) }}">
-                              {{ error.harvest_job_id[:8] }}...
+                      <td data-sort-value="{{ error.job.id }}">
+                          <a href="{{ url_for('main.view_harvest_job', job_id=error.job.id) }}">
+                              {{ error.job.id[:8] }}...
+                          </a>
+                      </td>
+                      <td data-sort-value="{{ error.job.source.name }}">
+                          <a href="{{ url_for('main.view_harvest_source', source_id=error.job.source.id) }}">
+                              {{ error.job.source.name }}
                           </a>
                       </td>
                       <td>{{ error.date_created.strftime('%Y-%m-%d %H:%M:%S')

--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -26,6 +26,7 @@
                 <td>Harvest Source:</td>
                 <td><a href="{{ url_for('main.view_harvest_source', source_id=value) }}">{{data.job.source.name}}</a>
                 </td>
+                {% else %}
                 <td>{{key}}:</td>
                 <td>{{value}}</td>
                 {% endif %}

--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -24,8 +24,7 @@
             <tr>
                 {% if key == 'harvest_source_id' %}
                 <td>Harvest Source:</td>
-                <td><a href="{{ url_for('main.view_harvest_source', source_id=value) }}">{{data.job.source.name}}</a>
-                </td>
+                <td><a href="{{ url_for('main.view_harvest_source', source_id=value) }}">{{data.job.source.name}}</a></td>
                 {% else %}
                 <td>{{key}}:</td>
                 <td>{{value}}</td>

--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -20,13 +20,13 @@
                 <td>{{data['percent_complete']}}</td>
             </tr>
             {% endif %}
-            {% for key, value in data.job_dict.items() %}
+            {% for key, value in data.job.to_dict().items() %}
             <tr>
-                <td>{{key}}:</td>
                 {% if key == 'harvest_source_id' %}
-                <td><a href="{{ url_for('main.view_harvest_source', source_id=value) }}">{{value}}</a>
+                <td>Harvest Source:</td>
+                <td><a href="{{ url_for('main.view_harvest_source', source_id=value) }}">{{data.job.source.name}}</a>
                 </td>
-                {% else %}
+                <td>{{key}}:</td>
                 <td>{{value}}</td>
                 {% endif %}
             </tr>

--- a/app/templates/view_source_data.html
+++ b/app/templates/view_source_data.html
@@ -15,16 +15,21 @@
     <h2>Whooops!</h2>
     <p>Looks like you navigated to a harvest source that doesn't exist.</p>
     {% else %}
-    <h1>{{data.source["name"]}}</h1>
+    <h1>{{data.source.name}}</h1>
     <h2>Configuration:</h2>
     <div class="config-table harvest-source-config-properties">
         <table class="table">
-            {% for key, value in data.source.items() %}
+            {% for key, value in data.source.to_dict().items() %}
             <tr>
-                <td>{{key}}:</td>
                 {% if key == 'organization_id' %}
-                <td><a href="{{ url_for('main.view_organization', org_id=value) }}">{{value}}</a></td>
+                <td>Organization:</td>
+                <td><a href="{{ url_for('main.view_organization', org_id=value) }}">{{data.source.org.name}}</a></td>
+                {% elif key == 'notification_emails' %}
+                <td>Notification emails:</td>
+                <td>{{value|join(',')}}</a>
+                </td>
                 {% else %}
+                <td>{{key}}:</td>
                 <td>{{value}}</td>
                 {% endif %}
             </tr>

--- a/database/models.py
+++ b/database/models.py
@@ -3,7 +3,7 @@ import uuid
 from flask_sqlalchemy import SQLAlchemy
 from geoalchemy2 import Geometry
 from sqlalchemy import Column, Enum, String, func
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, backref
 
 
 class Base(DeclarativeBase):
@@ -44,7 +44,7 @@ class Organization(db.Model):
         )
     )
     sources = db.relationship(
-        "HarvestSource", backref="org", cascade="all, delete-orphan", lazy=True
+        "HarvestSource", backref=backref("org", lazy="joined"), cascade="all, delete-orphan", lazy=True
     )
 
 
@@ -85,7 +85,7 @@ class HarvestSource(db.Model):
         db.Enum("document", "waf", name="source_type"), nullable=False
     )
     jobs = db.relationship(
-        "HarvestJob", backref="source", cascade="all, delete-orphan", lazy=True
+        "HarvestJob", backref=backref("source", lazy="joined"), cascade="all, delete-orphan", lazy=True
     )
     notification_frequency = db.Column(
         db.Enum(
@@ -103,6 +103,7 @@ class HarvestJob(db.Model):
     harvest_source_id = db.Column(
         db.String(36), db.ForeignKey("harvest_source.id"), nullable=False
     )
+
     status = db.Column(
         Enum(
             "in_progress",
@@ -127,7 +128,7 @@ class HarvestJob(db.Model):
     records_ignored = db.Column(db.Integer, default=0)
     records_validated = db.Column(db.Integer, default=0)
     errors = db.relationship(
-        "HarvestJobError", backref="job", cascade="all, delete-orphan", lazy=True
+        "HarvestJobError", backref=backref("job", lazy="joined"), cascade="all, delete-orphan", lazy=True
     )
     records = db.relationship(
         "HarvestRecord", backref="job", cascade="all, delete-orphan", lazy=True
@@ -135,6 +136,7 @@ class HarvestJob(db.Model):
     record_errors = db.relationship(
         "HarvestRecordError", backref="job", cascade="all, delete-orphan", lazy=True
     )
+
 
 
 class HarvestRecord(db.Model):

--- a/database/models.py
+++ b/database/models.py
@@ -44,7 +44,10 @@ class Organization(db.Model):
         )
     )
     sources = db.relationship(
-        "HarvestSource", backref=backref("org", lazy="joined"), cascade="all, delete-orphan", lazy=True
+        "HarvestSource",
+        backref=backref("org", lazy="joined"),
+        cascade="all, delete-orphan",
+        lazy=True,
     )
 
 
@@ -85,7 +88,10 @@ class HarvestSource(db.Model):
         db.Enum("document", "waf", name="source_type"), nullable=False
     )
     jobs = db.relationship(
-        "HarvestJob", backref=backref("source", lazy="joined"), cascade="all, delete-orphan", lazy=True
+        "HarvestJob",
+        backref=backref("source", lazy="joined"),
+        cascade="all, delete-orphan",
+        lazy=True,
     )
     notification_frequency = db.Column(
         db.Enum(
@@ -128,7 +134,10 @@ class HarvestJob(db.Model):
     records_ignored = db.Column(db.Integer, default=0)
     records_validated = db.Column(db.Integer, default=0)
     errors = db.relationship(
-        "HarvestJobError", backref=backref("job", lazy="joined"), cascade="all, delete-orphan", lazy=True
+        "HarvestJobError",
+        backref=backref("job", lazy="joined"),
+        cascade="all, delete-orphan",
+        lazy=True,
     )
     records = db.relationship(
         "HarvestRecord", backref="job", cascade="all, delete-orphan", lazy=True
@@ -136,7 +145,6 @@ class HarvestJob(db.Model):
     record_errors = db.relationship(
         "HarvestRecordError", backref="job", cascade="all, delete-orphan", lazy=True
     )
-
 
 
 class HarvestRecord(db.Model):

--- a/tests/integration/app/conftest.py
+++ b/tests/integration/app/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.fixture()
+def organization(interface, organization_data):
+    yield interface.add_organization(organization_data)
+
+
+@pytest.fixture()
+def source(interface, organization, source_data_dcatus):
+    yield interface.add_harvest_source(source_data_dcatus)
+
+
+@pytest.fixture
+def job(interface, source):
+    """A harvest job for the fixtured source."""
+    yield interface.add_harvest_job(
+        {
+            "harvest_source_id": source.id,
+            "status": "complete",
+        }
+    )

--- a/tests/integration/app/test_metrics.py
+++ b/tests/integration/app/test_metrics.py
@@ -6,10 +6,7 @@ import pytest
 
 
 @pytest.fixture()
-def failed_job_error(interface, organization_data, source_data_dcatus, job_data_new):
-    interface.add_organization(organization_data)
-    interface.add_harvest_source(source_data_dcatus)
-    job = interface.add_harvest_job(job_data_new)
+def failed_job_error(interface, job):
     error = interface.add_harvest_job_error(
         {
             "type": "FailedJobCleanup",
@@ -23,6 +20,12 @@ def failed_job_error(interface, organization_data, source_data_dcatus, job_data_
 class TestMetricsPage:
 
     def test_metrics_failed_table(self, client, failed_job_error):
-        """Test that the failed jobs table has rows."""
+        """Failed jobs table has rows."""
         resp = client.get("/metrics/")
         assert f'<a href="/harvest_job/{failed_job_error.harvest_job_id}">' in resp.text
+
+    def test_metrics_failed_source_name(self, client, job, failed_job_error):
+        """Failed jobs table links to source by name."""
+        resp = client.get("/metrics/")
+        assert job.source.name in resp.text
+        assert f'a href="/harvest_source/{job.source.id}"' in resp.text 

--- a/tests/integration/app/test_metrics.py
+++ b/tests/integration/app/test_metrics.py
@@ -28,4 +28,4 @@ class TestMetricsPage:
         """Failed jobs table links to source by name."""
         resp = client.get("/metrics/")
         assert job.source.name in resp.text
-        assert f'a href="/harvest_source/{job.source.id}"' in resp.text 
+        assert f'<a href="/harvest_source/{job.source.id}">' in resp.text

--- a/tests/integration/app/test_view_harvest_job.py
+++ b/tests/integration/app/test_view_harvest_job.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+@pytest.fixture
+def job(interface, source):
+    """A harvest job for the fixtured source."""
+    yield interface.add_harvest_job(
+        {
+            "harvest_source_id": source.id,
+            "status": "complete",
+        }
+    )
+
+
+class TestViewHarvestJob:
+
+    def test_harvest_source_name(self, client, job):
+        """The harvest source's name appear on the harvest job page."""
+        resp = client.get(f"/harvest_job/{job.id}")
+        assert job.source.name in resp.text
+        assert f'a href="/harvest_source/{job.source.id}"' in resp.text

--- a/tests/integration/app/test_view_harvest_job.py
+++ b/tests/integration/app/test_view_harvest_job.py
@@ -1,17 +1,3 @@
-import pytest
-
-
-@pytest.fixture
-def job(interface, source):
-    """A harvest job for the fixtured source."""
-    yield interface.add_harvest_job(
-        {
-            "harvest_source_id": source.id,
-            "status": "complete",
-        }
-    )
-
-
 class TestViewHarvestJob:
 
     def test_harvest_source_name(self, client, job):

--- a/tests/integration/app/test_view_harvest_source.py
+++ b/tests/integration/app/test_view_harvest_source.py
@@ -1,13 +1,7 @@
-import pytest
-
-
 class TestViewSource:
 
     def test_org_name(self, client, source, organization):
         """Organization name is linked."""
-        url = f'/harvest_source/{source.id}'
-        print(url)
-        resp = client.get(url)
-        print(resp.text)
+        resp = client.get(f"/harvest_source/{source.id}")
         assert organization.name in resp.text
         assert f'href="/organization/{organization.id}"' in resp.text

--- a/tests/integration/app/test_view_harvest_source.py
+++ b/tests/integration/app/test_view_harvest_source.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+class TestViewSource:
+
+    def test_org_name(self, client, source, organization):
+        """Organization name is linked."""
+        url = f'/harvest_source/{source.id}'
+        print(url)
+        resp = client.get(url)
+        print(resp.text)
+        assert organization.name in resp.text
+        assert f'href="/organization/{organization.id}"' in resp.text

--- a/tests/playwright/test_harvest_job.py
+++ b/tests/playwright/test_harvest_job.py
@@ -1,5 +1,4 @@
 import csv
-import re
 
 import pytest
 from playwright.sync_api import expect

--- a/tests/playwright/test_harvest_job.py
+++ b/tests/playwright/test_harvest_job.py
@@ -1,4 +1,5 @@
 import csv
+import re
 
 import pytest
 from playwright.sync_api import expect
@@ -22,8 +23,8 @@ class TestHarvestSourceUnauthed:
             upage.locator(".harvest-job-config-properties table tr td")
         ).to_have_text(
             [
-                "harvest_source_id:",
-                "2f2652de-91df-4c63-8b53-bfced20b276b",
+                "Harvest Source:",
+                "Test Source",
                 "status:",
                 "complete",
                 "job_type:",

--- a/tests/playwright/test_harvest_source.py
+++ b/tests/playwright/test_harvest_source.py
@@ -20,14 +20,14 @@ class TestHarvestSourceUnauthed:
             upage.locator(".harvest-source-config-properties table tr td")
         ).to_have_text(
             [
-                "organization_id:",
-                "d925f84d-955b-4cb7-812f-dcfd6681a18f",
+                "Organization:",
+                "Test Org",
                 "name:",
                 "Test Source",
                 "url:",
                 "http://localhost:80/dcatus/dcatus.json",
-                "notification_emails:",
-                "['email@example.com']",
+                "Notification emails:",
+                "email@example.com",
                 "frequency:",
                 "daily",
                 "schema_type:",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,12 +15,12 @@ from harvester.utils.ckan_utils import (
 from harvester.utils.general_utils import (
     create_retry_session,
     dynamic_map_list_items_to_dict,
+    find_indexes_for_duplicates,
     parse_args,
     prepare_transform_msg,
     process_job_complete_percentage,
     query_filter_builder,
     validate_geojson,
-    find_indexes_for_duplicates,
 )
 
 


### PR DESCRIPTION

# Pull Request

Using backrefs marked as joined, we can replace some of the opaque IDs in the web app with the corresponding names:

- On the Harvest Source page, we use the organization name in the link to the organization (as well as formatting the notification emails list).
- On the Harvest Job page, we use the harvest source name in the link to the harvest source
- On the metrics page, we link to harvest sources by name instead of ID.

## About

To accomplish this efficiently, we have changed a couple of the `backref`s in our ORM models to be `lazy="joined"` which means that a query for the child object (source, or job, or error) automatically joins the parent table (organization, source, or job respectively) to be able to get the parent properties without a separate database query. In general, this is much more efficient than going back to the database N+1 times for each parent property we need.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted