### PR TITLE
Add restarts and task increases for staging and prod

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -13,8 +13,12 @@ permissions:
 
 jobs:
   restart:
-    name: restart (development)
-    environment: development
+    name: restart harvest app
+    strategy:
+      fail-fast: false
+      matrix:
+        environ: ["development", "staging", "prod"]
+    environment: ${{ matrix.environ }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
@@ -27,7 +31,7 @@ jobs:
         with:
           command: harvester/bin/check-and-renew datagov-harvest restart
           cf_org: gsa-datagov
-          cf_space: development
+          cf_space: ${{ matrix.environ }}
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}
       - name: Create Issue if it fails 😢

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -8,7 +8,8 @@ admin_disk_quota: 4G
 CF_API_URL: https://api.fr.cloud.gov
 CKAN_API_URL: https://catalog-next-prod-admin-datagov.app.cloud.gov
 
-HARVEST_RUNNER_MAX_TASKS: 10
+# CKAN can't handle too many tasks talking to it
+HARVEST_RUNNER_MAX_TASKS: 3
 
 MDTRANSLATOR_URL: http://mdtranslator-prod.apps.internal:8080/translates
 

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -8,7 +8,7 @@ admin_disk_quota: 4G
 CF_API_URL: https://api.fr.cloud.gov
 CKAN_API_URL: https://catalog-next-prod-admin-datagov.app.cloud.gov
 
-HARVEST_RUNNER_MAX_TASKS: 5
+HARVEST_RUNNER_MAX_TASKS: 10
 
 MDTRANSLATOR_URL: http://mdtranslator-prod.apps.internal:8080/translates
 

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -8,7 +8,8 @@ admin_disk_quota: 4G
 CF_API_URL: https://api.fr.cloud.gov
 CKAN_API_URL: https://catalog-next-stage-admin-datagov.app.cloud.gov
 
-HARVEST_RUNNER_MAX_TASKS: 6
+# CKAN can't handle too many tasks talking to it
+HARVEST_RUNNER_MAX_TASKS: 3
 
 MDTRANSLATOR_URL: http://mdtranslator-staging.apps.internal:8080/translates
 

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -8,7 +8,7 @@ admin_disk_quota: 4G
 CF_API_URL: https://api.fr.cloud.gov
 CKAN_API_URL: https://catalog-next-stage-admin-datagov.app.cloud.gov
 
-HARVEST_RUNNER_MAX_TASKS: 2
+HARVEST_RUNNER_MAX_TASKS: 6
 
 MDTRANSLATOR_URL: http://mdtranslator-staging.apps.internal:8080/translates
 


### PR DESCRIPTION
# Pull Request

To run our scheduled harvest tasks in staging and production, we need the harvest applications on cloud.gov to be restarted regularly. This also adds an increase in the number of simultaneous tasks we use on each environment.

## About

We should monitor our memory usage after this change to make sure that the number of tasks we specify here doesn't use too much, but it shouldn't be a problem with our current quota.