### PR TITLE
Don't include resources without urls

### DIFF
--- a/app/filters.py
+++ b/app/filters.py
@@ -1,5 +1,5 @@
-
 import datetime
+
 
 def usa_icon(str):
     # ruff: noqa: E501

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -824,7 +824,9 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
         # if we didn't find either of the url_keys don't
         # include this resource https://github.com/GSA/data.gov/issues/5322
         if "url" not in resource:
-            logger.info("Not including resource that doesn't contain accessURL or downloadURL")
+            logger.info(
+                "Not including resource that doesn't contain accessURL or downloadURL"
+            )
             continue
 
         output.append(resource)

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -825,7 +825,9 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
         # include this resource https://github.com/GSA/data.gov/issues/5322
         if "url" not in resource:
             logger.info(
-                "Not including resource that doesn't contain accessURL or downloadURL"
+                "Not including resource that doesn't contain accessURL "
+                "or downloadURL for identifier %s",
+                metadata.get("identifier"),
             )
             continue
 

--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -821,6 +821,12 @@ def create_ckan_resources(metadata: dict) -> list[dict]:
             # if we know the mimetype add the other details
             if resource["mimetype"]:
                 change_resource_details(resource=resource)
+        # if we didn't find either of the url_keys don't
+        # include this resource https://github.com/GSA/data.gov/issues/5322
+        if "url" not in resource:
+            logger.info("Not including resource that doesn't contain accessURL or downloadURL")
+            continue
+
         output.append(resource)
 
     return output

--- a/tests/badges/unit/coverage.svg
+++ b/tests/badges/unit/coverage.svg
@@ -5,7 +5,7 @@
     width="92.5"
     height="20"
     role="img"
-    aria-label="coverage: 51%"
+    aria-label="coverage: 54%"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>coverage: 51%</title>
+    <title>coverage: 54%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(60.0 0)">
             <rect width="32.5" fill="#dfb317"/>
-            <text x="16.25" y="10.0" class="shadow">51%</text>
-            <text x="16.25" y="10.0">51%</text>
+            <text x="16.25" y="10.0" class="shadow">54%</text>
+            <text x="16.25" y="10.0">54%</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/unit/tests.svg
+++ b/tests/badges/unit/tests.svg
@@ -5,7 +5,7 @@
     width="62.5"
     height="20"
     role="img"
-    aria-label="tests: 63"
+    aria-label="tests: 65"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 63</title>
+    <title>tests: 65</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="25.0" fill="#4c1"/>
-            <text x="12.5" y="10.0" class="shadow">63</text>
-            <text x="12.5" y="10.0">63</text>
+            <text x="12.5" y="10.0" class="shadow">65</text>
+            <text x="12.5" y="10.0">65</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,6 +7,7 @@ from jsonschema import Draft202012Validator, FormatChecker
 
 from harvester.utils.ckan_utils import (
     create_ckan_extras,
+    create_ckan_resources,
     create_ckan_tags,
     munge_spatial,
     munge_tag,
@@ -321,6 +322,18 @@ class TestCKANUtils:
 
         access_level = list(filter(lambda e: e["key"] == "accessLevel", extras))[0]
         assert access_level["value"] == "public"
+
+    def test_create_ckan_resources(self, dol_distribution_json):
+        resources = create_ckan_resources(dol_distribution_json)
+        assert len(resources) == 5 # four distribution and one landingPage
+
+    def test_create_ckan_resources_missing_accessurl(
+        self, dol_distribution_json, caplog
+    ):
+        del dol_distribution_json["distribution"][0]["downloadURL"]
+        resources = create_ckan_resources(dol_distribution_json)
+        assert len(resources) == 4  # 3 valid distribution and one landingPage
+        assert "Not including" in caplog.text
 
 
 # Point example

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -325,7 +325,7 @@ class TestCKANUtils:
 
     def test_create_ckan_resources(self, dol_distribution_json):
         resources = create_ckan_resources(dol_distribution_json)
-        assert len(resources) == 5 # four distribution and one landingPage
+        assert len(resources) == 5  # four distribution and one landingPage
 
     def test_create_ckan_resources_missing_accessurl(
         self, dol_distribution_json, caplog


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5322, we were seeing errors where we tried to create CKAN packages that had "resources" with no `url` at all. This fixes the harvester to skip those resources that don't have either `accessURL` or `downloadURL`.

## About

This logs when this case happens, but doesn't register a record error. If we do get a facility to add "warnings" for catalog producers, it might be nice to include a warning here that they have a value in `distribution[]` that is invalid.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
