### PR TITLE
make dcat JSONB mutable

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -201,7 +201,8 @@ class Dataset(db.Model):
     )
 
     # This is all of the details of the dataset in DCAT schema in a JSON column
-    # make it mutable so that in-place mutations (e.g., dcat["spatial"] = "...", for tests) are tracked
+    # make it mutable so that in-place mutations (e.g.,
+    # dcat["spatial"] = "...", for tests) are tracked
     dcat = db.Column(MutableDict.as_mutable(JSONB), nullable=False)
 
     organization_id = db.Column(

--- a/database/models.py
+++ b/database/models.py
@@ -7,6 +7,7 @@ from geoalchemy2 import Geometry
 from sqlalchemy import CheckConstraint, Column, Enum, String, func, Index
 from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.orm import DeclarativeBase, backref
+from sqlalchemy.ext.mutable import MutableDict
 
 from shared.constants import ORGANIZATION_TYPE_VALUES
 
@@ -200,7 +201,8 @@ class Dataset(db.Model):
     )
 
     # This is all of the details of the dataset in DCAT schema in a JSON column
-    dcat = db.Column(JSONB, nullable=False)
+    # make it mutable so that in-place mutations (e.g., dcat["spatial"] = "...", for tests) are tracked
+    dcat = db.Column(MutableDict.as_mutable(JSONB), nullable=False)
 
     organization_id = db.Column(
         db.String(36),


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5511

## About
added a mutable wrapper so that SQLAlchemy is aware of the addition of a `spatial` field during tests.  
<!-- any pertinent notes -->

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
