### PR TITLE
Use the same user-agent as CKAN harvester

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -30,7 +30,7 @@ logger = logging.getLogger()
 FREQUENCY_ENUM = {"daily": 1, "weekly": 7, "biweekly": 14, "monthly": 30}
 
 # User-Agent header for all HTTP requests
-USER_AGENT = "HarvesterBot/1.0 (https://data.gov;datagovhelp@gsa.gov) Data.gov"
+USER_AGENT = "HarvesterBot/0.0 (https://data.gov; datagovhelp@gsa.gov) Data.gov/2.0"
 
 DT_PLACEHOLDER = datetime(1900, 1, 1, 0, 0)
 


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#5602

## About

Changes the user-agent header to match (hopefully exactly) the string that we currently use in our CKAN harvester which is found at https://github.com/GSA/ckanext-datajson/blob/105aaf01f70d053fabeefb61de9dff49f3e707bf/ckanext/datajson/harvester_datajson.py#L29