### PR TITLE
Fix bug with nonexistent db interface method

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -398,7 +398,7 @@ class HarvestSource:
         date_finished. date_finished is set here because this function is
         either called on critical exception or the job has completed harvesting.
         """
-        self.db_interface.finish_job_with_status(
+        self.db_interface.update_harvest_job(
             self.job_id, {"status": status, "date_finished": get_datetime()}
         )
 


### PR DESCRIPTION
# Pull Request

This error was hidden by our voracious exception swallowing in the harvest process. There is no `db_interface.finish_with_status` method. This switches the local method to using the interface's existing `db_interface.update_harvest_job` method instead.

## About

There are more errors like this that we will need to find from harvest jobs that complete "successfully" but bury these exceptions on what exactly went wrong. I'm hard-pressed to figure out how to test this.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
