### PR TITLE
Catch exceptions in load manager

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from dotenv import load_dotenv
@@ -9,6 +10,8 @@ from flask_migrate import Migrate
 from app.filters import else_na, usa_icon
 from database.models import db
 from harvester.lib.load_manager import LoadManager
+
+logger = logging.getLogger("harvest_admin")
 
 load_manager = LoadManager()
 
@@ -39,7 +42,12 @@ def create_app():
         # SQL-Alchemy can't be used to create the schema here
         # Instead, `flask db upgrade` must already have been run
         # db.create_all()
-        load_manager.start()
+        try:
+            load_manager.start()
+        except Exception as e:
+            # we need to get to app start up, so ignore all errors
+            # from the load manager but log them
+            logger.warning("Load manager startup failed with exception: %s", repr(e))
 
     return app
 

--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -89,6 +89,12 @@ class LoadManager:
         only schedule at most one new job.
         """
         running_tasks = self.handler.num_running_app_tasks()
+        if running_tasks is None:
+            # None here indicates that tasks couldn't be listed with the API
+            # so be safe by not doing anything.
+            logger.warning("Not starting new jobs because tasks could not be listed")
+            return
+
         if check_from_task:
             running_tasks -= 1
 
@@ -173,6 +179,9 @@ class LoadManager:
     def stop_job(self, job_id, job_type="harvest"):
         """task manager stop interface, takes a job_id"""
         tasks = self.handler.get_all_app_tasks()
+        if tasks is None:
+            # couldn't list tasks, nothing to do
+            return f"Could not stop job {job_id}, can't list tasks"
         job_task = [
             (t["guid"], t["state"])
             for t in tasks

--- a/tests/badges/functional/coverage.svg
+++ b/tests/badges/functional/coverage.svg
@@ -5,7 +5,7 @@
     width="92.5"
     height="20"
     role="img"
-    aria-label="coverage: 11%"
+    aria-label="coverage: 14%"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>coverage: 11%</title>
+    <title>coverage: 14%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(60.0 0)">
             <rect width="32.5" fill="#e05d44"/>
-            <text x="16.25" y="10.0" class="shadow">11%</text>
-            <text x="16.25" y="10.0">11%</text>
+            <text x="16.25" y="10.0" class="shadow">14%</text>
+            <text x="16.25" y="10.0">14%</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/functional/tests.svg
+++ b/tests/badges/functional/tests.svg
@@ -5,7 +5,7 @@
     width="55.0"
     height="20"
     role="img"
-    aria-label="tests: 0"
+    aria-label="tests: 3"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 0</title>
+    <title>tests: 3</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -41,9 +41,9 @@
             <text x="18.75" y="10.0">tests</text>
         </g>
         <g transform="translate(37.5 0)">
-            <rect width="17.5" fill="#9f9f9f"/>
-            <text x="8.75" y="10.0" class="shadow">0</text>
-            <text x="8.75" y="10.0">0</text>
+            <rect width="17.5" fill="#4c1"/>
+            <text x="8.75" y="10.0" class="shadow">3</text>
+            <text x="8.75" y="10.0">3</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/integration/tests.svg
+++ b/tests/badges/integration/tests.svg
@@ -5,7 +5,7 @@
     width="70.0"
     height="20"
     role="img"
-    aria-label="tests: 115"
+    aria-label="tests: 128"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 115</title>
+    <title>tests: 128</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="32.5" fill="#4c1"/>
-            <text x="16.25" y="10.0" class="shadow">115</text>
-            <text x="16.25" y="10.0">115</text>
+            <text x="16.25" y="10.0" class="shadow">128</text>
+            <text x="16.25" y="10.0">128</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/playwright/tests.svg
+++ b/tests/badges/playwright/tests.svg
@@ -2,10 +2,10 @@
 <svg
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    width="62.5"
+    width="85.0"
     height="20"
     role="img"
-    aria-label="tests: 33"
+    aria-label="tests: 22/33"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 33</title>
+    <title>tests: 22/33</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -41,9 +41,9 @@
             <text x="18.75" y="10.0">tests</text>
         </g>
         <g transform="translate(37.5 0)">
-            <rect width="25.0" fill="#4c1"/>
-            <text x="12.5" y="10.0" class="shadow">33</text>
-            <text x="12.5" y="10.0">33</text>
+            <rect width="47.5" fill="#9f9f9f"/>
+            <text x="23.75" y="10.0" class="shadow">22/33</text>
+            <text x="23.75" y="10.0">22/33</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/unit/coverage.svg
+++ b/tests/badges/unit/coverage.svg
@@ -5,7 +5,7 @@
     width="92.5"
     height="20"
     role="img"
-    aria-label="coverage: 47%"
+    aria-label="coverage: 50%"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>coverage: 47%</title>
+    <title>coverage: 50%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -41,9 +41,9 @@
             <text x="30.0" y="10.0">coverage</text>
         </g>
         <g transform="translate(60.0 0)">
-            <rect width="32.5" fill="#fe7d37"/>
-            <text x="16.25" y="10.0" class="shadow">47%</text>
-            <text x="16.25" y="10.0">47%</text>
+            <rect width="32.5" fill="#dfb317"/>
+            <text x="16.25" y="10.0" class="shadow">50%</text>
+            <text x="16.25" y="10.0">50%</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/unit/tests.svg
+++ b/tests/badges/unit/tests.svg
@@ -5,7 +5,7 @@
     width="62.5"
     height="20"
     role="img"
-    aria-label="tests: 58"
+    aria-label="tests: 62"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 58</title>
+    <title>tests: 62</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="25.0" fill="#4c1"/>
-            <text x="12.5" y="10.0" class="shadow">58</text>
-            <text x="12.5" y="10.0">58</text>
+            <text x="12.5" y="10.0" class="shadow">62</text>
+            <text x="12.5" y="10.0">62</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/functional/test_cf_tasks.py
+++ b/tests/functional/test_cf_tasks.py
@@ -1,6 +1,5 @@
 import os
 from time import sleep
-from unittest import TestCase
 from unittest.mock import patch
 
 from cloudfoundry_client.errors import InvalidStatusCode
@@ -17,7 +16,7 @@ dhl_cf_task_data = {
 }
 
 
-class TestCFTasking(TestCase):
+class TestCFTasking:
     def test_crud_task(self):
         # start a new task
         new_task = cf_handler.start_task(**dhl_cf_task_data)
@@ -40,12 +39,32 @@ class TestCFTasking(TestCase):
         assert tasks is not None
 
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
-    def tests_get_all_app_tasks_api_error(self, CFCMock):
+    def tests_get_all_app_tasks_api_error(self, CFCMock, caplog):
         cf_handler.setup()
 
         CFCMock.return_value.v3.apps.get.side_effect = InvalidStatusCode(500, "")
-        with self.assertLogs() as logs:
-            tasks = cf_handler.get_all_app_tasks()
-            assert CFCMock.return_value.v3.apps.get.call_count == 1
-            assert tasks == []
-            assert "Failed to get app tasks" in logs.output[0]
+
+        tasks = cf_handler.get_all_app_tasks()
+        assert CFCMock.return_value.v3.apps.get.call_count == 1
+        assert tasks is None
+        assert "Failed to get app tasks" in caplog.text
+
+    @patch("harvester.lib.cf_handler.CloudFoundryClient")
+    def tests_get_running_app_tasks_api_error(self, CFCMock, caplog):
+        cf_handler.setup()
+
+        CFCMock.return_value.v3.apps.get.side_effect = InvalidStatusCode(500, "")
+
+        tasks = cf_handler.get_running_app_tasks()
+        assert tasks is None
+        assert "Failed to get app tasks" in caplog.text
+
+    @patch("harvester.lib.cf_handler.CloudFoundryClient")
+    def tests_num_running_app_tasks_api_error(self, CFCMock, caplog):
+        cf_handler.setup()
+
+        CFCMock.return_value.v3.apps.get.side_effect = InvalidStatusCode(500, "")
+
+        num_tasks = cf_handler.num_running_app_tasks()
+        assert num_tasks is None
+        assert "Failed to get app tasks" in caplog.text

--- a/tests/integration/app/test_load_manager.py
+++ b/tests/integration/app/test_load_manager.py
@@ -31,6 +31,7 @@ def all_tasks_json_fixture():
 
 @freeze_time("Jan 14th, 2012")
 class TestLoadManager:
+
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
     @patch("harvester.lib.load_manager.MAX_TASKS_COUNT", 3)
     def test_load_manager_invokes_tasks(
@@ -423,13 +424,48 @@ class TestLoadManager:
         assert interface_with_multiple_jobs.db.query(HarvestJobError).count() == 0
 
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
-    def test_clean_old_jobs_api_error(self, CFCMock):
+    def test_clean_old_jobs_api_error(self, CFCMock, caplog):
         """Doesn't fail if API is down."""
