### PR TITLE
fix job status overwrite on report

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -460,7 +460,10 @@ class HarvestSource:
                 f"{self.name} failed to clear completely",
                 self.job_id,
             )
-        else:
+
+        # only label the job as "complete" if it hasn't errored out by now
+        job = self.db_interface.get_harvest_job(self.job_id)
+        if job.status != "error":
             job_status = {"status": "complete", "date_finished": get_datetime()}
             job_status.update(job_results)
             self.db_interface.update_harvest_job(self.job_id, job_status)

--- a/tests/generate_fixtures.py
+++ b/tests/generate_fixtures.py
@@ -54,7 +54,7 @@ def generate_dynamic_fixtures() -> Dict[str, Any]:
     job_templates = [
         {
             "id": "6bce761c-7a39-41c1-ac73-94234c139c76",
-            "status": "error",
+            "status": "new",
             "days_ago": 4,
             "duration_minutes": 0,
             "records_total": 10,

--- a/tests/playwright/test_metrics_display.py
+++ b/tests/playwright/test_metrics_display.py
@@ -27,7 +27,7 @@ class TestMetricsUnauthed:
         upage.goto("/metrics/")
         jobs_section = upage.locator("#jobs-to-harvest")
         print(jobs_section.inner_html())
-        expect(jobs_section.locator("tbody tr")).to_have_count(1)
+        expect(jobs_section.locator("tbody tr")).to_have_count(2)
 
     def test_failed_jobs_exist(self, upage):
         """has failed jobs section"""


### PR DESCRIPTION
# Pull Request

Related to [#5425](https://github.com/GSA/data.gov/issues/5425)

## About
- ensures the job status (on error) isn't overwritten on report
- ended up changing a job fixture from "error" to "new" since it didn't make sense (records were processed so it's not a critical error). this led to an increase of 1 job in the new jobs table explaining the playwright update.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
