### PR TITLE
Fix comma-separated aliases list in organization form

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import re
 
@@ -26,6 +27,21 @@ def validate_email_list(form, field):
 
 def strip_filter(data):
     return data.strip() if isinstance(data, str) else data
+
+
+def comma_separated_filter(data):
+    """Turn the list or the repr of a list into just comma-separated values."""
+    # "[" isn't likely to be an alias so if we see it, it's probably the repr
+    # of a list
+    if isinstance(data, list):
+        return ", ".join(data)
+    if data.startswith("["):
+        try:
+            data_list = ast.literal_eval(data)
+            return ", ".join(data_list)
+        except ValueError:
+            return data
+    return data
 
 
 class EmailListField(TextAreaField):
@@ -117,6 +133,7 @@ class OrganizationForm(FlaskForm):
     aliases = StringField(
         "Organization aliases (comma-separated)",
         validators=[Optional()],
+        filters=[comma_separated_filter],
         default="",
     )
 

--- a/tests/generate_fixtures.py
+++ b/tests/generate_fixtures.py
@@ -24,6 +24,7 @@ def generate_dynamic_fixtures() -> Dict[str, Any]:
                 "slug": "fixture-org",
                 "organization_type": "Federal Government",
                 "id": "d925f84d-955b-4cb7-812f-dcfd6681a18f",
+                "aliases": ["testorg"],
             }
         ],
         "source": [

--- a/tests/integration/app/test_forms.py
+++ b/tests/integration/app/test_forms.py
@@ -147,3 +147,17 @@ class TestForms:
         assert org.organization_type == "City Government"
         assert org.description == "New description"
         assert org.slug == "updated-slug"
+
+    def test_edit_organization_handles_aliases(
+        self, app, client, interface, organization_data
+    ):
+        """aliases form field is formatted correctly"""
+        app.config.update({"WTF_CSRF_ENABLED": False})
+        with client.session_transaction() as sess:
+            sess["user"] = "tester@gsa.gov"
+
+        interface.add_organization(organization_data)
+
+        edit_response = client.get(f"/organization/edit/{organization_data['id']}")
+        assert "testorg" in edit_response.text
+        assert "['testorg']" not in edit_response.text

--- a/tests/playwright/test_organization.py
+++ b/tests/playwright/test_organization.py
@@ -31,7 +31,7 @@ class TestOrganizationUnauthed:
                 "organization_type:",
                 "Federal Government",
                 "aliases:",
-                "None",
+                "['testorg']",
                 "id:",
                 "d925f84d-955b-4cb7-812f-dcfd6681a18f",
             ]


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#5574, this fixes the handling of a list-valued field in our Organization edit form.

## About

The test is minimal, but it checks to make sure that we don't have the problem that started this.

## PR TASKS

- [X] Code well documented
- [X] Tests written, run and passed
- [X] Files linted
