### PR TITLE
MV and GA count refresh on staging prod

### DIFF
--- a/.github/workflows/refresh_dataset_mv.yml
+++ b/.github/workflows/refresh_dataset_mv.yml
@@ -9,15 +9,21 @@ on:
       environment:
         description: "cf environment"
         required: true
-        default: "development" # TODO: pinning to dev. change to "choice"
+        type: choice
+        default: "development"
+        options:
+          - development
+          - staging
+          - prod
   schedule:
     - cron: "0 11 * * *" # every day at 6:00am EST
 
 jobs:
-  run-refresh:
+  run-refresh-manual:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    name: Refresh dataset mv
-    environment: development # TODO: pinning to dev. change when needed.
+    name: Refresh dataset mv (${{ inputs.environment }})
+    environment: ${{ inputs.environment }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -29,5 +35,24 @@ jobs:
             --command "python scripts/refresh_dataset_mv.py"
           cf_org: gsa-datagov
           cf_space: ${{ inputs.environment }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+
+  run-refresh-schedule:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    name: Refresh dataset mv (prod)
+    environment: prod
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+      - name: run task
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task datagov-harvest --name refresh_dataset_mv
+            --command "python scripts/refresh_dataset_mv.py"
+          cf_org: gsa-datagov
+          cf_space: prod
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}

--- a/.github/workflows/refresh_dataset_mv.yml
+++ b/.github/workflows/refresh_dataset_mv.yml
@@ -26,7 +26,7 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: run task
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -45,7 +45,7 @@ jobs:
     environment: prod
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: run task
         uses: cloud-gov/cg-cli-tools@main
         with:

--- a/.github/workflows/update_dataset_view_counts.yml
+++ b/.github/workflows/update_dataset_view_counts.yml
@@ -18,17 +18,15 @@ on:
   schedule:
     - cron: "0 0 2 * *" # Runs at 00:00 UTC on 2nd day of the month - to account for GA4 reporting latency
 
-env:
-  TARGET_ENV: ${{ inputs.environment || 'development' }}
-
 jobs:
-  dataset-view-count:
+  dataset-view-count-manual:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    name: generate dataset view count report
-    environment: ${{ env.TARGET_ENV }}
+    name: generate dataset view count report (${{ inputs.environment }})
+    environment: ${{ inputs.environment }}
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: run task
         uses: cloud-gov/cg-cli-tools@main
         with:
@@ -36,6 +34,28 @@ jobs:
             cf run-task datagov-harvest --name update_dataset_view_count
             --command "python scripts/update_dataset_view_count.py"
           cf_org: gsa-datagov
-          cf_space: ${{ env.TARGET_ENV }}
+          cf_space: ${{ inputs.environment }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+
+  dataset-view-count-cron:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    name: generate dataset view count report (${{ matrix.target_env }})
+    strategy:
+      matrix:
+        target_env: [staging, prod]
+    environment: ${{ matrix.target_env }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v5
+      - name: run task
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task datagov-harvest --name update_dataset_view_count
+            --command "python scripts/update_dataset_view_count.py"
+          cf_org: gsa-datagov
+          cf_space: ${{ matrix.target_env }}
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}

--- a/.github/workflows/update_dataset_view_counts.yml
+++ b/.github/workflows/update_dataset_view_counts.yml
@@ -9,15 +9,23 @@ on:
       environment:
         description: "cf environment"
         required: true
-        default: "development" # TODO: pinning to dev. change to "choice"
+        type: choice
+        default: "development"
+        options:
+          - development
+          - staging
+          - prod
   schedule:
     - cron: "0 0 2 * *" # Runs at 00:00 UTC on 2nd day of the month - to account for GA4 reporting latency
+
+env:
+  TARGET_ENV: ${{ inputs.environment || 'development' }}
 
 jobs:
   dataset-view-count:
     runs-on: ubuntu-latest
     name: generate dataset view count report
-    environment: development # TODO: pinning to dev. change when needed.
+    environment: ${{ env.TARGET_ENV }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -28,6 +36,6 @@ jobs:
             cf run-task datagov-harvest --name update_dataset_view_count
             --command "python scripts/update_dataset_view_count.py"
           cf_org: gsa-datagov
-          cf_space: ${{ inputs.environment }}
+          cf_space: ${{ env.TARGET_ENV }}
           cf_username: ${{secrets.CF_SERVICE_USER}}
           cf_password: ${{secrets.CF_SERVICE_AUTH}}


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5524

## About
Need MV refresh and GA count refresh actions on staging and prod.
- manual actions can be done on development, staging, prod
- scheduled MV refresh on prod only
- scheduled GA count refresh on staging and prod only 

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
