### PR TITLE
add egress check

### DIFF
--- a/.github/egress_check_error.md
+++ b/.github/egress_check_error.md
@@ -1,0 +1,14 @@
+---
+title: Egress Check Failed
+labels: ["bug", "o&m", "egress"]
+---
+
+Workflow with Issue: {{ workflow }}
+Job Failed: {{ env.GITHUB_JOB }}
+Type of Failure: {{ env.COMMAND }}
+Cloud.gov Environment: {{ env.ENVIRONMENT }}
+
+Last Commit: {{ env.LAST_COMMIT }}
+Number of times run: {{ env.GITHUB_ATTEMPTS }}
+Last run by: {{ env.LAST_RUN_BY }}
+Github Action Run: https://github.com/GSA/datagov-harvester/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/egress-check.yml
+++ b/.github/workflows/egress-check.yml
@@ -1,0 +1,63 @@
+---
+name: Check Egress Operation
+
+on:
+  schedule:
+    - cron: '40 02,14 * * *'
+  workflow_dispatch:
+
+jobs:
+  egress-check:
+    name: ${{matrix.environ}} - ${{matrix.command}}
+    runs-on: ubuntu-latest
+    environment: ${{ matrix.environ }}
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        command:
+          - 'GoodDomainTest || curl -I -L --http1.1 https://gsa.gov | grep \"HTTP/1.1 200 OK\"'
+          - 'BadDomainTest || curl -I -L --http1.1 https://yahoo.com | grep \"HTTP/1.1 403 Forbidden\"'
+        environ: ['development', 'staging', 'prod']
+
+    steps:
+      - name: Store Instance Name
+        run: |
+          INSTANCE_NAME="$(echo egress-check-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT})"
+          echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: run task
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task datagov-harvest --command "${{ matrix.command }}"
+            --name $INSTANCE_NAME -k 1500M -m 150M
+          cf_org: gsa-datagov
+          cf_space: ${{ matrix.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: monitor task output
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            tools/monitor_cf_logs.sh datagov-harvest $INSTANCE_NAME
+          cf_org: gsa-datagov
+          cf_space: ${{ matrix.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: Create Issue for failure 😢
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          COMMAND: ${{ matrix.command }}
+          ENVIRONMENT: ${{ matrix.environ }}
+        with:
+          filename: .github/egress_check_error.md
+          update_existing: true

--- a/.github/workflows/egress-check.yml
+++ b/.github/workflows/egress-check.yml
@@ -41,7 +41,7 @@ jobs:
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
-            tools/monitor_cf_logs.sh datagov-harvest $INSTANCE_NAME
+            bin/monitor_cf_logs.sh datagov-harvest $INSTANCE_NAME
           cf_org: gsa-datagov
           cf_space: ${{ matrix.environ }}
           cf_username: ${{secrets.CF_SERVICE_USER}}

--- a/bin/monitor_cf_logs.sh
+++ b/bin/monitor_cf_logs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Custom script to look at logs from run task...
+
+# Input any app name, any task name and any log key
+# log key helps to prevent printing sensitive info such as redis password
+app_to_monitor=$1
+task_to_monitor=$2
+
+# install a better version of grep which supports --line-buffered
+apk add grep 
+
+while read -r line ; do
+  echo "$line"
+  if echo "$line" | grep "OUT Exit status 0"; then
+    exit 0
+  elif echo "$line" | grep "OUT Exit status"; then
+    exit 1
+  fi
+done < <(cf logs "$app_to_monitor" | grep  --line-buffered "\[APP/TASK/$task_to_monitor/0\]")


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5352

## About

Add egress check cron. The check will fail until egress is implemented. 

The workflow is copied from gsa/catalog.data.gov. If this needs to be implemented to yet another repo, it will be time to  create a workflow template on our main repo /gsa/data.gov so that we don't repeat ourselves.