### PR TITLE
make harvest source name field readonly on edit

### DIFF
--- a/app/templates/edit_data.html
+++ b/app/templates/edit_data.html
@@ -11,7 +11,11 @@
     {% for field in form if field.widget.input_type != 'hidden' %}
     <div class="form-group">
         {{field.label(class_='form-control-label')}}
-        {{field(class_='form-control')}}
+        {% if data_type == "Harvest Source" and action == "Edit" and field.id == 'name' %}
+            {{field(class_='form-control', readonly_=true)}}
+        {% else %}
+            {{field(class_='form-control')}}
+        {% endif %}
     </div>
     {% endfor %}
 

--- a/tests/playwright/test_harvest_create_and_destroy.py
+++ b/tests/playwright/test_harvest_create_and_destroy.py
@@ -76,6 +76,14 @@ class TestHarvestCreateAndDestroy:
         apage_with_org.get_by_role("listitem").filter(
             has_text="Test Source New Details"
         ).get_by_role("link").click()
+        apage_with_org.get_by_role("button", name="Edit", exact=True).click()
+        assert apage_with_org.locator("#name").get_attribute("readonly") is not None
+
+        apage_with_org.get_by_role("link", name="Harvest Sources").click()
+
+        apage_with_org.get_by_role("listitem").filter(
+            has_text="Test Source New Details"
+        ).get_by_role("link").click()
         apage_with_org.once("dialog", lambda dialog: dialog.accept())
         apage_with_org.get_by_role("button", name="Delete", exact=True).click()
         expect(apage_with_org.locator(".alert-warning")).to_contain_text(


### PR DESCRIPTION
# Pull Request

Related to [#5389](https://github.com/GSA/data.gov/issues/5389)

## About
 on [dev](https://datagov-harvest-dev.app.cloud.gov/harvest_source/edit/019a8e55-9ed8-4ed6-9451-51c176f86e28)

<img width="325" height="227" alt="Screenshot 2025-08-28 at 6 07 55 PM" src="https://github.com/user-attachments/assets/4cb90e4d-6895-4d07-ab4f-5bad4ae303ea" />

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
