### PR TITLE
Guess a better distribution URL

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -616,6 +616,15 @@ class Record:
             raise ValueError("status must be a string")
         self._status = value
 
+    @staticmethod
+    def _is_valid_url(url: str) -> bool:
+        """Return whether a string is a valid URL."""
+        return Draft202012Validator(
+            {"type": "string", "format": "uri"},
+            format_checker=Draft202012Validator.FORMAT_CHECKER,
+        ).is_valid(url)
+
+
     def harvest(self) -> None:
         """
         this is the main harvest function for a record instance. it runs the compare,
@@ -772,18 +781,12 @@ class Record:
         # If distribution items have a downloadURL or accessURL,
         # check if it just needs an "https://" at the beginning
         # to be valid
-        def _is_valid_url(url):
-            return Draft202012Validator(
-                {"type": "string", "format": "uri"},
-                format_checker=Draft202012Validator.FORMAT_CHECKER,
-            ).is_valid(url)
-
         def _guess_better_url_in_item(item, key):
             url = item.get(key)
-            if url is not None and not _is_valid_url(url):
+            if url is not None and not self._is_valid_url(url):
                 # it exists and isn't valid
                 candidate = "https://" + url
-                if _is_valid_url(candidate):
+                if self._is_valid_url(candidate):
                     # TODO: log a warning that we are making this change
                     item[key] = candidate
 

--- a/tests/badges/integration/tests.svg
+++ b/tests/badges/integration/tests.svg
@@ -5,7 +5,7 @@
     width="70.0"
     height="20"
     role="img"
-    aria-label="tests: 136"
+    aria-label="tests: 137"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 136</title>
+    <title>tests: 137</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="32.5" fill="#4c1"/>
-            <text x="16.25" y="10.0" class="shadow">136</text>
-            <text x="16.25" y="10.0">136</text>
+            <text x="16.25" y="10.0" class="shadow">137</text>
+            <text x="16.25" y="10.0">137</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/integration/tests.svg
+++ b/tests/badges/integration/tests.svg
@@ -5,7 +5,7 @@
     width="70.0"
     height="20"
     role="img"
-    aria-label="tests: 135"
+    aria-label="tests: 136"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 135</title>
+    <title>tests: 136</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="32.5" fill="#4c1"/>
-            <text x="16.25" y="10.0" class="shadow">135</text>
-            <text x="16.25" y="10.0">135</text>
+            <text x="16.25" y="10.0" class="shadow">136</text>
+            <text x="16.25" y="10.0">136</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -201,3 +201,37 @@ class TestValidateDataset:
         assert valid_iso_2_record.transformed_data["publisher"] == {
             "name": organization_data["name"]
         }
+
+    def test_transformed_iso_downloadURL_placeholder(
+        self, organization_data, valid_iso_2_record
+    ):
+        valid_iso_2_record.transform()
+        valid_iso_2_record.transformed_data["distribution"][0][
+            "downloadURL"
+        ] = "www.example.com/"
+
+        # now fill in the missing items
+        valid_iso_2_record.fill_placeholders()
+        assert valid_iso_2_record.validate()
+
+        assert (
+            valid_iso_2_record.transformed_data["distribution"][0]["downloadURL"]
+            == "https://www.example.com/"
+        )
+
+    def test_transformed_iso_accessURL_placeholder(
+        self, organization_data, valid_iso_2_record
+    ):
+        valid_iso_2_record.transform()
+        valid_iso_2_record.transformed_data["distribution"][0][
+            "accessURL"
+        ] = "www.example.com/"
+
+        # now fill in the missing items
+        valid_iso_2_record.fill_placeholders()
+        assert valid_iso_2_record.validate()
+
+        assert (
+            valid_iso_2_record.transformed_data["distribution"][0]["accessURL"]
+            == "https://www.example.com/"
+        )

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -209,6 +209,8 @@ class TestValidateDataset:
         valid_iso_2_record.transformed_data["distribution"][0][
             "downloadURL"
         ] = "www.example.com/"
+        # makes the record invalid
+        assert not valid_iso_2_record.validate()
 
         # now fill in the missing items
         valid_iso_2_record.fill_placeholders()
@@ -226,6 +228,8 @@ class TestValidateDataset:
         valid_iso_2_record.transformed_data["distribution"][0][
             "accessURL"
         ] = "www.example.com/"
+        # makes the record invalid
+        assert not valid_iso_2_record.validate()
 
         # now fill in the missing items
         valid_iso_2_record.fill_placeholders()


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5307, we observe lots of records that fail validation because their `distribution` items don't have valid `downloadURL` or `accessURL` when they just left off the `https://` scheme from the URL. This change adds that `https://` scheme at the beginning if it makes an invalid URL into a valid URL.

## About

Since we had the `jsonschema` library already, we can use it to check on what is a valid URL by using a tiny little schema.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
