### PR TITLE
use record identifier in exception message

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -354,8 +354,12 @@ class HarvestSource:
                 del record
             except Exception as e:
                 self.update_job_record_count_by_action("errored")
+
+                # "record"s in self.external_records are standardized as dicts at this point
+                record_id = record["identifier"] if "identifier" in record else None
+
                 ExternalRecordToClass(
-                    f"{self.name} {self.url} failed to prepare record for harvest :: {repr(e)}",
+                    f"{self.name} {record_id} failed to prepare record for harvest :: {repr(e)}",
                     self.job_id,
                     None,  # there is no record id to associate
                 )


### PR DESCRIPTION
# Pull Request

Related to [#5432](https://github.com/GSA/data.gov/issues/5432)

## About
- uses harvest source identifier (full address path of xml file when waf or "identifier" in dcatus) in `ExternalRecordToClass` exception message instead of harvest source url

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
