### PR TITLE
add specific exception handling for download file

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -16,6 +16,7 @@ from uuid import UUID
 
 import geojson_validator
 import requests
+import http
 import sansjson
 import sqlalchemy.sql.operators as sa_operators
 from bs4 import BeautifulSoup
@@ -102,14 +103,17 @@ def open_json(file_path):
 def download_file(url: str, file_type: str) -> Union[str, dict]:
     # ruff: noqa: E501
     headers = {"User-Agent": USER_AGENT}
-    resp = requests.get(url, headers=headers)
-    if 200 <= resp.status_code < 300:
-        if file_type == ".xml":
-            data = resp.content
-            if isinstance(data, bytes):
-                data = data.decode()
-            return data
-        return resp.json()
+    try:
+        resp = requests.get(url, headers=headers)
+        if 200 <= resp.status_code < 300:
+            if file_type == ".xml":
+                data = resp.content
+                if isinstance(data, bytes):
+                    data = data.decode()
+                return data
+            return resp.json()
+    except (http.client.RemoteDisconnected, requests.exceptions.ConnectionError) as e:
+        raise e
 
     raise Exception
 


### PR DESCRIPTION
# Pull Request

## About
- there shouldn't be any uncaught exceptions in the harvest runner.
- this [job](https://datagov-harvest-dev.app.cloud.gov/harvest_job/98b77d64-5350-4f9f-bfe7-a2cabed57bc1) threw an unexpected exception and was picked up on app restart job cleanup. 
- investigation of logs during that [time period](https://one.newrelic.com/logger?account=1601367&begin=1756249800000&end=1756251000000&state=637b88ca-3011-b5fc-c649-6f161c29880c) shows unhandled exceptions concerning connection issues.

<!-- any pertinent notes -->

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
