### PR TITLE
fix pagination for metrics and harvest source jobs

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -587,6 +587,7 @@ def view_harvest_source(source_id: str):
     htmx_vars = {
         "target_div": "#paginated__harvest-jobs",
         "endpoint_url": f"/harvest_source/{source_id}",
+        "page_param": "page",
     }
     harvest_jobs_facets = (
         f"harvest_source_id = '{source_id}' AND date_created <= '{get_datetime()}'"

--- a/app/templates/components/pagination/pagination_arrow.html
+++ b/app/templates/components/pagination/pagination_arrow.html
@@ -3,7 +3,7 @@
   #}
   {% macro pagination_arrow(direction, pagination, htmx_vars) %}
     {% set page_var = ((pagination.current - 1) if direction == 'previous' else (pagination.current + 1)) | string() %}
-    {% set placeholder_link = htmx_vars.endpoint_url + "?page=" + page_var %}
+    {% set placeholder_link = htmx_vars.endpoint_url ~ "?" ~ htmx_vars.page_param ~ "=" ~ page_var %}
 
     {% set link_attrs = {
       'class': 'usa-pagination__link usa-pagination__'  ~ direction ~ '-page',

--- a/app/templates/view_source_data.html
+++ b/app/templates/view_source_data.html
@@ -115,7 +115,9 @@
         <canvas id="datagov-line-chart" height="200"></canvas>
         {% block htmx_paginated %}
         <div id="paginated__harvest-jobs">
-            {{ job_table.job_table(data.jobs, "Harvest Jobs for Harvest Source: " + data.source.name, show_source=false) }}
+            <!-- job_table is undefined on pagination so importing here -->
+            {% import 'components/job-table/job_table.j2' as job_table %}
+            {{ job_table.job_table(data.jobs, "Harvest Jobs for Harvest Source: " + data.source.id, show_source=false) }}
             {% if pagination.count > data.jobs|count %}
             {% include '/components/pagination/pagination.html' %}
             {% endif %}


### PR DESCRIPTION
# Pull Request

Related to [#5355](https://github.com/GSA/data.gov/issues/5355)

## About
- fixes pagination on metrics tables [on dev](https://datagov-harvest-dev.app.cloud.gov/metrics/) vs [on staging](https://datagov-harvest-staging.app.cloud.gov/metrics/) and harvest source job table ([example](https://datagov-harvest-dev.app.cloud.gov/harvest_source/967c8acb-7171-48bb-93e2-f5b221d34d36)). since i've already deployed the fix to dev and there aren't enough job records per harvest source for pagination you'll need to check job pagination on the harvest source page locally.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
