### PR TITLE
update job reporter action counting

### DIFF
--- a/harvester/utils/ckan_utils.py
+++ b/harvester/utils/ckan_utils.py
@@ -137,14 +137,6 @@ class CKANSyncTool:
         )
         record.status = "success"
 
-        # update harvest reporter
-        record.harvest_source.reporter.update(record.action)
-
-        # # update harvest job
-        record.harvest_source.db_interface.update_harvest_job(
-            record.harvest_source.job_id, record.harvest_source.reporter.report()
-        )
-
         return True
 
     def create_record(self, record, retry=False) -> dict:

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -132,7 +132,7 @@ class TestHarvestJobFullFlow:
 
         # assert job rollup
         assert harvest_job.status == "complete"
-        assert harvest_job.records_total == 4
+        assert harvest_job.records_total == 5
         assert len(harvest_job.record_errors) == 3
         assert harvest_job.records_errored == 3
 


### PR DESCRIPTION
# Pull Request

Related to [#5426](https://github.com/GSA/data.gov/issues/5426)

## About
- add `HarvestSource` method for updating reporter action counter per record and updates the current job with the latest counts. this update includes record errors now instead of just records added, deleted, and updated. 
- centralize all counting logic to harvest.py
- record total is immediate instead of reported at the end
- progress bar is fixed
- change is live on dev. test [source](https://datagov-harvest-dev.app.cloud.gov/harvest_job/eafdaa22-cb7e-4f56-bfc0-1a8b6f54302c).

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
