### PR TITLE
improve validation messages

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -38,6 +38,7 @@ from harvester.lib.harvest_reporter import HarvestReporter
 from harvester.lib.load_manager import LoadManager
 from harvester.utils.ckan_utils import CKANSyncTool
 from harvester.utils.general_utils import (
+    assemble_validation_errors,
     create_retry_session,
     dataset_to_hash,
     download_file,
@@ -809,7 +810,10 @@ class Record:
         # save ourselves a second call to is_valid by keeping a flag of
         # whether we saw any errors
         valid = True
-        for error in self.harvest_source.validator.iter_errors(record):
+
+        errors = self.harvest_source.validator.iter_errors(record)
+        errors = assemble_validation_errors(errors)
+        for error in errors:
             valid = False
             self._report_error(error)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1038,3 +1038,10 @@ def sample_harvest_jobs():
         "12345678-1234-1234-1234-123456789abc": job2,
         "abcdef12-3456-7890-abcd-ef1234567890": job3,
     }
+
+
+@pytest.fixture
+def dcatus_non_federal_schema():
+    schema = Path(__file__).parents[1] / "schemas" / "non-federal_dataset.json"
+    with open(schema) as f:
+        return json.load(f)

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -83,12 +83,12 @@ class TestValidateDataset:
         errors = [
             e[0] for e in interface.get_harvest_record_errors_by_job(harvest_job.id)
         ]
-        assert errors[0].message.startswith(
-            "<ValidationError: '\"<p align=\\'center\\'"
-        )
-        assert errors[0].message.endswith(
-            "is not valid under any of the given schemas'>"
-        )
+
+        assert len(errors) == 1
+
+        # ruff: noqa E501
+        expected = "<ValidationError: \"$.license, 'center' does not match any of the acceptable formats: 'uri', 'null', '^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$'\">"
+        assert errors[0].message == expected
 
     def test_multiple_invalid(
         self,
@@ -114,12 +114,16 @@ class TestValidateDataset:
             e[0] for e in interface.get_harvest_record_errors_by_job(harvest_job.id)
         ]
         assert len(errors) == 3
-        assert errors[-1].message.startswith(
-            "<ValidationError: '\"<p align=\\'center\\'"
-        )
-        assert errors[-1].message.endswith(
-            "is not valid under any of the given schemas'>"
-        )
+
+        # ruff: noqa E501
+        expected = [
+            "<ValidationError: '$.contactPoint.hasEmail, \\'ocagoadmin@oakgov.com\\' does not match any of the acceptable formats: \"^mailto:[\\\\\\\\w\\\\\\\\_\\\\\\\\~\\\\\\\\!\\\\\\\\$\\\\\\\\&\\\\\\\\\\'\\\\\\\\(\\\\\\\\)\\\\\\\\*\\\\\\\\+\\\\\\\\,\\\\\\\\;\\\\\\\\=\\\\\\\\:.-]+@[\\\\\\\\w.-]+\\\\\\\\.[\\\\\\\\w.-]+?$\", \\'^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$\\''>",
+            "<ValidationError: \"$.distribution[0].accessURL, '//////not-a-url.example.com/' does not match any of the acceptable formats: 'uri', 'null', '^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$'\">",
+            "<ValidationError: \"$.license, 'center' does not match any of the acceptable formats: 'uri', 'null', '^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$'\">",
+        ]
+
+        for i in range(len(errors)):
+            assert errors[i].message.startswith(expected[i])
 
     def test_valid_transformed_iso(
         self,
@@ -149,7 +153,7 @@ class TestValidateDataset:
         ]
         assert (
             errors[0].message
-            == "<ValidationError: \"'contactPoint' is a required property\">"
+            == """<ValidationError: "$, 'contactPoint' is a required property">"""
         )
 
     def test_transformed_iso_contact_placeholder(self, valid_iso_2_record):


### PR DESCRIPTION
# Pull Request

Related to [#5206](https://github.com/GSA/data.gov/issues/5206)

## About
- improve validation messages by digging into the exact reason(s) for failure. this particularly improves errors with nested content (e.g. distributions) where the original error would be vague to the effect of "there's something wrong with distributions" which isn't helpful at all. this instead will return exactly what's wrong by providing the offending distribution and field (for example).
- update to the ISO19115_1 fixture to reflect update to the email in contactPoint processing in transformation app (lowercase) 

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