-        # CF reports all running jobs
+        # CF tasks list call fails
         CFCMock.return_value.v3.apps.get.side_effect = InvalidStatusCode(500, "")
 
         load_manager = LoadManager()
         load_manager._clean_old_jobs()
+        assert "task information is not accurate" in caplog.text
+
+    @patch("harvester.lib.cf_handler.CloudFoundryClient")
+    def test_start_new_jobs_api_error(self, CFCMock, caplog):
+        """Doesn't fail if API is down."""
+        # CF tasks list call fails
+        CFCMock.return_value.v3.apps.get.side_effect = InvalidStatusCode(500, "")
+
+        load_manager = LoadManager()
+        load_manager._start_new_jobs()
+        assert "Not starting new jobs" in caplog.text
+
+    @patch("harvester.lib.cf_handler.CloudFoundryClient")
+    def test_stop_job_api_fails(
+        self,
+        CFCMock,
+        all_tasks_json_fixture,
+        mock_good_cf_index,
+        interface_no_jobs,
+        source_data_dcatus,
+    ):
+        """Doesn't do anything if API is down."""
+        # CF tasks list call fails
+        CFCMock.return_value.v3.apps.get.side_effect = InvalidStatusCode(500, "")
+
+        load_manager = LoadManager()
+        load_manager.trigger_manual_job(source_data_dcatus["id"])
+
+        source_id = source_data_dcatus["id"]
+        jobs = interface_no_jobs.pget_harvest_jobs(
+            facets=f"harvest_source_id = '{source_id}'"
+        )
+
+        retval = load_manager.stop_job(jobs[0].id)
+        assert "Could not stop job" in retval
 
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
     def test_load_manager_from_tasks_invokes_one_task(


### PR DESCRIPTION
We had a problem recently where a CloudFoundry bug was leading to exceptions from the CloudFoundry client in `cf_handler.get_all_app_tasks`. This adds exception handling and tests for that particular error situation. BUT this error was also preventing our web app from starting up, so I also added a very broad try-clause around `load_manager.start()` so that any errors in that phase wouldn't stop the web app from coming up.