### PR TITLE
fix clear job

### DIFF
--- a/tests/integration/harvest_job_flows/test_harvest_job_clear.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_clear.py
@@ -32,7 +32,8 @@ class TestHarvestJobClear:
         harvest_job = interface.get_harvest_job(job_id)
         assert harvest_job.status == "complete"
         assert harvest_job.records_added == 7
-
+        # - 1 ckan call from close_conection
+        assert len(CKANMock.method_calls) - 1 == harvest_job.records_added
         records_from_db = interface.get_latest_harvest_records_by_source(
             source_data_dcatus["id"]
         )
@@ -55,6 +56,9 @@ class TestHarvestJobClear:
         harvest_job = interface.get_harvest_job(job_id)
         assert harvest_job.status == "complete"
         assert harvest_job.records_deleted == 7
+        # 9 = 7 package creates + 1 close connection on harvest
+        # + 1 close connection on clear
+        assert len(CKANMock.method_calls) - 9 == harvest_job.records_deleted
         records_from_db = interface.get_latest_harvest_records_by_source(
             source_data_dcatus["id"]
         )


### PR DESCRIPTION
# Pull Request

Related to [#5358](https://github.com/GSA/data.gov/issues/5358)

## About
- fixes clear helper job
- removes unneeded `make_record_contract` function. the clear helper was the only thing using it.
- test [cleared harvest source](https://datagov-harvest-dev.app.cloud.gov/harvest_job/8e6f58fe-54c3-4e75-b1c9-a8db5701bf2d). 

here's the harvest record id and ckan id of the cleared records on dev
```terminal
                  id                  |               ckan_id                
--------------------------------------+--------------------------------------
 beb422ed-42cd-4956-8236-7c9ddd01a2e8 | aa2faa44-f2d2-41f8-b579-e032fbb243a6
 43c1c5e9-2e8f-46f6-97e3-07e135d0cf7a | 0613fd93-1317-4f55-9030-0e3efc21f0a1
 1277d4f1-8a0e-45ac-b002-ace0d8779c5a | 3cfd6d3e-c265-4e89-88ef-0c17c7e47142
 f0cc0b3f-e5a2-41c8-b967-206d7a0a4e36 | 46846381-fe05-4c06-8296-2fafefc253fe
 42d59b30-9481-49fc-ac00-5cee7c29491d | 612e91ba-2f22-4f8e-95fa-d70e0ec38c7e
 0f74bbc6-1de0-4498-9156-317a79225463 | f1a4fe62-1bd8-4ac0-88b2-f037cd1ca719
```

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
