### PR TITLE
Use Placeholder for `describedByType`

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -798,6 +798,11 @@ class Record:
                 "name": self.harvest_source.get_source_orm().org.name
             }
 
+        if not self.is_valid_describedByType(
+            self.transformed_data.get("describedByType", "")
+        ):
+            self.transformed_data["describedByType"] = "application/octet-steam"
+
         # If distribution items have a downloadURL or accessURL,
         # check if it just needs an "https://" at the beginning
         # to be valid

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -632,6 +632,14 @@ class Record:
             format_checker=Draft202012Validator.FORMAT_CHECKER,
         ).is_valid(url)
 
+    def is_valid_describedByType(self, described_by_type: str) -> bool:
+        """Return whether a string is a valid describedByType."""
+
+        return Draft202012Validator(
+            self.harvest_source.dataset_schema["properties"]["describedByType"],
+            format_checker=FormatChecker(),
+        ).is_valid(described_by_type)
+
     def harvest(self) -> None:
         """
         this is the main harvest function for a record instance. it runs the compare,
@@ -802,6 +810,8 @@ class Record:
         for dist_item in self.transformed_data.get("distribution", []):
             _guess_better_url_in_item(dist_item, "downloadURL")
             _guess_better_url_in_item(dist_item, "accessURL")
+            if not self.is_valid_describedByType(dist_item.get("describedByType", "")):
+                dist_item["describedByType"] = "application/octet-steam"
 
     def _report_error(self, e):
         """Report an exception to the database.

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -226,7 +226,7 @@ class TestValidateDataset:
                 valid_iso_2_record.harvest_source.job_id
             )
         ]
-        
+
         # 'ExternalRecordToClass' caused by decoding error. not needed for this test.
         del errors[0]
 
@@ -347,4 +347,18 @@ class TestValidateDataset:
         assert (
             valid_iso_2_record.transformed_data["distribution"][0]["accessURL"]
             == "https://www.example.com/"
+        )
+
+    def test_transformed_iso_describedByType_placeholder(self, valid_iso_2_record):
+        valid_iso_2_record.transform()
+        valid_iso_2_record.transformed_data["distribution"][0][
+            "describedByType"
+        ] = "WWW:LINK-1.0-http--link"
+        assert not valid_iso_2_record.validate()
+
+        valid_iso_2_record.fill_placeholders()
+        assert valid_iso_2_record.validate()
+        assert (
+            valid_iso_2_record.transformed_data["distribution"][0]["describedByType"]
+            == "application/octet-steam"
         )

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -349,7 +349,29 @@ class TestValidateDataset:
             == "https://www.example.com/"
         )
 
-    def test_transformed_iso_describedByType_placeholder(self, valid_iso_2_record):
+    def test_transformed_iso_root_describedByType_placeholder(self, valid_iso_2_record):
+        valid_iso_2_record.transform()
+
+        # if `describedByType` is not in the root its valid
+        assert valid_iso_2_record.validate()
+
+        # test for invalid describedByType
+        valid_iso_2_record.transformed_data["describedByType"] = (
+            "WWW:LINK-1.0-http--link"
+        )
+        assert not valid_iso_2_record.validate()
+
+        # replace invalid describedByType with placeholder
+        valid_iso_2_record.fill_placeholders()
+        assert valid_iso_2_record.validate()
+        assert (
+            valid_iso_2_record.transformed_data["describedByType"]
+            == "application/octet-steam"
+        )
+
+    def test_transformed_iso_distribution_describedByType_placeholder(
+        self, valid_iso_2_record
+    ):
         valid_iso_2_record.transform()
         valid_iso_2_record.transformed_data["distribution"][0][
             "describedByType"


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5335

## About

- Uses the a placeholder (`application/octet-steam`) for non-valid `describedByTypes`

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
