### PR TITLE
Use non-federal DCAT schema for all harvest sources

### DIFF
--- a/scripts/ckan_migration/migrate_harvest_sources.py
+++ b/scripts/ckan_migration/migrate_harvest_sources.py
@@ -194,7 +194,9 @@ def _derive_source_fields():
 
         if source["source_type"] == "datajson":
             if organization_type == "Federal Government":
-                return "dcatus1.1: federal"
+                # https://github.com/GSA/data.gov/issues/5306
+                # Use non-federal schema even for federal organizations
+                return "dcatus1.1: non-federal"
             return "dcatus1.1: non-federal"
         elif source["source_type"].startswith("waf"):
             # WAF sources have auto-detected schemas in CKAN, so just choose


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5306 which asks to use the less restrictive non-federal DCAT schema for validation of all DCAT harvest sources.

## About

This will only be relevant the next time we do an import into a harvester environment, likely staging.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
