### PR TITLE
Use unchanged instead of ignored in UI elements

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -778,7 +778,7 @@ def view_harvest_source(source_id: str):
                     "backgroundColor": "red",
                 },
                 {
-                    "label": "Ignored",
+                    "label": "Unchanged",
                     "data": chart_data_values["records_ignored"],
                     "borderColor": "grey",
                     "backgroundColor": "grey",

--- a/app/templates/components/job-table/job_table.j2
+++ b/app/templates/components/job-table/job_table.j2
@@ -14,7 +14,7 @@
                 <th scope="col" title="Records Updated">Updated</th>
                 <th scope="col" title="Records Deleted">Deleted</th>
                 <th scope="col" title="Records Errored">Errored</th>
-                <th scope="col" title="Records Unchanged and Ignored">Unchanged</th>
+                <th scope="col" title="Records Unchanged">Unchanged</th>
             </tr>
         </thead>
         <tbody id="paginated_harvest_jobs">

--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -30,6 +30,9 @@
                 <td class="utc-date" data-utc-date="{{ value | utc_isoformat }}">
                     {{ value | else_na }}
                 </td>
+                {% elif key == 'records_ignored' %}
+                <td>records_unchanged:</td>
+                <td>{{value}}</td>
                 {% else %}
                 <td>{{key}}:</td>
                 <td>{{value}}</td>

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -472,7 +472,7 @@ class HarvestSource:
                 f"- Records Added: {job_results['records_added']}\n"
                 f"- Records Updated: {job_results['records_updated']}\n"
                 f"- Records Deleted: {job_results['records_deleted']}\n"
-                f"- Records Ignored: {job_results['records_ignored']}\n"
+                f"- Records Unchanged: {job_results['records_ignored']}\n"
                 f"- Records Errored: {job_results['records_errored']}\n"
                 f"- Records Validated: {job_results['records_validated']}\n\n"
                 "====\n"

--- a/tests/badges/integration/coverage.svg
+++ b/tests/badges/integration/coverage.svg
@@ -5,7 +5,7 @@
     width="92.5"
     height="20"
     role="img"
-    aria-label="coverage: 83%"
+    aria-label="coverage: 84%"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>coverage: 83%</title>
+    <title>coverage: 84%</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(60.0 0)">
             <rect width="32.5" fill="#a4a61d"/>
-            <text x="16.25" y="10.0" class="shadow">83%</text>
-            <text x="16.25" y="10.0">83%</text>
+            <text x="16.25" y="10.0" class="shadow">84%</text>
+            <text x="16.25" y="10.0">84%</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/integration/tests.svg
+++ b/tests/badges/integration/tests.svg
@@ -2,10 +2,10 @@
 <svg
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    width="100.0"
+    width="70.0"
     height="20"
     role="img"
-    aria-label="tests: 140/144"
+    aria-label="tests: 145"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 140/144</title>
+    <title>tests: 145</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -41,9 +41,9 @@
             <text x="18.75" y="10.0">tests</text>
         </g>
         <g transform="translate(37.5 0)">
-            <rect width="62.5" fill="#9f9f9f"/>
-            <text x="31.25" y="10.0" class="shadow">140/144</text>
-            <text x="31.25" y="10.0">140/144</text>
+            <rect width="32.5" fill="#4c1"/>
+            <text x="16.25" y="10.0" class="shadow">145</text>
+            <text x="16.25" y="10.0">145</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/badges/unit/tests.svg
+++ b/tests/badges/unit/tests.svg
@@ -5,7 +5,7 @@
     width="62.5"
     height="20"
     role="img"
-    aria-label="tests: 84"
+    aria-label="tests: 85"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 84</title>
+    <title>tests: 85</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="25.0" fill="#4c1"/>
-            <text x="12.5" y="10.0" class="shadow">84</text>
-            <text x="12.5" y="10.0">84</text>
+            <text x="12.5" y="10.0" class="shadow">85</text>
+            <text x="12.5" y="10.0">85</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/playwright/test_harvest_job.py
+++ b/tests/playwright/test_harvest_job.py
@@ -37,7 +37,7 @@ class TestHarvestSourceUnauthed:
         expect(table).to_contain_text("records_deleted:")
         expect(table).to_contain_text("records_errored:")
         expect(table).to_contain_text("8")
-        expect(table).to_contain_text("records_ignored:")
+        expect(table).to_contain_text("records_unchanged:")
         expect(table).to_contain_text("records_validated:")
         expect(table).to_contain_text("id:")
         expect(table).to_contain_text("6bce761c-7a39-41c1-ac73-94234c139c76")


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#5288, this changes the UI language for dataset records that haven't changed since the last harvest from "ignored" to "unchanged". This is the minimal intervention, I didn't change anything at the database level, I only changed the visible language in harvest emails, the job view page, and the harvest source chart. At this point, I think that this is a better mix of effort/reward than renaming fields in the database.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
