### PR TITLE
Nmb/fix format string

### DIFF
--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -63,7 +63,7 @@ class LoadManager:
         job_url = f"{SMTP_CONFIG['base_url']}/harvest_job/{job.id}"
         send_email_to_recipients(
             [SMTP_CONFIG.get("recipient")],
-            "Failed job cleaned up for {job.source.name}",
+            f"Failed job cleaned up for {job.source.name}",
             (
                 f"The harvest job ({job.id}) for harvest source {job.source.name}\n"
                 "was found to have failed.\n\n"

--- a/tests/integration/app/test_load_manager.py
+++ b/tests/integration/app/test_load_manager.py
@@ -398,6 +398,8 @@ class TestLoadManager:
         assert interface_with_multiple_jobs.db.query(HarvestJobError).count() == 3
         # emails were sent for each failed job
         assert email_mock.call_count == 3
+        # email subjects did not have format string characters
+        assert all("{" not in args[1] for args, _ in email_mock.call_args_list)
 
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
     def test_clean_old_jobs_still_running(self, CFCMock, interface_with_multiple_jobs):


### PR DESCRIPTION
# Pull Request

Tiny bug noticed: The email subjects for our failed job notifications were not marked as Python format strings so the values weren't being interpolated, they were just coming through as the raw text `(job.source.name}`. This one character fix takes care of that.

## About

And a test case so we don't make this exact mistake ever again.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
