### PR TITLE
Non-critical exceptions have two required arguments

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -317,6 +317,7 @@ class HarvestSource:
                 raise ExternalRecordToClass(
                     f"{self.name} {self.url} failed to prepare record for harvest :: {repr(e)}",
                     self.job_id,
+                    None,  # there is no record id to associate
                 )
 
     def acquire_minimum_external_data(self) -> list:


### PR DESCRIPTION
# Pull Request

This is another error that we didn't see because of our voraciousness in swallowing exceptions. This sub-class of HarvesterNonCrtiticalException needs to be created with two positional arguments, the second one a harvest_record_id, but there isn't a corresponding record here, so we pass `None`.

## About

Again, these errors are hard to see and hard to test.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
