### PR TITLE
Use cloud.gov brokered ses

### DIFF
--- a/.profile
+++ b/.profile
@@ -34,7 +34,7 @@ export HARVEST_SMTP_SERVER=$(vcap_get_service smtp .credentials.smtp_server)
 export HARVEST_SMTP_STARTTLS=True
 export HARVEST_SMTP_USER=$(vcap_get_service smtp .credentials.smtp_user)
 export HARVEST_SMTP_PASSWORD=$(vcap_get_service smtp .credentials.smtp_password)
-export HARVEST_SMTP_SENDER=harvester@$(vcap_get_service smtp .credentials.domain_arn | grep -o "ses-[[:alnum:]]\+.ssb.data.gov")
+export HARVEST_SMTP_SENDER=harvester@$(vcap_get_service smtp .credentials.domain_arn | grep -o "ses-[[:alnum:]]\+.appmail.cloud.gov")
 export HARVEST_SMTP_RECIPIENT=datagovhelp@gsa.gov
 
 echo "Setting CA Bundle.."

--- a/create_cloudgov_services.sh
+++ b/create_cloudgov_services.sh
@@ -10,7 +10,7 @@ app_name=${1:-datagov-harvest}
 space=$(cf target | grep space | cut -d : -f 2 | xargs)
 
 # create email service
-cf service "${app_name}-smtp"  > /dev/null 2>&1 || cf create-service datagov-smtp base "${app_name}-smtp" -b "ssb-smtp-gsa-datagov-${space}"
+cf service "${app_name}-smtp"  > /dev/null 2>&1 || cf create-service aws-ses domain "${app_name}-smtp"
 
 # create the secrets service if necessary
 cf service "${app_name}-secrets"  > /dev/null 2>&1 || cf cups "${app_name}-secrets"


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#5396 we can now use a brokered email service from Cloud.gov. This changes our infrastructure-creation script to use that plan and modifies our environment variable settings to account for the change from `...ssb.data.gov` to `...appmail.cloud.gov`.

## About

This will take some care when merging. The current SMTP services from prod and staging either need to be deleted to let the new `aws-ses` one get created on deploy, or we need to make a new `aws-ses` service and rename it into place just after this is merged, then restart the applications.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
