### PR TITLE
add manual refresh action

### DIFF
--- a/.github/workflows/refresh_dataset_mv.yml
+++ b/.github/workflows/refresh_dataset_mv.yml
@@ -1,0 +1,29 @@
+permissions:
+  contents: read
+  
+name: Refresh "dataset" materialized view
+
+on:
+  workflow_dispatch:
+    inputs: 
+      environment:
+        description: 'cf environment'
+        required: true
+        default: 'development' # TODO: pinning to dev. change to "choice"
+
+run-refresh:
+    runs-on: ubuntu-latest
+    name: Refresh dataset mv
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: run task
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task datagov-harvest --name refresh_dataset_mv
+            --command "python scripts/refresh_dataset_mv.py""
+          cf_org: gsa-datagov
+          cf_space: ${{ inputs.environment }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}

--- a/scripts/refresh_dataset_mv.py
+++ b/scripts/refresh_dataset_mv.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+sys.path.insert(1, "/".join(os.path.realpath(__file__).split("/")[0:-2]))
+
+from harvester import HarvesterDBInterface  # noqa E402
+
+DATABASE_URI = os.getenv("DATABASE_URI")
+
+engine = create_engine(DATABASE_URI)
+session_factory = sessionmaker(bind=engine, autoflush=True)
+session = scoped_session(session_factory)
+
+
+def main():
+    interface = HarvesterDBInterface(session=session)
+    interface.refresh_dataset_mv()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request

Related to [#5503](https://github.com/GSA/data.gov/issues/5503)

## About
- adds manual refresh action (pinned to development space)
- adds refresh script called as cf task

task succeeded 
```
Getting tasks for app datagov-harvest in org gsa-datagov / space development as reid.hewitt@gsa.gov...

id     name                                                       state       start time                      command
5950   refresh_dataset_mv                                         SUCCEEDED   Fri, 10 Oct 2025 15:01:11 UTC   python scripts/refresh_dataset_mv.py
```
## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
