### PR TITLE
Add date formatting to source page

### DIFF
--- a/app/templates/view_source_data.html
+++ b/app/templates/view_source_data.html
@@ -95,13 +95,13 @@
             </tr>
             <tr>
                 <td>Last Job Finished:</td>
-                <td>
+                <td class="utc-date" data-utc-date="{{ data.summary_data['last_job_finished'] | utc_isoformat }}">
                     {{data.summary_data["last_job_finished"] | else_na }}
                 </td>
             </tr>
             <tr>
                 <td>Next Job Scheduled:</td>
-                <td>
+                <td class="utc-date" data-utc-date="{{ data.summary_data['next_job_scheduled'] | utc_isoformat }}">
                     {{data.summary_data["next_job_scheduled"] | else_na }}
                 </td>
             </tr>

--- a/scripts/lib/qa/datasets.py
+++ b/scripts/lib/qa/datasets.py
@@ -62,11 +62,7 @@ class Datasets(OutputBase):
         fq = "collection_package_id:*%20OR%20"
         if "beta" in self.base_url:
             fq = "include_collection:true"
-        res = session.get(
-            (
-                f"{self.base_url}/api/action/package_search?fq={fq}"
-            )
-        )
+        res = session.get((f"{self.base_url}/api/action/package_search?fq={fq}"))
         res.raise_for_status()
         return res.json()["result"]["count"]
 


### PR DESCRIPTION
# Pull Request

Found when reviewing https://github.com/GSA/data.gov/issues/5311

## About

Just integrating a missing change, nothing to crazy. I tried to write a test for this, but since there are already other date-time objects on this page working correctly and the test data is dynamically generated there isn't an easy way to validate. Screenshot of local should suffice.
<img width="1147" height="577" alt="image" src="https://github.com/user-attachments/assets/69d4639c-203f-41c9-9d0c-29e6244e3702" />


## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
