### PR TITLE
Add support for single ISO document harvest sources

### DIFF
--- a/tests/badges/integration/tests.svg
+++ b/tests/badges/integration/tests.svg
@@ -5,7 +5,7 @@
     width="70.0"
     height="20"
     role="img"
-    aria-label="tests: 148"
+    aria-label="tests: 154"
 >
     <style>
         rect {
@@ -26,7 +26,7 @@
             fill: #010101;
         }
     </style>
-    <title>tests: 148</title>
+    <title>tests: 154</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
@@ -42,8 +42,8 @@
         </g>
         <g transform="translate(37.5 0)">
             <rect width="32.5" fill="#4c1"/>
-            <text x="16.25" y="10.0" class="shadow">148</text>
-            <text x="16.25" y="10.0">148</text>
+            <text x="16.25" y="10.0" class="shadow">154</text>
+            <text x="16.25" y="10.0">154</text>
         </g>
         <rect width="100%" height="100%" fill="url(#s)"/>
     </g>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,21 @@ def source_data_iso19115_2_orm(source_data_waf_iso19115_2: dict) -> HarvestSourc
 
 
 @pytest.fixture
+def source_data_iso19115_2_document(organization_data: dict) -> dict:
+    return {
+        "id": "8c3cd8c5-6174-42ef-9512-10503533c3a8",
+        "name": "Test Source (ISO19115_2 document)",
+        "notification_emails": ["wafl@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/iso_2_waf/valid_iso2.xml",
+        "schema_type": "iso19115_2",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
 def source_data_dcatus_invalid(organization_data: dict) -> dict:
     return {
         "id": "2bfcb047-70dc-435a-a46c-4dec5df7532d",

--- a/tests/integration/harvest/test_exception_handling.py
+++ b/tests/integration/harvest/test_exception_handling.py
@@ -45,6 +45,26 @@ class TestHarvestJobExceptionHandling:
         harvest_error = interface.get_harvest_job_errors_by_job(harvest_job.id)[0]
         assert harvest_error.type == "ExtractExternalException"
 
+    def test_harvest_source_bad_schema_type(self, interface,
+                                            organization_data,
+                                            source_data_dcatus,
+                                            job_data_dcatus):
+        """Schema types that don't start with dcatus or iso19115 raise an exception."""
+        interface.add_organization(organization_data)
+        source_data_dcatus["schema_type"] = "csdgm"
+        interface.add_harvest_source(source_data_dcatus)
+        harvest_job = interface.add_harvest_job(job_data_dcatus)
+
+        harvest_source = HarvestSource(harvest_job.id)
+
+        with pytest.raises(ExtractExternalException) as e:
+            harvest_source.acquire_minimum_external_data()
+
+        assert harvest_job.status == "error"
+
+        harvest_error = interface.get_harvest_job_errors_by_job(harvest_job.id)[0]
+        assert harvest_error.type == "ExtractExternalException"
+
     def test_extract_internal_exception(
         self,
         interface,

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -194,6 +194,37 @@ class TestHarvestJobFullFlow:
         )
 
     @patch("harvester.harvest.ckan_sync_tool.ckan")
+    @patch("harvester.harvest.HarvestSource.send_notification_emails")
+    def test_harvest_iso19115_2_document(
+        self,
+        send_notification_emails_mock: MagicMock,
+        CKANMock,
+        interface,
+        organization_data,
+        source_data_iso19115_2_document,
+    ):
+        CKANMock.action.package_create.return_value = {"id": 1234}
+
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_iso19115_2_document)
+        harvest_job = interface.add_harvest_job(
+            {
+                "status": "new",
+                "harvest_source_id": source_data_iso19115_2_document["id"],
+            }
+        )
+
+        job_id = harvest_job.id
+        harvest_job_starter(job_id, "harvest")
+        harvest_job = interface.get_harvest_job(job_id)
+
+        # assert job rollup
+        assert harvest_job.status == "complete"
+        assert harvest_job.records_total == 1
+        assert len(harvest_job.record_errors) == 0
+        assert harvest_job.records_errored == 0
+
+    @patch("harvester.harvest.ckan_sync_tool.ckan")
     @patch("harvester.harvest.download_file")
     @patch("harvester.harvest.HarvestSource.send_notification_emails")
     def test_harvest_record_errors_reported(


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5182, we want to support harvest sources that have a single document that is an ISO-format XML file rather than a DCAT-US JSON file. This adds support for that situation by entering that single file into the harvesting process as if we had observed a WAF with a single file.

## About

This was intensely, incredibly easy to add. @rshewitt is a legend.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
