### PR TITLE
Bug fix: include admin_email in service creation

### DIFF
--- a/create_cloudgov_services.sh
+++ b/create_cloudgov_services.sh
@@ -10,7 +10,7 @@ app_name=${1:-datagov-harvest}
 space=$(cf target | grep space | cut -d : -f 2 | xargs)
 
 # create email service
-cf service "${app_name}-smtp"  > /dev/null 2>&1 || cf create-service aws-ses domain "${app_name}-smtp"
+cf service "${app_name}-smtp"  > /dev/null 2>&1 || cf create-service aws-ses domain "${app_name}-smtp" -c '{"admin_email": "datagovhelp@gsa.gov"}'
 
 # create the secrets service if necessary
 cf service "${app_name}-secrets"  > /dev/null 2>&1 || cf cups "${app_name}-secrets"


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#5396, we needed to specify this parameter in our automatic service creation script.


## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
