### PR TITLE
handle ExternalRecordToClass

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -404,6 +404,8 @@ class HarvestSource:
         except (ExtractInternalException, ExtractExternalException):
             self.finish_job_with_status("error")
             return
+        except ExternalRecordToClass:
+            pass
 
     def finish_job_with_status(self, status: str):
         """
@@ -630,7 +632,6 @@ class Record:
             self.validate()
             self.sync()
         except (
-            ExternalRecordToClass,
             CompareException,
             TransformationException,
         ):


### PR DESCRIPTION
# Pull Request

Related to [LINK TO ISSUE]

## About
- some jobs have errored out because of this unhandled exception. 
- passing because there's nothing else that needs doing. we can consider changing how we're doing exception handling post-mvp.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
