### PR TITLE
add qa action 

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,59 @@
+name: Harvester QA script
+
+env:
+  PY_VERSION: "3.13"
+  POETRY_VERSION: "2.0.0"
+
+on:
+  workflow_dispatch:
+    inputs: 
+      job_type:
+        description: 'The QA job to run'
+        required: false
+        type: choice
+        options:
+          - 'all'
+          - 'harvest_source'
+          - 'organization'
+          - 'dataset'
+        default: 'all'
+jobs:
+  run-qa:
+    env:
+        DATAGOV_BASIC_AUTH_USER: ${{secrets.DATAGOV_BASIC_AUTH_USER}}
+        DATAGOV_BASIC_AUTH_PASS: ${{secrets.DATAGOV_BASIC_AUTH_PASS}}
+    runs-on: ubuntu-latest
+    name: Harvester QA ${{ inputs.job_type }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python ${{ env.PY_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PY_VERSION }}
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
+          poetry-plugins: "poetry-plugin-export"
+
+      - name: Install Dependencies
+        run: |
+          poetry env use ${{ env.PY_VERSION }}
+          poetry install
+      
+      - name: Run QA
+        run: poetry run ./scripts/qa.py --job_type ${{ inputs.job_type }}
+      
+      - name: Zip QA output directory
+        run: zip -r qa_archive.zip ./scripts/qa_output
+
+      - name: Upload QA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa_archive
+          path: qa_archive.zip

--- a/scripts/lib/qa/__init__.py
+++ b/scripts/lib/qa/__init__.py
@@ -1,0 +1,11 @@
+import os
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+session = requests.Session()
+
+username = os.getenv("DATAGOV_BASIC_AUTH_USER")
+password = os.getenv("DATAGOV_BASIC_AUTH_PASS")
+
+session.auth = HTTPBasicAuth(username, password)

--- a/scripts/lib/qa/datasets.py
+++ b/scripts/lib/qa/datasets.py
@@ -2,16 +2,15 @@ import logging
 import random
 
 import click
-import requests
 from deepdiff import DeepDiff
 
+from . import session
 from .utils import CATALOG_NEXT_BASE_URL, CATALOG_PROD_BASE_URL, OutputBase
 
 logger = logging.getLogger(__name__)
 
 
 class Datasets(OutputBase):
-
     def __init__(
         self,
         base_url: str,
@@ -60,7 +59,7 @@ class Datasets(OutputBase):
 
     def get_num_datasets(self):
         """Return the number of datasets in this catalog."""
-        res = requests.get(f"{self.base_url}/api/action/package_search")
+        res = session.get(f"{self.base_url}/api/action/package_search")
         res.raise_for_status()
         return res.json()["result"]["count"]
 
@@ -70,7 +69,7 @@ class Datasets(OutputBase):
         Returns None if no matching dataset is found.
         """
         url = f'{self.base_url}/api/action/package_search?fq=name:"{other["name"]}"'
-        res = requests.get(url)
+        res = session.get(url)
         if res.ok:
             data = res.json()["result"]["results"]
             if data:
@@ -84,7 +83,7 @@ class Datasets(OutputBase):
                 f"{self.base_url}/api/action/package_search"
                 f'?fq=identifier:"{identifier}"'
             )
-            res = requests.get(url)
+            res = session.get(url)
             if res.ok:
                 data = res.json()["result"]["results"]
                 if data:
@@ -93,7 +92,7 @@ class Datasets(OutputBase):
 
             # some catalog datasets have guid instead
             url = f'{self.base_url}/api/action/package_search?fq=guid:"{identifier}"'
-            res = requests.get(url)
+            res = session.get(url)
             if res.ok:
                 data = res.json()["result"]["results"]
                 if data:
@@ -115,7 +114,7 @@ class Datasets(OutputBase):
             num_datasets = self.get_num_datasets()
             start = random.randint(1, int(num_datasets - self.sample_size))
 
-            res = requests.get(
+            res = session.get(
                 f"{self.base_url}/api/action/package_search"
                 f"?start={start}&rows={self.sample_size}&sort=id%20asc"
             )

--- a/scripts/lib/qa/harvest_sources.py
+++ b/scripts/lib/qa/harvest_sources.py
@@ -1,6 +1,6 @@
 import click
-import requests
 
+from . import session
 from .utils import CATALOG_NEXT_BASE_URL, CATALOG_PROD_BASE_URL, OutputBase
 
 
@@ -42,7 +42,7 @@ class HarvestSources(OutputBase):
             )
 
     def get_harvest_sources(self):
-        res = requests.get(self.harvest_sources_url)
+        res = session.get(self.harvest_sources_url)
         if res.ok:
             if self.source_type == "catalog":
                 self.sources = res.json()["result"]["results"]
@@ -52,7 +52,7 @@ class HarvestSources(OutputBase):
 
     def get_num_datasets(self):
         # harvest sources with no datasets aren't returned from the solr facet
-        res = requests.get(self.harvest_sources_dset_count_url)
+        res = session.get(self.harvest_sources_dset_count_url)
         if res.ok:
             titles = res.json()["result"]["facets"]["harvest_source_title"]
             self.titles = {

--- a/scripts/lib/qa/organizations.py
+++ b/scripts/lib/qa/organizations.py
@@ -1,6 +1,6 @@
 import click
-import requests
 
+from . import session
 from .utils import CATALOG_NEXT_BASE_URL, CATALOG_PROD_BASE_URL, OutputBase
 
 """Organization collection for QA."""
@@ -22,7 +22,7 @@ class Organizations(OutputBase):
         self.get_all_organization_details()
 
     def get_organization_details(self, org_name: str):
-        res = requests.post(self.org_url, data={"id": org_name})
+        res = session.post(self.org_url, data={"id": org_name})
         if res.ok:
             return res.json()["result"]
 
@@ -32,7 +32,7 @@ class Organizations(OutputBase):
                 return extra["value"]
 
     def get_organization_list(self):
-        res = requests.get(self.org_list_url)
+        res = session.get(self.org_list_url)
         res.raise_for_status()
 
         data = res.json()

--- a/scripts/qa.py
+++ b/scripts/qa.py
@@ -1,5 +1,6 @@
 import enum
 import logging
+import os
 from functools import wraps
 from pathlib import Path
 from time import time
@@ -63,6 +64,15 @@ class Job(enum.StrEnum):
 )
 @timing
 def process_job(job_type: str, seed: int, sample_size: int):
+    username = os.getenv("DATAGOV_BASIC_AUTH_USER")
+    password = os.getenv("DATAGOV_BASIC_AUTH_PASS")
+
+    if not all([username, password]):
+        logger.critical(
+            "basic auth credentials for catalog need to be set as env vars. exiting."
+        )
+        return
+
     if job_type == Job.all:
         compare_organizations(OUTPUT_DIR)
         compare_harvest_sources(OUTPUT_DIR)


### PR DESCRIPTION
# Pull Request

Related to [#5274](https://github.com/GSA/data.gov/issues/5274)

## About
- add a manual dispatch action for running the QA script. zips the output and archives it in the action as `qa_archive`
- basic auth has been put in front of all catalog-next instances so i configured a requests session with those credentials on every request in the qa script
- apparently the action won't show up until it's on the default branch (main) which seems odd that i have to debug it (if something breaks) after it's merged in (maybe i'm not doing something right?)

## PR TASKS

- [x] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
