### PR TITLE
remove and log dcatus records without identifier

### DIFF
--- a/example_data/dcatus/dcatus_no_identifier.json
+++ b/example_data/dcatus/dcatus_no_identifier.json
@@ -1,0 +1,36 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "http://www.cftc.gov/data.json",
+  "@type": "dcat:Catalog",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "contactPoint": {
+        "fn": "Harold W. Hild",
+        "hasEmail": "mailto:hhild@CFTC.GOV"
+      },
+      "describedBy": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/ExplanatoryNotes/index.htm",
+      "description": "COT reports provide a breakdown of each Tuesday's open interest for futures and options on futures market in which 20 or more traders hold positions equal to or above the reporting levels established by CFTC",
+      "distribution": [
+        {
+          "accessURL": "https://www.cftc.gov/MarketReports/CommitmentsofTraders/index.htm"
+        }
+      ],
+      "modified": "R/P1W",
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "U.S. Commodity Futures Trading Commission",
+        "subOrganizationOf": {
+          "name": "U.S. Government"
+        }
+      },
+      "title": "Commitment of Traders",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "isPartOf": "some-collection-id",
+      "keyword": ["commitment of traders", "cot", "open interest"],
+      "spatial": "United States"
+    }
+  ]
+}

--- a/harvester/exceptions.py
+++ b/harvester/exceptions.py
@@ -113,3 +113,7 @@ class CKANRejectionException(SynchronizeException):
 
 class CKANDownException(SynchronizeException):
     pass
+
+
+class NoIdentifierException(HarvestNonCriticalException):
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,6 +179,21 @@ def source_data_dcatus_same_title(organization_data: dict) -> dict:
 
 
 @pytest.fixture
+def source_data_dcatus_no_identifier(organization_data: dict) -> dict:
+    return {
+        "id": "48f1b0d6-ecd7-4b5f-9e5d-9e2146e21f77",
+        "name": "Test Source (no identifier)",
+        "notification_emails": ["email@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_no_identifier.json",
+        "schema_type": "dcatus1.1: federal",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
 def source_data_waf_csdgm(organization_data: dict) -> dict:
     return {
         "id": "55dca495-3b92-4fe4-b9c5-d433cbc3c82d",
@@ -401,6 +416,15 @@ def job_data_dcatus_2(source_data_dcatus_2: dict) -> dict:
         "id": "392ac4b3-79a6-414b-a2b3-d6c607d3b8d4",
         "status": "new",
         "harvest_source_id": source_data_dcatus_2["id"],
+    }
+
+
+@pytest.fixture
+def job_data_dcatus_no_identifier(source_data_dcatus_no_identifier: dict) -> dict:
+    return {
+        "id": "b9457afe-d5a3-48e3-ab97-2e9f728013a1",
+        "status": "new",
+        "harvest_source_id": source_data_dcatus_no_identifier["id"],
     }
 
 
@@ -1201,6 +1225,7 @@ def sample_ckan_records():
             "harvest_source_title": "nasa-data-json",
         },
     ]
+
 
 @pytest.fixture
 def view_count_datasets():

--- a/tests/integration/harvest/test_extract.py
+++ b/tests/integration/harvest/test_extract.py
@@ -38,3 +38,28 @@ class TestExtract:
         harvest_source = HarvestSource(harvest_job.id)
 
         assert str(harvest_source.schema_file).endswith("iso-non-federal_dataset.json")
+
+    def test_extract_source_with_dataset_missing_identifier(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_no_identifier,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        assert len(harvest_source.external_records) == 0
+
+        errors = interface.get_harvest_record_errors_by_job(harvest_job.id)
+
+        msg = (
+            "Test Source (no identifier) Commitment of Traders is "
+            "missing 'identifier' field"
+        )
+        assert errors[0][0].message == msg


### PR DESCRIPTION
# Pull Request

Related to [#5480](https://github.com/GSA/data.gov/issues/5480)

## About
[commerce-non-spatial-data-json-harvest-source](https://harvest.data.gov/harvest_source/7660cf65-6dbc-49a7-9ebb-6c9736fcb006) has been failing for the past couple weeks because of an unhandled exception. the cause of the exception is because one of the records in the source doesn't have an "identifier" field when it's expected. i've emailed the provider.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
