### PR TITLE
Use word-break for wrapping long identifiers

### DIFF
--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -130,7 +130,7 @@
                     {% for record_error in data.record_errors %}
                     <div class="error-block">
                         <h3>{{ record_error.error.id }}</h3>
-                        <p><strong>Identifier:</strong> {{ record_error.identifier if record_error.identifier else "N/A"
+                        <p style="word-break: break-all"><strong>Identifier:</strong> {{ record_error.identifier if record_error.identifier else "N/A"
                             }}</p>
                         <p><strong>Title:</strong> {{ record_error.title if record_error.title else "N/A" }}</p>
                         <p><strong>Harvest Record ID:</strong>


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#5353, this adds the `word-break: break-all` CSS property to the identifier in our record error display so that long identifiers don't extend off of the screen.

## About

The ticket suggests `overflow-wrap: break-word`, but that could break the line before the identifier if that would avoid breaking the word. I don't think that's what we want, so I used `word-break: break-all` instead. 

I couldn't find a way in Playwright to test the visual display of wrapped content on a particular size of screen, so I offer this screenshot from my local as evidence that this works as desired.

<img width="1374" height="831" alt="Screenshot 2025-09-25 at 12 45 56 PM" src="https://github.com/user-attachments/assets/97430600-2df7-47e0-849d-3d8eb7c5a08b" />


## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
