### PR TITLE
handle decode exception

### DIFF
--- a/example_data/iso_2_waf/decode_error.xml
+++ b/example_data/iso_2_waf/decode_error.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+    <data>Valid text</data>
+    <data>Here’s a bad character: –</data>
+</root>

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -339,7 +339,7 @@ class HarvestSource:
                 del record
             except Exception as e:
                 self.reporter.update("errored")
-                raise ExternalRecordToClass(
+                ExternalRecordToClass(
                     f"{self.name} {self.url} failed to prepare record for harvest :: {repr(e)}",
                     self.job_id,
                     None,  # there is no record id to associate
@@ -421,8 +421,6 @@ class HarvestSource:
         except (ExtractInternalException, ExtractExternalException):
             self.finish_job_with_status("error")
             return
-        except ExternalRecordToClass:
-            pass
 
     def finish_job_with_status(self, status: str):
         """

--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -114,6 +114,8 @@ def download_file(url: str, file_type: str) -> Union[str, dict]:
             return resp.json()
     except (http.client.RemoteDisconnected, requests.exceptions.ConnectionError) as e:
         raise e
+    except UnicodeDecodeError as e:
+        raise e
 
     raise Exception
 

--- a/tests/integration/harvest/test_transform.py
+++ b/tests/integration/harvest/test_transform.py
@@ -49,6 +49,10 @@ class TestTransform:
         )
 
         job_errors = interface.get_harvest_record_errors_by_job(harvest_job.id)
+
+        # 'ExternalRecordToClass' caused by decoding error. not needed for this test.
+        del job_errors[0]
+
         assert len(job_errors) == 1
         assert job_errors[0][0].message == expected_error_msg
 

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -226,6 +226,10 @@ class TestValidateDataset:
                 valid_iso_2_record.harvest_source.job_id
             )
         ]
+        
+        # 'ExternalRecordToClass' caused by decoding error. not needed for this test.
+        del errors[0]
+
         assert (
             errors[0].message
             == """<ValidationError: "$, 'contactPoint' is a required property">"""
@@ -249,6 +253,9 @@ class TestValidateDataset:
                 valid_iso_2_too_many_keywords_record.harvest_source.job_id
             )
         ]
+
+        # 'ExternalRecordToClass' caused by decoding error. not needed for this test.
+        del errors[0]
 
         assert len(errors) == 1
 

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -133,12 +133,18 @@ class TestHarvestJobFullFlow:
         # assert job rollup
         assert harvest_job.status == "complete"
         assert harvest_job.records_total == 4
-        assert len(harvest_job.record_errors) == 2
-        assert harvest_job.records_errored == 2
+        assert len(harvest_job.record_errors) == 3
+        assert harvest_job.records_errored == 3
 
         # assert error insertion order
         errors = interface.get_harvest_record_errors_by_job(job_id)
-        assert errors[0][0].type == "TransformationException"
+        # the first doc ("decode_error.xml") throws a decoding error and since we can't fetch the doc
+        # there's no record to associate it to so checking to make sure the error
+        # exists and the message is what we expect then we remove it so the
+        # proceeeding assertions work as intended.
+        assert errors[0][0].type == "ExternalRecordToClass"
+        assert "UnicodeDecodeError" in errors[0][0].message
+        del errors[0]
 
         # assert harvest_record_id & type match
         for error in errors:
@@ -409,7 +415,6 @@ class TestHarvestJobFullFlow:
 
 
 class TestCheckMoreWork:
-
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
     def test_check_more_work(
         self, CFCMock, interface, organization_data, source_data_dcatus_single_record


### PR DESCRIPTION
# Pull Request
- [job](https://harvest.data.gov/harvest_job/4204b31b-be2f-4b73-a21e-892b9ef1ef5f) stopped early because of decoding error on [record](https://meta.geo.census.gov/data/existing/decennial/GEO/GPMB/TIGERline/TIGER2015/featnames/tl_2015_72131_featnames.dbf.iso.xml). 

## About
- removed raise of `ExternalRecordToClass` allows record processing to continue. i tried a couple of try/except wrappers in the parent/calling function but couldn't get anything to work. 
- add new decode error fixture (encoded it in Windows 1252) and update tests to handle it

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
