### PR TITLE
add progress bar to "in_progress" jobs

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1331,6 +1331,10 @@ def view_metrics():
             facets="status eq in_progress",
             order_by="desc",
         )
+
+        for job in current_jobs:
+            job.percent_complete = process_job_complete_percentage(job.to_dict())
+
         data = {
             "current_jobs": current_jobs,
             "jobs": jobs,

--- a/app/static/_scss/_uswds-theme-custom-styles.scss
+++ b/app/static/_scss/_uswds-theme-custom-styles.scss
@@ -25,6 +25,7 @@ i.e.
 @import "components/glossary";
 @import "components/icons";
 @import "components/blockview";
+@import "components/progress_bar";
 
 ul.menu {
   padding-inline-start: 0;

--- a/app/static/_scss/components/_progress_bar.scss
+++ b/app/static/_scss/components/_progress_bar.scss
@@ -1,0 +1,37 @@
+.progress-meter {
+  display: block;
+  height: 10px;
+  box-shadow: color("shadow-2");
+  border-radius: 5px;
+  padding: 1px;
+  margin-right: 2rem;
+  position: relative;
+}
+
+.progress-percent {
+  display: block;
+  height: 100%;
+  border-radius: 5px;
+  width: calc(var(--progress) * 1%); 
+  background-color: color("bg-green");
+  font-size: 85%;
+  color: black;
+}
+
+.progress-percent[style="--progress: 0"] {
+  background-color: color("bg-white")
+}
+
+
+.progress-percent::after {
+  counter-reset: percent var(--progress);
+  content: counter(percent) '%';
+  position: absolute;
+  right: -2rem;
+  bottom: -0.3rem;
+}
+
+// progress bar on job page
+.table td:nth-child(2) {
+  vertical-align: middle;
+}

--- a/app/templates/components/job-table/job_table.j2
+++ b/app/templates/components/job-table/job_table.j2
@@ -1,4 +1,4 @@
-{% macro job_table(jobs, caption, show_source=true) -%}
+{% macro job_table(jobs, caption, show_source=true, show_progress=False) -%}
 <div class="usa-table-container" tabindex="0">
     <table class="usa-table usa-table--striped usa-table--borderless">
         <caption>{{ caption }}</caption>
@@ -7,6 +7,9 @@
                 <th scope="col" title="Job ID">Job ID</th>
                 {% if show_source %}<th scope="col" title="Harvest Source">Source</th>{% endif %}
                 <th scope="col" title="Job Status">Status</th>
+                {% if show_progress %}
+                    <th scope="col" title="Job Progress">Progress</th>
+                {% endif %}
                 <th scope="col" title="Job Type">Type</th>
                 <th scope="col" title="Start Date">Started</th>
                 <th scope="col" title="Completion Date">Finished</th>
@@ -45,6 +48,14 @@
                                         {% endif %}
                                         tablet:display-none">{{ job.status[:4] }}</span>
                 </td>
+                {% if show_progress %}
+                    <td>
+                        <div class="progress-meter">
+                            {# [:-1] slices off "%" #}
+                            <div class="progress-percent" style="--progress: {{ job.percent_complete[:-1] }}"></div>
+                        </div>
+                    </td>
+                {% endif %}
                 <td class="text-tabular">{{ job.job_type }}</td>
                 <td class="font-mono-sm utc-date" data-utc-date="{{ job.date_created | utc_isoformat }}">
                     {{ job.date_created | else_na}}

--- a/app/templates/metrics_dashboard.html
+++ b/app/templates/metrics_dashboard.html
@@ -13,7 +13,7 @@
       <h2>Jobs In Progress: {{ data.current_jobs | length }}</h2>
 
       {% if data.current_jobs %}
-      {{ job_table.job_table(data.current_jobs, "Jobs In Progress") }}
+      {{ job_table.job_table(data.current_jobs, "Jobs In Progress", show_progress=True) }}
       {% else %}
         <div class="usa-alert usa-alert--info">
             <div class="usa-alert__body">

--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -15,9 +15,14 @@
     <div class="config-table harvest-job-config-properties">
         <table class="table">
             {% if data['percent_complete'] %}
-            <tr class="bg-error-light">
+            <tr>
                 <td>Percent complete:</td>
-                <td>{{data['percent_complete']}}</td>
+                <td>
+                    <div class="progress-meter">
+                        <!-- [:-1] slices off "%" -->
+                        <div class="progress-percent" style="--progress: {{ data['percent_complete'][:-1] }}"></div>
+                    </div> 
+                </td>
             </tr>
             {% endif %}
             {% for key, value in data.job.to_dict().items() %}

--- a/tests/badges/playwright/tests.svg
+++ b/tests/badges/playwright/tests.svg
@@ -5,7 +5,7 @@
     width="62.5"
     height="20"
     role="img"
-    aria-label="tests: 35"
+    aria-label="tests: 45"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 35</title>
+    <title>tests: 45</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="25.0" fill="#4c1"/>
-            <text x="12.5" y="10.0" class="shadow">35</text>
-            <text x="12.5" y="10.0">35</text>
+            <text x="12.5" y="10.0" class="shadow">45</text>
+            <text x="12.5" y="10.0">45</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/playwright/test_harvest_job.py
+++ b/tests/playwright/test_harvest_job.py
@@ -22,6 +22,7 @@ class TestHarvestJobUnauthed:
         table = upage.locator(".harvest-job-config-properties table")
 
         # Test static content that should always be present
+        expect(table).not_to_contain_text("Percent complete:")  # job is not in progress
         expect(table).to_contain_text("Harvest Source:")
         expect(table).to_contain_text("Test Source")
         expect(table).to_contain_text("status:")
@@ -63,9 +64,9 @@ class TestHarvestJobUnauthed:
     def test_harvest_job_record_errors_summary(self, upage):
         expect(upage.locator("table#harvest-job-error-summary")).to_be_visible()
 
-        expect(
-            upage.locator("table#harvest-job-error-summary thead tr")
-        ).to_have_count(1)
+        expect(upage.locator("table#harvest-job-error-summary thead tr")).to_have_count(
+            1
+        )
         expect(
             upage.locator("table#harvest-job-error-summary tbody tr td")
         ).to_have_text(["TestException", "8", "ValidationException", "8"])

--- a/tests/playwright/test_metrics_display.py
+++ b/tests/playwright/test_metrics_display.py
@@ -15,7 +15,6 @@ def upage(
 
 
 class TestMetricsUnauthed:
-
     def test_new_jobs_exist(self, upage):
         """has scheduled jobs table"""
         expect(upage.locator("#jobs-to-harvest")).to_be_visible()
@@ -33,3 +32,13 @@ class TestMetricsUnauthed:
     def test_failed_jobs_exist(self, upage):
         """has failed jobs section"""
         expect(upage.locator("#recent-failed-jobs")).to_be_visible()
+
+    def test_jobs_in_progress(self, upage):
+        """has "Jobs in Progress" table and progress bar checks"""
+        expect(upage.locator("#jobs-harvesting")).to_be_visible()
+
+        expect(upage.locator(".progress-meter")).to_have_count(1)
+        assert (
+            upage.locator(".progress-percent").get_attribute("style")
+            == "--progress: 0"  # 0% completion
+        )


### PR DESCRIPTION
# Pull Request

Related to [#5438](https://github.com/GSA/data.gov/issues/5438)

## About
- adds progress bar to "in_progress" job on metrics page and replaces progress table data on job page
- update are live on [dev](https://datagov-harvest-dev.app.cloud.gov/)
- there's a bug which causes a "not found" error when navigating to some jobs (test data). the in progress job being one of them. this prevented me from adding a test checking to see if the progress bar was visible and at 0. i'm gonna create a ticket to fix that but didn't want to include that in this PR. [ticket](https://github.com/GSA/data.gov/issues/5440)
- there's a pytest name interference with "test_metrics" which prevented it from being included so I renamed the file. 

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
