### PR TITLE
Check for more work even if failure

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -953,4 +953,5 @@ if __name__ == "__main__":
         check_for_more_work()
     except Exception as e:
         logger.error(f"Harvest has experienced an error :: {repr(e)}")
+        check_for_more_work()
         sys.exit(1)


### PR DESCRIPTION
Even if the job fails, it should still check for more work so the slot can be filled.

# Pull Request

Related to https://github.com/GSA/data.gov/issues/5373

## About

Noticed in real time, multiple failures resulted in harvester not running for long periods.

## PR TASKS

- [ ] ~Code well documented~
- [ ] ~Tests written, run and passed~
- [ ] ~Files linted~
