### PR TITLE
fix duplicate point issue for point geometries

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -587,14 +587,20 @@ def munge_spatial(spatial_value: str) -> str:
             spatial_value = spatial_value.replace(" ", ",")
     except ValueError:
         pass
+    
+    parts = [part.strip() for part in spatial_value.strip().split(",")]
 
-    parts = spatial_value.strip().split(",")
-    if len(parts) == 4 and all(is_number(x) for x in parts):
-        minx, miny, maxx, maxy = parts
-        return geojson_polygon_tpl.format(minx=minx, miny=miny, maxx=maxx, maxy=maxy)
     if len(parts) == 2 and all(is_number(x) for x in parts):
         x, y = parts
         return geojson_point_tpl.format(x=x, y=y)
+    
+    if len(parts) == 4 and all(is_number(x) for x in parts):
+        # duplicate points situation (e.g. "-92.109, 15.132, -92.109, 15.132")
+        if parts[:2] == parts[2:]:
+            x,y = list(dict.fromkeys(parts)) # removes duplicates while preserving order
+            return geojson_point_tpl.format(x=x, y=y)
+        minx, miny, maxx, maxy = parts
+        return geojson_polygon_tpl.format(minx=minx, miny=miny, maxx=maxx, maxy=maxy)
 
     try:
         geometry = json.loads(spatial_value)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -31,8 +31,9 @@ from harvester.utils.general_utils import (
     query_filter_builder,
     traverse_waf,
     validate_geojson,
-    get_waf_datetimes
+    get_waf_datetimes,
 )
+
 
 class TestCKANUtils:
     """Some of these tests are copied from
@@ -65,6 +66,12 @@ class TestCKANUtils:
             '{"type": "Polygon", "coordinates": '
             "[[[1.0, 2.0], [1.0, 5.5], [3.5, 5.5], "
             "[3.5, 2.0], [1.0, 2.0]]]}"
+        )
+
+    def test_munge_spatial_duplicates(self):
+        assert (
+            munge_spatial("-92.109, 15.132, -92.109, 15.132")
+            == '{"type": "Point", "coordinates": [-92.109, 15.132]}'
         )
 
     def test_translate_spatial_simple_bbox(self):
@@ -221,16 +228,16 @@ class TestGeneralUtils:
         dol_distribution_json["keyword"] = []  # empty array
         dol_distribution_json["distribution"][0]["title"] = ""  # empty string
         dol_distribution_json["distribution"][1] = bool  # wrong type
-        dol_distribution_json["contactPoint"][
-            "hasEmail"
-        ] = "bad email"  # bad value based on regex
+        dol_distribution_json["contactPoint"]["hasEmail"] = (
+            "bad email"  # bad value based on regex
+        )
         dol_distribution_json["accrualPeriodicity"] = (
             "No longer updated (dataset archived)"  # bad const value
         )
         dol_distribution_json["rights"] = "a" * 256  # max string length exceeded
-        dol_distribution_json["distribution"][0][
-            "@type"
-        ] = "Distribution"  # not dcat:Distribution
+        dol_distribution_json["distribution"][0]["@type"] = (
+            "Distribution"  # not dcat:Distribution
+        )
 
         validator = Draft202012Validator(
             dcatus_non_federal_schema, format_checker=FormatChecker()


### PR DESCRIPTION
# Pull Request

Related to [5647](https://github.com/GSA/data.gov/issues/5647)

## About
when we get a spatial value like `"-92.109, 15.132, -92.109, 15.132"` it ends up being transformed into a polygon geojson when it should be a point geojson this causes opensearch sync failures

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
