### PR TITLE
add placeholder describedByType

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -771,6 +771,8 @@ class Record:
         """Fill in placeholder values to prevent some validation errors.
 
         We work directly on the self.transformed_data dict.
+
+        This function is only called on ISO records. It is not applied on DCATUS.
         """
         # missing contactPoint or it's empty
         if not self.transformed_data.get("contactPoint"):
@@ -791,6 +793,11 @@ class Record:
             self.transformed_data["publisher"] = {
                 "name": self.harvest_source.get_source_orm().org.name
             }
+
+        if self.transformed_data.get("describedBy"):
+            # recommended for unknown files types
+            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types
+            self.transformed_data["describedByType"] = "application/octet-stream"
 
     def validate(self) -> None:
         # TODO: create a different status for transformation exceptions

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -167,3 +167,18 @@ class TestValidateDataset:
         assert valid_iso_2_record.transformed_data["publisher"] == {
             "name": organization_data["name"]
         }
+
+    def test_transformed_iso_described_by_type_placeholder(self, valid_iso_2_record):
+        valid_iso_2_record.transform()
+        valid_iso_2_record.transformed_data["describedBy"] = (
+            "https://geodesy.noaa.gov/CORS/"
+        )
+
+        # now fill in the missing items
+        valid_iso_2_record.fill_placeholders()
+        valid_iso_2_record.validate()  ## passes
+
+        assert (
+            valid_iso_2_record.transformed_data["describedByType"]
+            == "application/octet-stream"
+        )


### PR DESCRIPTION
# Pull Request

Related to [#5335](https://github.com/GSA/data.gov/issues/5335)

## About
- some ISO docs are failing validation because of bad `describedByType` values. see [job](https://datagov-harvest-dev.app.cloud.gov/harvest_job/2e3eb103-9a3b-4c7a-88e3-c242936eadd7).
- this PR uses `application/octet-stream` as the placeholder when "describedBy" is present. this value is recommended for unknown file types: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
