### PR TITLE
remove csdgm from schema type enum

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -76,7 +76,6 @@ class HarvestSource(db.Model):
         db.Enum(
             "iso19115_1",
             "iso19115_2",
-            "csdgm",
             "dcatus1.1: federal",
             "dcatus1.1: non-federal",
             name="schema_type",

--- a/migrations/versions/a6aa1afd27b7_remove_csdgm_from_schema_type.py
+++ b/migrations/versions/a6aa1afd27b7_remove_csdgm_from_schema_type.py
@@ -1,0 +1,69 @@
+"""remove 'csdgm' from schema_type
+
+Revision ID: a6aa1afd27b7
+Revises: 1800d355e5b9
+Create Date: 2025-09-12 17:06:56.439448
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a6aa1afd27b7'
+down_revision = '1800d355e5b9'
+branch_labels = None
+depends_on = None
+
+# remove "csdgm" from schema_type
+old_options = (
+    "iso19115_1",
+    "iso19115_2",
+    "csdgm",
+    "dcatus1.1: federal",
+    "dcatus1.1: non-federal",
+)
+new_options = (
+    "iso19115_1",
+    "iso19115_2",
+    "dcatus1.1: federal",
+    "dcatus1.1: non-federal",
+)
+
+old_enum = sa.Enum(*old_options, name="schema_type")
+new_enum = sa.Enum(*new_options, name="schema_type_new")
+
+def upgrade():
+    # Create new enum
+    new_enum.create(op.get_bind(), checkfirst=False)
+
+    # Alter column to use new enum
+    op.execute(
+        "ALTER TABLE harvest_source ALTER COLUMN schema_type TYPE schema_type_new "
+        "USING schema_type::text::schema_type_new"
+    )
+
+    # Drop old enum
+    old_enum.drop(op.get_bind(), checkfirst=False)
+
+    # Rename new enum to old name
+    op.execute("ALTER TYPE schema_type_new RENAME TO schema_type")
+
+
+def downgrade():
+    # recreate the old enum
+    old_enum.name = "schema_type_old"
+    old_enum.create(op.get_bind(), checkfirst=False)
+
+    # Alter column back
+    op.execute(
+        "ALTER TABLE harvest_source ALTER COLUMN schema_type TYPE schema_type_old "
+        "USING schema_type::text::schema_type_old"
+    )
+
+    # Drop the present enum
+    new_enum.name = "schema_type"
+    new_enum.drop(op.get_bind(), checkfirst=False)
+
+    # Rename old enum to current enum
+    op.execute("ALTER TYPE schema_type_old RENAME TO schema_type")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,15 +373,6 @@ def job_data_dcatus_2(source_data_dcatus_2: dict) -> dict:
 
 
 @pytest.fixture
-def job_data_waf_csdgm(source_data_waf_csdgm: dict) -> dict:
-    return {
-        "id": "963cdc51-94d5-425d-a688-e0a57e0c5dd2",
-        "status": "new",
-        "harvest_source_id": source_data_waf_csdgm["id"],
-    }
-
-
-@pytest.fixture
 def job_data_waf_iso19115_2(source_data_waf_iso19115_2: dict) -> dict:
     return {
         "id": "83c431e6-0f53-4471-8003-b6afc0541101",

--- a/tests/integration/database/test_db.py
+++ b/tests/integration/database/test_db.py
@@ -827,9 +827,7 @@ class TestDatabase:
         organization_data,
         source_data_waf_csdgm,
     ):
-        source_data_waf_csdgm["schema_type"] = "unsupported_schema"
-
+        """attempts to add a 'csdgm' harvest source which is unsupported"""
         interface.add_organization(organization_data)
-
         # we can't add the source because we use an enum for schema type
         assert interface.add_harvest_source(source_data_waf_csdgm) is None

--- a/tests/integration/harvest/test_exception_handling.py
+++ b/tests/integration/harvest/test_exception_handling.py
@@ -45,26 +45,6 @@ class TestHarvestJobExceptionHandling:
         harvest_error = interface.get_harvest_job_errors_by_job(harvest_job.id)[0]
         assert harvest_error.type == "ExtractExternalException"
 
-    def test_harvest_source_bad_schema_type(self, interface,
-                                            organization_data,
-                                            source_data_dcatus,
-                                            job_data_dcatus):
-        """Schema types that don't start with dcatus or iso19115 raise an exception."""
-        interface.add_organization(organization_data)
-        source_data_dcatus["schema_type"] = "csdgm"
-        interface.add_harvest_source(source_data_dcatus)
-        harvest_job = interface.add_harvest_job(job_data_dcatus)
-
-        harvest_source = HarvestSource(harvest_job.id)
-
-        with pytest.raises(ExtractExternalException) as e:
-            harvest_source.acquire_minimum_external_data()
-
-        assert harvest_job.status == "error"
-
-        harvest_error = interface.get_harvest_job_errors_by_job(harvest_job.id)[0]
-        assert harvest_error.type == "ExtractExternalException"
-
     def test_extract_internal_exception(
         self,
         interface,

--- a/tests/integration/harvest/test_extract.py
+++ b/tests/integration/harvest/test_extract.py
@@ -8,22 +8,6 @@ class TestExtract:
         files = traverse_waf(url="https://example.com")
         assert len(files) == 2
 
-    def test_extract_waf(
-        self,
-        interface,
-        organization_data,
-        source_data_waf_csdgm,
-        job_data_waf_csdgm,
-    ):
-        interface.add_organization(organization_data)
-        interface.add_harvest_source(source_data_waf_csdgm)
-        harvest_job = interface.add_harvest_job(job_data_waf_csdgm)
-
-        harvest_source = HarvestSource(harvest_job.id)
-        harvest_source.acquire_minimum_external_data()
-
-        assert len(harvest_source.external_records) == 7
-
     def test_extract_dcatus(
         self,
         interface,


### PR DESCRIPTION
# Pull Request

Related to [#5088](https://github.com/GSA/data.gov/issues/5088)

## About
- removes "csdgm" from schema_type enum in harvest source model
- refactored `test_harvest_source_bad_schema_type` to check that the org has no harvest sources because it was rejected.
- removed an old test involving a "csdgm" source which we no longer support

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
