### PR TITLE
use https for mdtranslator

### DIFF
--- a/vars.development.yml
+++ b/vars.development.yml
@@ -11,7 +11,7 @@ CKAN_API_URL: https://catalog-next-dev-admin-datagov.app.cloud.gov
 HARVEST_RUNNER_MAX_TASKS: 4
 HARVEST_RETRY_ON_ERROR: true
 
-MDTRANSLATOR_URL: http://mdtranslator-development.apps.internal:8080/translates
+MDTRANSLATOR_URL: https://mdtranslator-development.apps.internal:61443/translates
 
 # Login.gov
 CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:datagov-dev-harvest-admin

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -12,7 +12,7 @@ CKAN_API_URL: https://catalog-next-prod-admin-datagov.app.cloud.gov
 HARVEST_RUNNER_MAX_TASKS: 3
 HARVEST_RETRY_ON_ERROR: true
 
-MDTRANSLATOR_URL: http://mdtranslator-prod.apps.internal:8080/translates
+MDTRANSLATOR_URL: https://mdtranslator-prod.apps.internal:61443/translates
 
 # Login.gov
 CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:datagov-prod-harvest-admin

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -12,7 +12,7 @@ CKAN_API_URL: https://catalog-next-stage-admin-datagov.app.cloud.gov
 HARVEST_RUNNER_MAX_TASKS: 3
 HARVEST_RETRY_ON_ERROR: true
 
-MDTRANSLATOR_URL: http://mdtranslator-staging.apps.internal:8080/translates
+MDTRANSLATOR_URL: https://mdtranslator-staging.apps.internal:61443/translates
 
 # Login.gov
 CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:datagov-staging-harvest-admin


### PR DESCRIPTION
## About

Use HTTPS instead of HTTP for mdtranslator traffic.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
