### PR TITLE
Use placeholders for missing DCAT-US 1.1 required fields

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -15,6 +15,8 @@ from requests.exceptions import HTTPError, Timeout
 sys.path.insert(1, "/".join(os.path.realpath(__file__).split("/")[0:-2]))
 
 
+from database.models import HarvestSource as HarvestSourceORM
+
 # ruff: noqa: E402
 from harvester import SMTP_CONFIG, HarvesterDBInterface, db_interface
 from harvester.exceptions import (
@@ -48,7 +50,6 @@ from harvester.utils.general_utils import (
     sort_dataset,
     traverse_waf,
 )
-from database.models import HarvestSource as HarvestSourceORM
 
 # requests data
 session = create_retry_session()

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -154,7 +154,9 @@ class TestValidateDataset:
         assert len(valid_iso_2_record.transformed_data["keyword"]) == 1
         assert valid_iso_2_record.transformed_data["keyword"][0] == "__"
 
-    def test_transformed_iso_publisher_placeholder(self, organization_data, valid_iso_2_record):
+    def test_transformed_iso_publisher_placeholder(
+        self, organization_data, valid_iso_2_record
+    ):
         valid_iso_2_record.transform()
         del valid_iso_2_record.transformed_data["publisher"]
 
@@ -162,4 +164,6 @@ class TestValidateDataset:
         valid_iso_2_record.fill_placeholders()
         valid_iso_2_record.validate()  ## passes
 
-        assert valid_iso_2_record.transformed_data["publisher"] == {"name": organization_data["name"]}
+        assert valid_iso_2_record.transformed_data["publisher"] == {
+            "name": organization_data["name"]
+        }

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -4,6 +4,22 @@ from harvester.exceptions import ValidationException
 from harvester.harvest import HarvestSource
 
 
+@pytest.fixture
+def valid_iso_2_record(
+    interface, organization_data, source_data_waf_iso19115_2, job_data_waf_iso19115_2
+):
+    interface.add_organization(organization_data)
+    interface.add_harvest_source(source_data_waf_iso19115_2)
+    harvest_job = interface.add_harvest_job(job_data_waf_iso19115_2)
+
+    harvest_source = HarvestSource(harvest_job.id)
+    harvest_source.acquire_minimum_external_data()
+    external_records_to_process = harvest_source.external_records_to_process()
+
+    # "valid_iso2.xml" is always the last one
+    yield list(external_records_to_process)[-1]
+
+
 class TestValidateDataset:
     def test_validate_dcatus_federal(
         self,
@@ -77,53 +93,73 @@ class TestValidateDataset:
 
     def test_valid_transformed_iso(
         self,
-        interface,
-        organization_data,
-        source_data_waf_iso19115_2,
-        job_data_waf_iso19115_2,
+        valid_iso_2_record,
     ):
-        interface.add_organization(organization_data)
-        interface.add_harvest_source(source_data_waf_iso19115_2)
-        harvest_job = interface.add_harvest_job(job_data_waf_iso19115_2)
+        valid_iso_2_record.transform()
+        valid_iso_2_record.validate()
 
-        harvest_source = HarvestSource(harvest_job.id)
-        harvest_source.acquire_minimum_external_data()
-        external_records_to_process = harvest_source.external_records_to_process()
-
-        # "valid_iso2.xml" is always the last one
-        test_iso_2_record = list(external_records_to_process)[-1]
-        test_iso_2_record.transform()
-        test_iso_2_record.validate()
-
-        assert test_iso_2_record.valid is True
+        assert valid_iso_2_record.valid is True
 
     def test_invalid_transformed_iso(
         self,
-        interface,
-        organization_data,
-        source_data_waf_iso19115_2,
-        job_data_waf_iso19115_2,
+        valid_iso_2_record,
     ):
-        interface.add_organization(organization_data)
-        interface.add_harvest_source(source_data_waf_iso19115_2)
-        harvest_job = interface.add_harvest_job(job_data_waf_iso19115_2)
-
-        harvest_source = HarvestSource(harvest_job.id)
-        harvest_source.acquire_minimum_external_data()
-        external_records_to_process = harvest_source.external_records_to_process()
-
-        # "valid_iso2.xml" is always the last one
-        test_iso_2_record = list(external_records_to_process)[-1]
-        test_iso_2_record.transform()
+        valid_iso_2_record.transform()
 
         # we increased our contactPoint options in mdtranslator
         # so this actually gets pulled so deleting it here
-        del test_iso_2_record.transformed_data["contactPoint"]
+        del valid_iso_2_record.transformed_data["contactPoint"]
 
         # validator throws an exception when the dataset is invalid
         with pytest.raises(ValidationException) as e:
-            test_iso_2_record.validate()
+            valid_iso_2_record.validate()
         assert (
             e.value.msg
             == "<ValidationError: \"'contactPoint' is a required property\">"
         )
+
+    def test_transformed_iso_contact_placeholder(self, valid_iso_2_record):
+        valid_iso_2_record.transform()
+        del valid_iso_2_record.transformed_data["contactPoint"]
+
+        # now fill in the missing contactPoint
+        valid_iso_2_record.fill_placeholders()
+        valid_iso_2_record.validate()  ## passes
+        assert (
+            "@gsa.gov"
+            in valid_iso_2_record.transformed_data["contactPoint"]["hasEmail"]
+        )
+        assert valid_iso_2_record.transformed_data["contactPoint"][
+            "hasEmail"
+        ].startswith("mailto:")
+
+    def test_transformed_iso_description_placeholder(self, valid_iso_2_record):
+        valid_iso_2_record.transform()
+        del valid_iso_2_record.transformed_data["description"]
+
+        # now fill in the missing items
+        valid_iso_2_record.fill_placeholders()
+        valid_iso_2_record.validate()  ## passes
+
+        assert "No description" in valid_iso_2_record.transformed_data["description"]
+
+    def test_transformed_iso_keyword_placeholder(self, valid_iso_2_record):
+        valid_iso_2_record.transform()
+        del valid_iso_2_record.transformed_data["keyword"]
+
+        # now fill in the missing items
+        valid_iso_2_record.fill_placeholders()
+        valid_iso_2_record.validate()  ## passes
+
+        assert len(valid_iso_2_record.transformed_data["keyword"]) == 1
+        assert valid_iso_2_record.transformed_data["keyword"][0] == "__"
+
+    def test_transformed_iso_publisher_placeholder(self, organization_data, valid_iso_2_record):
+        valid_iso_2_record.transform()
+        del valid_iso_2_record.transformed_data["publisher"]
+
+        # now fill in the missing items
+        valid_iso_2_record.fill_placeholders()
+        valid_iso_2_record.validate()  ## passes
+
+        assert valid_iso_2_record.transformed_data["publisher"] == {"name": organization_data["name"]}


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5323 we want to add some of the DCAT-US required elements with generic placeholder values for WAF/ISO sources that don't include them (because they weren't included in the ISO standards).

## About

I think that the placeholders are all in one place and they should be extensible enough if we change our minds in the future about what the values should be or we want to add placeholders to more fields.

We also added a potential call back into the database to get the harvest source's organization data to use in the `publisher` field.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
