### PR TITLE
Use url_for in redirects

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -898,7 +898,7 @@ def trigger_harvest_source(source_id, job_type):
         return JSON_NOT_FOUND()
     message = load_manager.trigger_manual_job(source_id, job_type)
     flash(message)
-    return redirect(f"/harvest_source/{source_id}")
+    return redirect(url_for("main.view_harvest_source", source_id=source_id))
 
 
 ## Harvest Job
@@ -1013,7 +1013,7 @@ def cancel_harvest_job(job_id):
         return redirect("/")
     message = load_manager.stop_job(job_id)
     flash(message)
-    return redirect(f"/harvest_job/{job_id}")
+    return redirect(url_for("main.view_harvest_job", job_id=job_id))
 
 
 ### Download all errors for a given job

--- a/tests/playwright/test_harvest_source.py
+++ b/tests/playwright/test_harvest_source.py
@@ -78,7 +78,6 @@ class TestHarvestSourceUnauthed:
     @pytest.mark.parametrize(
         "data_term_name, glossary_term_name",
         [
-            ("notification emails", "Notification emails"),
             ("frequency", "frequency"),
             ("schema_type", "schema_type"),
             ("source_type", "source_type"),


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#5368 fixes our use of string interpolation in creating URL redirects, restoring the pattern that we use elsewhere in this file.

## About

I fixed the two occurrences I could find in this file, I hope this will fix the finding.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
