### PR TITLE
fix datetime UI

### DIFF
--- a/app/static/js/datetime.js
+++ b/app/static/js/datetime.js
@@ -1,0 +1,53 @@
+// Convert UTC dates to local timezone
+function convertUTCDatesToLocal(container) {
+  // Find all date cells with UTC timestamps within the container (or document if no container)
+  const searchRoot = container || document;
+  const dateCells = searchRoot.querySelectorAll(".utc-date[data-utc-date]");
+  const localFormat = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZoneName: "shortOffset",
+  });
+
+  dateCells.forEach(function (cell) {
+    // Skip if already converted (to avoid double conversion)
+    if (cell.hasAttribute("data-converted")) return;
+
+    const utcDateString = cell.getAttribute("data-utc-date");
+    if (!utcDateString) return;
+
+    const dateObject = new Date(Date.parse(utcDateString));
+    if (isNaN(dateObject)) return;
+
+    const parts = localFormat.formatToParts(dateObject);
+    const partValues = parts.map((p) => p.value);
+
+    // a.m. to A.M.
+    partValues[10] = partValues[10].toUpperCase();
+    // put timezone info in parentheses
+    partValues[12] = "(" + partValues[12] + ")";
+
+    cell.textContent = partValues.join("").replaceAll(".", "").replace(",", "");
+
+    cell.setAttribute("data-converted", "true");
+  });
+}
+
+// Convert dates on initial page load
+document.addEventListener("DOMContentLoaded", function () {
+  convertUTCDatesToLocal();
+});
+
+// Convert dates after HTMX content is loaded
+document.addEventListener("htmx:afterSwap", function (event) {
+  // Convert dates in the newly swapped content
+  convertUTCDatesToLocal(event.detail.target);
+});
+
+// Also handle htmx:load event for broader compatibility
+document.addEventListener("htmx:load", function (event) {
+  convertUTCDatesToLocal(event.detail.elt);
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
   <script src="{{ url_for('static', filename='assets/uswds/js/uswds-init.js') }}"></script>
   <script src="{{ url_for('static', filename='assets/htmx/htmx.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/datetime.js') }}"></script>
   {% block script_head %}
   {% endblock %}
 </head>

--- a/app/templates/components/job-table/job_table.j2
+++ b/app/templates/components/job-table/job_table.j2
@@ -63,54 +63,5 @@
     </table>
     <div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>
 </div>
-
-<script>
-// Convert UTC dates to local timezone
-function convertUTCDatesToLocal(container) {
-    // Find all date cells with UTC timestamps within the container (or document if no container)
-    const searchRoot = container || document;
-    const dateCells = searchRoot.querySelectorAll('.utc-date[data-utc-date]');
-    const localFormat = new Intl.DateTimeFormat(undefined,
-      {
-        year: "numeric",
-        month: "numeric",
-        day: "numeric",
-        hour: "numeric",
-        minute: "numeric",
-        hour12: false,
-      }
-    );
-
-    dateCells.forEach(function(cell) {
-        // Skip if already converted (to avoid double conversion)
-        if (cell.hasAttribute('data-converted')) return;
-
-        const utcDateString = cell.getAttribute('data-utc-date');
-        if (!utcDateString) return;
-
-        const dateObject = new Date(Date.parse(utcDateString));
-        if (isNaN(dateObject)) return;
-
-        cell.textContent = localFormat.format(dateObject);
-        cell.setAttribute('data-converted', 'true');
-    });
-}
-
-// Convert dates on initial page load
-document.addEventListener('DOMContentLoaded', function() {
-    convertUTCDatesToLocal();
-});
-
-// Convert dates after HTMX content is loaded
-document.addEventListener('htmx:afterSwap', function(event) {
-    // Convert dates in the newly swapped content
-    convertUTCDatesToLocal(event.detail.target);
-});
-
-// Also handle htmx:load event for broader compatibility
-document.addEventListener('htmx:load', function(event) {
-    convertUTCDatesToLocal(event.detail.elt);
-});
-</script>
 {% endmacro -%}
 

--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -25,6 +25,11 @@
                 {% if key == 'harvest_source_id' %}
                 <td>Harvest Source:</td>
                 <td><a href="{{ url_for('main.view_harvest_source', source_id=value) }}">{{data.job.source.name}}</a></td>
+                {% elif key == 'date_created' or key == 'date_finished' %}
+                <td>{{key}}:</td>
+                <td class="utc-date" data-utc-date="{{ value | utc_isoformat }}">
+                    {{ value | else_na }}
+                </td>
                 {% else %}
                 <td>{{key}}:</td>
                 <td>{{value}}</td>
@@ -67,7 +72,9 @@
                 <tbody>
                     {% for errors in data.job.errors %}
                     <tr>
-                        <td> {{errors.date_created | utc_isoformat }}</td>
+                        <td class="utc-date" data-utc-date="{{ errors.date_created | utc_isoformat }}">
+                            {{ errors.date_created | else_na }}
+                        </td>
                         <td>{{errors.id}}</td>
                         <td>{{errors.type}}</td>
                         <td>{{errors.message}}</td>
@@ -111,7 +118,9 @@
                         </p>
                         <p><strong>Error Message:</strong> {{ record_error.error.message }}</p>
                         <p><strong>Type:</strong> {{ record_error.error.type }}</p>
-                        <p><strong>Date Created:</strong> {{ record_error.error.date_created | utc_isoformat }}</p>
+                        <p class="utc-date" data-utc-date="{{record_error.error.date_created | utc_isoformat }}">
+                            <strong>Date Created:</strong> {{ record_error.error.date_created | else_na }}
+                        </p>
                     </div>
                     {% endfor %}
                 </div>

--- a/app/templates/view_org_data.html
+++ b/app/templates/view_org_data.html
@@ -82,7 +82,13 @@
                             N/A
                             {% endif %}
                         </td>
-                        <td scope="row" class="text-center">{{data.future_harvest_jobs[source.id] | else_na}}</td>
+                        {% if data.future_harvest_jobs[source.id] %}
+                        <td class="utc-date" data-utc-date="{{ data.future_harvest_jobs[source.id] | utc_isoformat }}">
+                            {{ data.future_harvest_jobs[source.id] | else_na }}
+                        </td>
+                        {% else %}
+                        <td>N/A</td>
+                        {% endif %}
                         <td data-sort-value={{source.records_updated}}>{{source.source_type}}</td>
                         <td data-sort-value={{source.records_deleted}}>{{source.frequency}}</td>
                         <td data-sort-value={{source.date_finished}}>{{source.notification_emails}} </td>


### PR DESCRIPTION
# Pull Request

Related to [#5360](https://github.com/GSA/data.gov/issues/5360)

## About
- isolate datetime logic as static js asset
- localize dateteimes on job pages
- all datetimes in the UI will be in this format.

## local UI
<img width="636" height="124" alt="Screenshot 2025-08-13 at 12 42 32 PM" src="https://github.com/user-attachments/assets/6a23dbd2-1518-42c5-ba1f-9bd49110cdad" />


## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
