### PR TITLE
Generate Openapi spec "automatically"

### DIFF
--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -14,6 +14,7 @@ from shared.constants import (
     SOURCE_TYPE_VALUES,
 )
 
+
 def _to_enum(name, values):
     """Make an iterable of values into a Python enum.
 
@@ -25,7 +26,9 @@ def _to_enum(name, values):
 ACTION_ENUM = _to_enum("Action", ACTION_VALUES)
 FREQUENCY_ENUM = _to_enum("Frequency", FREQUENCY_VALUES)
 JOB_STATUS_ENUM = _to_enum("JobStatus", JOB_STATUS_VALUES)
-NOTIFICATION_FREQUENCY_ENUM = _to_enum("NotificationFrequency", NOTIFICATION_FREQUENCY_VALUES)
+NOTIFICATION_FREQUENCY_ENUM = _to_enum(
+    "NotificationFrequency", NOTIFICATION_FREQUENCY_VALUES
+)
 ORGANIZATION_TYPE_ENUM = _to_enum("OrganizationType", ORGANIZATION_TYPE_VALUES)
 RECORD_STATUS_ENUM = _to_enum("RecordStatus", RECORD_STATUS_VALUES)
 SCHEMA_TYPE_ENUM = _to_enum("SchemaType", SCHEMA_TYPE_VALUES)

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -14,18 +14,22 @@ from shared.constants import (
     SOURCE_TYPE_VALUES,
 )
 
-ACTION_ENUM = PyEnum("Action", [(a, a) for a in ACTION_VALUES])
-FREQUENCY_ENUM = PyEnum("Frequency", [(a, a) for a in FREQUENCY_VALUES])
-JOB_STATUS_ENUM = PyEnum("JobStatus", [(a, a) for a in JOB_STATUS_VALUES])
-NOTIFICATION_FREQUENCY_ENUM = PyEnum(
-    "NotificationFrequency", [(a, a) for a in NOTIFICATION_FREQUENCY_VALUES]
-)
-ORGANIZATION_TYPE_ENUM = PyEnum(
-    "OrganizationType", [(a, a) for a in ORGANIZATION_TYPE_VALUES]
-)
-RECORD_STATUS_ENUM = PyEnum("RecordStatus", [(a, a) for a in RECORD_STATUS_VALUES])
-SCHEMA_TYPE_ENUM = PyEnum("SchemaType", [(a, a) for a in SCHEMA_TYPE_VALUES])
-SOURCE_TYPE_ENUM = PyEnum("SourceType", [(a, a) for a in SOURCE_TYPE_VALUES])
+def _to_enum(name, values):
+    """Make an iterable of values into a Python enum.
+
+    The produced enum has the name and values the same.
+    """
+    return PyEnum(name, [(a, a) for a in values])
+
+
+ACTION_ENUM = _to_enum("Action", ACTION_VALUES)
+FREQUENCY_ENUM = _to_enum("Frequency", FREQUENCY_VALUES)
+JOB_STATUS_ENUM = _to_enum("JobStatus", JOB_STATUS_VALUES)
+NOTIFICATION_FREQUENCY_ENUM = to_enum("NotificationFrequency", NOTIFICATION_FREQUENCY_VALUES)
+ORGANIZATION_TYPE_ENUM = _to_enum("OrganizationType", ORGANIZATION_TYPE_VALUES)
+RECORD_STATUS_ENUM = _to_enum("RecordStatus", RECORD_STATUS_VALUES)
+SCHEMA_TYPE_ENUM = _to_enum("SchemaType", SCHEMA_TYPE_VALUES)
+SOURCE_TYPE_ENUM = _to_enum("SourceType", SOURCE_TYPE_VALUES)
 
 
 # must be created from a dict because "type" key

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -1,0 +1,112 @@
+from enum import Enum as PyEnum
+
+from apiflask import Schema, validators
+from apiflask.fields import UUID, Boolean, DateTime, Dict, Enum, Integer, List, String
+
+from shared.constants import (
+    ACTION_VALUES,
+    FREQUENCY_VALUES,
+    JOB_STATUS_VALUES,
+    NOTIFICATION_FREQUENCY_VALUES,
+    ORGANIZATION_TYPE_VALUES,
+    RECORD_STATUS_VALUES,
+    SCHEMA_TYPE_VALUES,
+    SOURCE_TYPE_VALUES,
+)
+
+ACTION_ENUM = PyEnum("Action", [(a, a) for a in ACTION_VALUES])
+FREQUENCY_ENUM = PyEnum("Frequency", [(a, a) for a in FREQUENCY_VALUES])
+JOB_STATUS_ENUM = PyEnum("JobStatus", [(a, a) for a in JOB_STATUS_VALUES])
+NOTIFICATION_FREQUENCY_ENUM = PyEnum(
+    "NotificationFrequency", [(a, a) for a in NOTIFICATION_FREQUENCY_VALUES]
+)
+ORGANIZATION_TYPE_ENUM = PyEnum(
+    "OrganizationType", [(a, a) for a in ORGANIZATION_TYPE_VALUES]
+)
+RECORD_STATUS_ENUM = PyEnum("RecordStatus", [(a, a) for a in RECORD_STATUS_VALUES])
+SCHEMA_TYPE_ENUM = PyEnum("SchemaType", [(a, a) for a in SCHEMA_TYPE_VALUES])
+SOURCE_TYPE_ENUM = PyEnum("SourceType", [(a, a) for a in SOURCE_TYPE_VALUES])
+
+
+# must be created from a dict because "type" key
+ErrorInfo = Schema.from_dict(
+    {
+        "id": UUID(required=True),
+        "date_created": DateTime(),
+        "type": String(),
+        "message": String(),
+        "harvest_record_id": UUID(required=True),
+        "harvest_job_id": UUID(required=True),
+    },
+    name="ErrorInfo",
+)
+
+
+class JobInfo(Schema):
+    id = UUID(required=True)
+    harvest_source_id = UUID(required=True)
+    status = Enum(JOB_STATUS_ENUM, required=True)
+    job_type = String()
+    date_created = DateTime()
+    date_finished = DateTime()
+    records_total = Integer()
+    records_added = Integer()
+    records_updated = Integer()
+    records_deleted = Integer()
+    records_errored = Integer()
+    records_ignored = Integer()
+    records_validated = Integer()
+
+
+class OrgCreate(Schema):
+    name = String(required=True)
+    logo = String()
+    description = String()
+    slug = String(validate=validators.Length(max=100))
+    organization_type = Enum(ORGANIZATION_TYPE_ENUM)
+    aliases = List(String())
+
+
+class OrgInfo(OrgCreate):
+    id = UUID(required=True)
+
+
+class QueryInfo(Schema):
+    """Query input for various object types."""
+
+    harvest_job_id = UUID()
+    harvest_source_id = UUID()
+    facets = String()
+    page = Integer()
+    per_page = Integer()
+    count = Boolean()
+    order_by = String()
+
+
+class RecordInfo(Schema):
+    id = UUID(required=True)
+    identifier = String(required=True)
+    harvest_job_id = UUID(required=True)
+    harvest_source_id = UUID(required=True)
+    source_hash = String()
+    source_raw = String()
+    source_transform = Dict()
+    date_created = DateTime()
+    date_finished = DateTime()
+    ckan_id = String()
+    action = Enum(ACTION_ENUM)
+    parent_identifier = String()
+    status = Enum(RECORD_STATUS_ENUM)
+
+
+class SourceInfo(Schema):
+    id = String(required=True)
+    organization_id = UUID(required=True)
+    name = String(required=True)
+    url = String(required=True)
+    notification_emails = List(String())
+    frequency = Enum(FREQUENCY_ENUM, required=True)
+    schema_type = Enum(SCHEMA_TYPE_ENUM, required=True)
+    source_type = Enum(SOURCE_TYPE_ENUM, required=True)
+    notification_frequency = Enum(NOTIFICATION_FREQUENCY_ENUM, required=True)
+    collection_parent_url = String()

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -25,7 +25,7 @@ def _to_enum(name, values):
 ACTION_ENUM = _to_enum("Action", ACTION_VALUES)
 FREQUENCY_ENUM = _to_enum("Frequency", FREQUENCY_VALUES)
 JOB_STATUS_ENUM = _to_enum("JobStatus", JOB_STATUS_VALUES)
-NOTIFICATION_FREQUENCY_ENUM = to_enum("NotificationFrequency", NOTIFICATION_FREQUENCY_VALUES)
+NOTIFICATION_FREQUENCY_ENUM = _to_enum("NotificationFrequency", NOTIFICATION_FREQUENCY_VALUES)
 ORGANIZATION_TYPE_ENUM = _to_enum("OrganizationType", ORGANIZATION_TYPE_VALUES)
 RECORD_STATUS_ENUM = _to_enum("RecordStatus", RECORD_STATUS_VALUES)
 SCHEMA_TYPE_ENUM = _to_enum("SchemaType", SCHEMA_TYPE_VALUES)

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,45 @@
+"""APIFlask auth object to wrap our login_required logic."""
+
+import os
+import typing as t
+from functools import wraps
+
+from apiflask.security import APIKeyHeaderAuth
+from flask import redirect, request, session, url_for
+
+
+class LoginRequiredAuth(APIKeyHeaderAuth):
+
+    def get_security_scheme(self) -> dict[str, t.Any]:
+        """Hardcode our particular security scheme."""
+        security_scheme = {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header",
+        }
+        return security_scheme
+
+    def login_required(self, **kwargs):
+        """login_required returns the decorator that will be called on the view."""
+
+        def login_required_internal(f):
+            @wraps(f)
+            def decorated_function(*args, **kwargs):
+                provided_token = request.headers.get("Authorization")
+                if request.is_json or provided_token is not None:
+                    if provided_token is None:
+                        return "error: Authorization header missing", 401
+                    api_token = os.getenv("FLASK_APP_SECRET_KEY")
+                    if provided_token != api_token:
+                        return "error: Unauthorized", 401
+                    return f(*args, **kwargs)
+
+                # check session-based authentication for web users
+                if "user" not in session:
+                    session["next"] = request.url
+                    return redirect(url_for("main.login"))
+                return f(*args, **kwargs)
+
+            return decorated_function
+
+        return login_required_internal

--- a/app/commands/__init__.py
+++ b/app/commands/__init__.py
@@ -1,0 +1,13 @@
+from .job import job
+from .org import org
+from .source import source
+from .testdata import testdata
+from .user import user
+
+
+def register_commands(app):
+    app.register_blueprint(testdata)
+    app.register_blueprint(user)
+    app.register_blueprint(org)
+    app.register_blueprint(source)
+    app.register_blueprint(job)

--- a/app/commands/job.py
+++ b/app/commands/job.py
@@ -1,0 +1,20 @@
+import click
+from flask import Blueprint
+
+from database.interface import HarvesterDBInterface
+
+job = Blueprint("harvest_job", __name__)
+
+db = HarvesterDBInterface()
+
+
+## Harvet Job Management
+@job.cli.command("delete")
+@click.argument("id")
+def cli_remove_harvest_job(id):
+    """Remove a harvest job with a given id."""
+    result = db.delete_harvest_job(id)
+    if result:
+        print(f"Triggered delete of harvest job with ID: {id}")
+    else:
+        print("Failed to delete harvest job")

--- a/app/commands/org.py
+++ b/app/commands/org.py
@@ -1,0 +1,80 @@
+import click
+from flask import Blueprint
+from werkzeug.datastructures import MultiDict
+
+from database.interface import HarvesterDBInterface
+
+from ..forms import OrganizationForm
+from ..util import make_new_org_contract
+
+org = Blueprint("org", __name__)
+
+db = HarvesterDBInterface()
+
+
+@org.cli.command("add")
+@click.argument("name")
+@click.option("--slug", default="", help="Slug for the organization")
+@click.option(
+    "--logo",
+    default="https://raw.githubusercontent.com/GSA/datagov-harvester/refs/heads/main/app/static/assets/img/placeholder-organization.png",
+    help="Org Logo",
+)
+@click.option(
+    "--aliases",
+    default="",
+    help="Comma-separated list of organization aliases",
+)
+@click.option("--id", help="Org ID: should correspond to CKAN ORG ID")
+def cli_add_org(name, slug, logo, id, aliases):
+    # let the web UI handle the validation, mostly for slug uniqueness
+    form_data = MultiDict(
+        {
+            "name": name,
+            "slug": slug,
+            "logo": logo,
+            "description": "",
+            "organization_type": "",
+            "aliases": aliases,
+        }
+    )
+
+    form = OrganizationForm(formdata=form_data, meta={"csrf": False})
+    if not form.validate():
+        click.echo("Failed to add organization.")
+        for field, errors in form.errors.items():
+            for error in errors:
+                click.echo(f" - {field}: {error}")
+        return
+
+    org_contract = make_new_org_contract(form)
+    if id:
+        org_contract["id"] = id
+
+    org = db.add_organization(org_contract)
+    if org:
+        print(f"Added new organization with ID: {org.id}")
+    else:
+        print("Failed to add organization.")
+
+
+@org.cli.command("list")
+def cli_list_org():
+    """List all organizations"""
+    organizations = db.get_all_organizations()
+    if organizations:
+        for org in organizations:
+            print(f"{org.name} : {org.id}")
+    else:
+        print("No organizations found.")
+
+
+@org.cli.command("delete")
+@click.argument("id")
+def cli_remove_org(id):
+    """Remove an organization with a given id."""
+    result = db.delete_organization(id)
+    if result:
+        print(f"Triggered delete of organization with ID: {id}")
+    else:
+        print("Failed to delete organization")

--- a/app/commands/source.py
+++ b/app/commands/source.py
@@ -1,0 +1,41 @@
+import click
+from flask import Blueprint
+
+from database.interface import HarvesterDBInterface
+
+from .evaluate_sources import evaluate_sources
+
+source = Blueprint("harvest_source", __name__)
+
+db = HarvesterDBInterface()
+
+
+@source.cli.command("list")
+def cli_list_harvest_source():
+    """List all harvest sources"""
+    harvest_sources = db.get_all_harvest_sources()
+    if harvest_sources:
+        for source in harvest_sources:
+            print(f"{source.name} : {source.id}")
+    else:
+        print("No harvest sources found.")
+
+
+@source.cli.command("delete")
+@click.argument("id")
+def cli_remove_harvest_source(id):
+    """Remove a harvest source with a given id."""
+    result = db.delete_harvest_source(id)
+    if result:
+        print(f"Triggered delete of harvest source with ID: {id}")
+    else:
+        print("Failed to delete harvest source")
+
+
+@source.cli.command("evaluate_sources")
+def cli_evaluate_sources():
+    """
+    Evaluates existing sources to see if they are still availible,
+    captures the response code, and schema type.
+    """
+    evaluate_sources()

--- a/app/commands/testdata.py
+++ b/app/commands/testdata.py
@@ -1,0 +1,34 @@
+import click
+from flask import Blueprint
+
+from database.interface import HarvesterDBInterface
+
+testdata = Blueprint("testdata", __name__)
+
+db = HarvesterDBInterface()
+
+
+## Load Test Data
+# TODO move this into its own file when you break up routes
+@testdata.cli.command("load_test_data")
+def fixtures():
+    """Load database fixtures from JSON."""
+
+    from tests.generate_fixtures import generate_dynamic_fixtures
+
+    fixture = generate_dynamic_fixtures()
+
+    for item in fixture["organization"]:
+        db.add_organization(item)
+    for item in fixture["source"]:
+        db.add_harvest_source(item)
+    for item in fixture["job"]:
+        db.add_harvest_job(item)
+    for item in fixture["job_error"]:
+        db.add_harvest_job_error(item)
+    for item in fixture["record"]:
+        db.add_harvest_record(item)
+    for item in fixture["record_error"]:
+        db.add_harvest_record_error(item)
+
+    click.echo("Done.")

--- a/app/commands/user.py
+++ b/app/commands/user.py
@@ -1,0 +1,50 @@
+import click
+from flask import Blueprint
+
+from database.interface import HarvesterDBInterface
+
+user = Blueprint("user", __name__)
+
+db = HarvesterDBInterface()
+
+
+# CLI commands
+## User management
+@user.cli.command("add")
+@click.argument("email")
+@click.option("--name", default="", help="Name of the user")
+def add_user(email, name):
+    """add new user with .gov email."""
+
+    email = email.lower()
+    usr_data = {"email": email}
+    if name:
+        usr_data["name"] = name
+
+    success, message = db.add_user(usr_data)
+    if success:
+        print("User added successfully!")
+    else:
+        print("Error:", message)
+
+
+@user.cli.command("list")
+def list_users():
+    """List all users' emails."""
+    users = db.list_users()
+    if users:
+        for user in users:
+            print(user.email)
+    else:
+        print("No users found.")
+
+
+@user.cli.command("remove")
+@click.argument("email")
+def remove_user(email):
+    """Remove a user with the given EMAIL."""
+    email = email.lower()
+    if db.remove_user(email):
+        print(f"Removed user with email: {email}")
+    else:
+        print("Failed to remove user or user not found.")

--- a/app/routes.py
+++ b/app/routes.py
@@ -173,7 +173,7 @@ def create_client_assertion():
 def trigger_manual_job_helper(source_id, job_type="harvest"):
     message = load_manager.trigger_manual_job(source_id, job_type)
     flash(message)
-    return redirect(url_for("main.view_harvest_source", source_id=source_id))
+    return redirect(url_for("api.view_harvest_source", source_id=source_id))
 
 
 @main.route("/login")
@@ -526,7 +526,7 @@ def view_harvest_source(source_id: str):
     elif request.method == "POST":
         form = HarvestTriggerForm(request.form)
         if form.data["edit"]:
-            return redirect(url_for("main.edit_harvest_source", source_id=source_id))
+            return redirect(url_for("api.edit_harvest_source", source_id=source_id))
         elif form.data["harvest"]:
             if form.data["force_check"]:
                 return trigger_manual_job_helper(source_id, "force_harvest")
@@ -541,7 +541,7 @@ def view_harvest_source(source_id: str):
                 flash(message)
                 if status == 409:
                     return redirect(
-                        url_for("main.view_harvest_source", source_id=source_id)
+                        url_for("api.view_harvest_source", source_id=source_id)
                     )
                 else:
                     return redirect(url_for("main.harvest_source_list"))
@@ -550,10 +550,10 @@ def view_harvest_source(source_id: str):
                 logger.error(message)
                 flash(message)
                 return redirect(
-                    url_for("main.view_harvest_source", source_id=source_id)
+                    url_for("api.view_harvest_source", source_id=source_id)
                 )
         else:
-            return redirect(url_for("main.view_harvest_source", source_id=source_id))
+            return redirect(url_for("api.view_harvest_source", source_id=source_id))
 
     else:
         form = HarvestTriggerForm()

--- a/app/templates/components/job-table/job_table.j2
+++ b/app/templates/components/job-table/job_table.j2
@@ -24,13 +24,13 @@
             {% for job in jobs %}
             <tr>
                 <td data-sort-value="{{ job.id }}">
-                    <a href="{{ url_for('main.view_harvest_job', job_id=job.id) }}">
+                    <a href="{{ url_for('api.view_harvest_job', job_id=job.id) }}">
                         {{ job.id[:6] }}
                     </a>
                 </td>
                 {% if show_source %}
                 <td data-sort-value="{{ job.source.name }}">
-                    <a href="{{ url_for('main.view_harvest_source', source_id=job.source.id) }}" title="{{ job.source.name }}">
+                    <a href="{{ url_for('api.view_harvest_source', source_id=job.source.id) }}" title="{{ job.source.name }}">
                         <span class="display-none tablet:display-inline">{{ job.source.name[:25] }}{% if job.source.name|length > 25 %}...{% endif %}</span>
                         <span class="tablet:display-none">{{ job.source.name[:12] }}{% if job.source.name|length > 12 %}...{% endif %}</span>
                     </a>

--- a/app/templates/metrics_dashboard.html
+++ b/app/templates/metrics_dashboard.html
@@ -68,12 +68,12 @@
                       {% for error in data.failures %}
                       <tr>
                           <td data-sort-value="{{ error.job.id }}">
-                              <a href="{{ url_for('main.view_harvest_job', job_id=error.job.id) }}">
+                              <a href="{{ url_for('api.view_harvest_job', job_id=error.job.id) }}">
                                   {{ error.job.id[:8] }}
                               </a>
                           </td>
                           <td data-sort-value="{{ error.job.source.name }}">
-                              <a href="{{ url_for('main.view_harvest_source', source_id=error.job.source.id) }}">
+                              <a href="{{ url_for('api.view_harvest_source', source_id=error.job.source.id) }}">
                                   {{ error.job.source.name }}
                               </a>
                           </td>

--- a/app/templates/view_job_data.html
+++ b/app/templates/view_job_data.html
@@ -29,7 +29,7 @@
             <tr>
                 {% if key == 'harvest_source_id' %}
                 <td>Harvest Source:</td>
-                <td><a href="{{ url_for('main.view_harvest_source', source_id=value) }}">{{data.job.source.name}}</a></td>
+                <td><a href="{{ url_for('api.view_harvest_source', source_id=value) }}">{{data.job.source.name}}</a></td>
                 {% elif key == 'date_created' or key == 'date_finished' %}
                 <td>{{key}}:</td>
                 <td class="utc-date" data-utc-date="{{ value | utc_isoformat }}">
@@ -50,7 +50,7 @@
     <div class="config-actions">
         <ul class="usa-button-group">
             <li class="usa-button-group__item">
-                <a href="{{ url_for('main.cancel_harvest_job', job_id=data.job.id)}}">
+                <a href="{{ url_for('api.cancel_harvest_job', job_id=data.job.id)}}">
                     <button class="usa-button usa-button--secondary">Cancel</button>
                 </a>
             </li>
@@ -63,7 +63,7 @@
         No job errors found
         {% else %}
         {% set error_type = "job" %}
-        <a href="{{ url_for('main.download_harvest_errors_by_job', job_id=data.job.id, error_type=error_type)}}">
+        <a href="{{ url_for('api.download_harvest_errors_by_job', job_id=data.job.id, error_type=error_type)}}">
             <button class="btn btn-primary">download job errors as .csv</button>
         </a>
         <div class="usa-table-container--scrollable" tabindex="0">
@@ -101,7 +101,7 @@
         <p>No record errors found</p>
         {% else %}
         {% set error_type = "record" %}
-        <a href="{{ url_for('main.download_harvest_errors_by_job', job_id=data.job.id, error_type=error_type)}}">
+        <a href="{{ url_for('api.download_harvest_errors_by_job', job_id=data.job.id, error_type=error_type)}}">
             <button class="btn btn-primary">download record errors as .csv</button>
         </a>
 
@@ -136,7 +136,7 @@
                         <p><strong>Harvest Record ID:</strong>
                             {% if record_error.error.harvest_record_id %}
                             <a
-                                href="{{ url_for('main.get_harvest_record', record_id=record_error.error.harvest_record_id) }}">
+                                href="{{ url_for('api.get_harvest_record', record_id=record_error.error.harvest_record_id) }}">
                                 {{ record_error.error.harvest_record_id }}
                             </a>
                             {% else %}

--- a/app/templates/view_org_data.html
+++ b/app/templates/view_org_data.html
@@ -77,12 +77,12 @@
                     {% for source in data.harvest_sources %}
                     <tr>
                         <td data-sort-value={{source.date_created}}><a
-                                href="{{ url_for('main.view_harvest_source', source_id=source.id) }}">{{source.name}}</a>
+                                href="{{ url_for('api.view_harvest_source', source_id=source.id) }}">{{source.name}}</a>
                         </td>
                         <td scope="row" class="text-center">
                             {% if data.harvest_jobs[source.id] %}
                             {% set last_job_has_errors = (data.harvest_jobs[source.id].errors | length) == 0 %}
-                            <a href="{{ url_for('main.view_harvest_job', job_id=data.harvest_jobs[source.id].id) }}">
+                            <a href="{{ url_for('api.view_harvest_job', job_id=data.harvest_jobs[source.id].id) }}">
                                 <svg class="usa-icon align-middle {% if last_job_has_errors %}check{%else%}cancel{%endif%}"
                                     aria-hidden="true" focusable="false" role="img">
                                     <use

--- a/app/templates/view_org_list.html
+++ b/app/templates/view_org_list.html
@@ -15,7 +15,7 @@
   {% if session['user'] %}
   <div class="add-buttons-div mt-3">
     <ul class="list-unstyled">
-      <li><a href="{{ url_for('main.add_organization') }}" class="btn btn-primary">
+      <li><a href="{{ url_for('api.add_organization') }}" class="btn btn-primary">
           Add Organization</a></li>
     </ul>
   </div>
@@ -36,7 +36,7 @@
       </div>
       <div class="usa-card__body"></div>
       <div class="usa-card__footer">
-        <a href="{{ url_for('main.view_organization', org_id=org.id) }}"
+        <a href="{{ url_for('api.view_organization', org_id=org.id) }}"
           class="usa-button usa-button--outline">Details</a>
       </div>
     </div>

--- a/app/templates/view_source_data.html
+++ b/app/templates/view_source_data.html
@@ -36,7 +36,7 @@
             <tr>
                 {% if key == 'organization_id' %}
                 <td>Organization:</td>
-                <td><a href="{{ url_for('main.view_organization', org_id=value) }}">{{data.source.org.name}}</a></td>
+                <td><a href="{{ url_for('api.view_organization', org_id=value) }}">{{data.source.org.name}}</a></td>
                 {% elif key == 'notification_emails' %}
                 {% if session['user'] %}
                 <td>Notification emails:</td>

--- a/app/templates/view_source_data.html
+++ b/app/templates/view_source_data.html
@@ -93,7 +93,7 @@
     <br>
     <h2>Summary: </h2>
     {% if data.summary_data["active_job_in_progress"] %}
-    <a class="text-error" href="{{ url_for('main.view_harvest_job', job_id=data.jobs[0].id)}}">
+    <a class="text-error" href="{{ url_for('api.view_harvest_job', job_id=data.jobs[0].id)}}">
         <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
             <use href="/assets/uswds/img/sprite.svg#alarm"></use>
         </svg>

--- a/app/templates/view_source_list.html
+++ b/app/templates/view_source_list.html
@@ -17,7 +17,7 @@
     {% if session['user'] %}
     <div class="add-buttons-div mt-3">
         <ul class="list-unstyled">
-            <li><a href="{{ url_for('main.add_harvest_source') }}" class="btn btn-primary">
+            <li><a href="{{ url_for('api.add_harvest_source') }}" class="btn btn-primary">
                     Add Harvest Source</a></li>
         </ul>
     </div>
@@ -36,7 +36,7 @@
             <div class="usa-card__footer">
                 <ul class="usa-button-group">
                     <li class="usa-button-group__item">
-                        <a href="{{ url_for('main.view_harvest_source', source_id=source.id) }}"
+                        <a href="{{ url_for('api.view_harvest_source', source_id=source.id) }}"
                             class="usa-button usa-button--outline">Details</a>
                     </li>
                 </ul>

--- a/app/util.py
+++ b/app/util.py
@@ -1,0 +1,46 @@
+# Helper Functions
+def make_new_source_contract(form):
+    return {
+        "organization_id": form.organization_id.data,
+        "name": form.name.data,
+        "url": form.url.data,
+        "notification_emails": form.notification_emails.data,
+        "frequency": form.frequency.data,
+        "schema_type": form.schema_type.data,
+        "source_type": form.source_type.data,
+        "notification_frequency": form.notification_frequency.data,
+    }
+
+
+def make_new_record_error_contract(error: tuple) -> dict:
+    """
+    convert the record error row tuple into a dict. splits the validation message
+    value into an array
+    """
+    fields = [
+        "harvest_record_id",
+        "harvest_job_id",
+        "date_created",
+        "type",
+        "message",
+        "id",
+    ]
+
+    # identifier and source_raw are the last 2 and kept the same
+    record_error = dict(zip(fields, error[:-2]))
+    error_type = error[3]
+    if error_type in ["ValidationException", "ValidationError"]:
+        record_error["message"] = record_error["message"].split("::")  # turn into array
+
+    return record_error
+
+
+def make_new_org_contract(form):
+    return {
+        "name": form.name.data,
+        "slug": form.slug.data,
+        "logo": form.logo.data,
+        "description": form.description.data or None,
+        "organization_type": form.organization_type.data or None,
+        "aliases": [alias.strip() for alias in (form.aliases.data or "").split(",")],
+    }

--- a/database/models.py
+++ b/database/models.py
@@ -7,10 +7,17 @@ from flask_sqlalchemy import SQLAlchemy
 from geoalchemy2 import Geometry
 from sqlalchemy import CheckConstraint, Column, Enum, String, func
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import DeclarativeBase, backref
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import DeclarativeBase, backref
 
-from shared.constants import ORGANIZATION_TYPE_VALUES
+from shared.constants import (
+    FREQUENCY_VALUES,
+    JOB_STATUS_VALUES,
+    NOTIFICATION_FREQUENCY_VALUES,
+    ORGANIZATION_TYPE_VALUES,
+    SCHEMA_TYPE_VALUES,
+    SOURCE_TYPE_VALUES,
+)
 
 
 class Base(DeclarativeBase):
@@ -75,11 +82,7 @@ class HarvestSource(db.Model):
     notification_emails = db.Column(db.ARRAY(db.String))
     frequency = db.Column(
         Enum(
-            "manual",
-            "daily",
-            "weekly",
-            "biweekly",
-            "monthly",
+            *FREQUENCY_VALUES,
             name="frequency",
         ),
         nullable=False,
@@ -87,17 +90,14 @@ class HarvestSource(db.Model):
     )
     schema_type = db.Column(
         db.Enum(
-            "iso19115_1",
-            "iso19115_2",
-            "dcatus1.1: federal",
-            "dcatus1.1: non-federal",
+            *SCHEMA_TYPE_VALUES,
             name="schema_type",
         ),
         nullable=False,
     )
 
     source_type = db.Column(
-        db.Enum("document", "waf", "waf-collection", name="source_type"), nullable=False
+        db.Enum(*SOURCE_TYPE_VALUES, name="source_type"), nullable=False
     )
     jobs = db.relationship(
         "HarvestJob",
@@ -107,9 +107,7 @@ class HarvestSource(db.Model):
     )
     notification_frequency = db.Column(
         db.Enum(
-            "on_error",
-            "always",
-            "on_error_or_update",
+            *NOTIFICATION_FREQUENCY_VALUES,
             name="notification_frequency",
         ),
         nullable=False,
@@ -126,10 +124,7 @@ class HarvestJob(db.Model):
 
     status = db.Column(
         Enum(
-            "in_progress",
-            "complete",
-            "new",
-            "error",
+            *JOB_STATUS_VALUES,
             name="job_status",
         ),
         nullable=False,
@@ -201,12 +196,7 @@ class Dataset(db.Model):
     # Base has a string `id` column that is uuid by default
 
     # slug is the string that we use in a URL for this dataset
-    slug = db.Column(
-        db.String,
-        nullable=False,
-        index=True,
-        unique=True
-    )
+    slug = db.Column(db.String, nullable=False, index=True, unique=True)
 
     # This is all of the details of the dataset in DCAT schema in a JSON column
     # make it mutable so that in-place mutations (e.g.,
@@ -236,10 +226,7 @@ class Dataset(db.Model):
     )
 
     popularity = db.Column(db.Integer, server_default="0")
-    last_harvested_date = db.Column(
-        db.DateTime,
-        index=True
-    )
+    last_harvested_date = db.Column(db.DateTime, index=True)
 
     organization = db.relationship(
         "Organization",

--- a/poetry.lock
+++ b/poetry.lock
@@ -207,6 +207,66 @@ alembic = ">=1.7"
 SQLAlchemy = ">=1.4"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+description = "Reusable constraint types to use with typing.Annotated"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
+name = "apiflask"
+version = "3.0.2"
+description = "A lightweight web API framework based on Flask."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "apiflask-3.0.2-py3-none-any.whl", hash = "sha256:fd9865fd6d4e331b4e4c9482f1e1c43981b47b97eab68be0d81122398b6dad91"},
+    {file = "apiflask-3.0.2.tar.gz", hash = "sha256:106c3011da9f7fff86e33ea47294f84b4d0f7c121d67af6aac387363af997443"},
+]
+
+[package.dependencies]
+apispec = ">=6.0.0"
+flask = ">=2.1.0"
+flask-httpauth = ">=4.8.0"
+flask-marshmallow = ">=1.0.0"
+marshmallow = ">=3.20"
+pydantic = {version = ">=2.0", extras = ["email"]}
+webargs = ">=8.3"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
+yaml = ["pyyaml"]
+
+[[package]]
+name = "apispec"
+version = "6.9.0"
+description = "A pluggable API specification generator. Currently supports the OpenAPI Specification (f.k.a. the Swagger specification)."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "apispec-6.9.0-py3-none-any.whl", hash = "sha256:4c275f0a6dac0bcfcceee00b451a16b650f9184a57c624b0b6d12d82b8d15a61"},
+    {file = "apispec-6.9.0.tar.gz", hash = "sha256:7a38ce7c3eedc7771e6e33295afdd8c4b0acdd9865b483f8cf6cc369c93e8d1e"},
+]
+
+[package.dependencies]
+packaging = ">=21.3"
+
+[package.extras]
+dev = ["apispec[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
+docs = ["apispec[marshmallow]", "pyyaml (==6.0.3)", "sphinx (==8.2.3)", "sphinx-issues (==5.0.1)", "sphinx-rtd-theme (==3.0.2)"]
+marshmallow = ["marshmallow (>=3.18.0)"]
+tests = ["apispec[marshmallow,yaml]", "openapi-spec-validator (==0.7.2)", "pytest"]
+yaml = ["PyYAML (>=3.10)"]
+
+[[package]]
 name = "arrow"
 version = "1.4.0"
 description = "Better dates & times for Python"
@@ -907,6 +967,27 @@ files = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
+    {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
+]
+
+[package.extras]
+dev = ["black (>=25.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.17.0)", "mypy (>=1.17)", "pylint (>=3)", "pytest (>=8.4)", "pytest-cov (>=6.2.0)", "quart-trio (>=0.12.0)", "sphinx (>=8.2.0)", "sphinx-rtd-theme (>=3.0.0)", "twine (>=6.1.0)", "wheel (>=0.45.0)"]
+dnssec = ["cryptography (>=45)"]
+doh = ["h2 (>=4.2.0)", "httpcore (>=1.0.0)", "httpx (>=0.28.0)"]
+doq = ["aioquic (>=1.2.0)"]
+idna = ["idna (>=3.10)"]
+trio = ["trio (>=0.30)"]
+wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 description = "Pythonic argument parser, that will make you smile"
@@ -928,6 +1009,22 @@ files = [
     {file = "dominate-2.9.1-py2.py3-none-any.whl", hash = "sha256:cb7b6b79d33b15ae0a6e87856b984879927c7c2ebb29522df4c75b28ffd9b989"},
     {file = "dominate-2.9.1.tar.gz", hash = "sha256:558284687d9b8aae1904e3d6051ad132dd4a8c0cf551b37ea4e7e42a31d19dc4"},
 ]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+description = "A robust email address syntax and deliverability validation library."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"},
+    {file = "email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
 
 [[package]]
 name = "filelock"
@@ -995,6 +1092,43 @@ files = [
 
 [package.dependencies]
 Flask = ">=2.0.2,<4.0.0"
+
+[[package]]
+name = "flask-httpauth"
+version = "4.8.0"
+description = "HTTP authentication for Flask routes"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "Flask-HTTPAuth-4.8.0.tar.gz", hash = "sha256:66568a05bc73942c65f1e2201ae746295816dc009edd84b482c44c758d75097a"},
+    {file = "Flask_HTTPAuth-4.8.0-py3-none-any.whl", hash = "sha256:a58fedd09989b9975448eef04806b096a3964a7feeebc0a78831ff55685b62b0"},
+]
+
+[package.dependencies]
+flask = "*"
+
+[[package]]
+name = "flask-marshmallow"
+version = "1.3.0"
+description = "Flask + marshmallow for beautiful APIs"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "flask_marshmallow-1.3.0-py3-none-any.whl", hash = "sha256:c0a0644b46406851873ab41c1e8a7de3ef27fa69b00b89bf630f1696ec0813a0"},
+    {file = "flask_marshmallow-1.3.0.tar.gz", hash = "sha256:27a35d0ce5dcba161cc5f2f4764afbc2536c93fa439a793250b827835e3f3be6"},
+]
+
+[package.dependencies]
+Flask = ">=2.2"
+marshmallow = ">=3.0.0"
+
+[package.extras]
+dev = ["flask-marshmallow[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
+docs = ["Sphinx (==8.1.3)", "marshmallow-sqlalchemy (>=0.19.0)", "sphinx-issues (==5.0.0)"]
+sqlalchemy = ["flask-sqlalchemy (>=3.0.0)", "marshmallow-sqlalchemy (>=0.29.0)"]
+tests = ["flask-marshmallow[sqlalchemy]", "pytest"]
 
 [[package]]
 name = "flask-migrate"
@@ -1861,6 +1995,23 @@ files = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "4.2.1"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "marshmallow-4.2.1-py3-none-any.whl", hash = "sha256:d82b1a83cfbb4667d050850fbed4e9d4435576cb95f5ff37894f375dce201768"},
+    {file = "marshmallow-4.2.1.tar.gz", hash = "sha256:4d1d66189c8d279ca73a6b0599d74117e5f8a3830b5cd766b75c2bb08e3464e7"},
+]
+
+[package.extras]
+dev = ["marshmallow[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
+docs = ["autodocsumm (==0.2.14)", "furo (==2025.12.19)", "sphinx (==8.2.3)", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.1)", "sphinxext-opengraph (==0.13.0)"]
+tests = ["pytest", "simplejson"]
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 description = "multidict implementation"
@@ -2616,6 +2767,163 @@ files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
 ]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+description = "Data validation using Python type hints"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d"},
+    {file = "pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"},
+]
+
+[package.dependencies]
+annotated-types = ">=0.6.0"
+email-validator = {version = ">=2.0.0", optional = true, markers = "extra == \"email\""}
+pydantic-core = "2.41.5"
+typing-extensions = ">=4.14.1"
+typing-inspection = ">=0.4.2"
+
+[package.extras]
+email = ["email-validator (>=2.0.0)"]
+timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows\""]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+description = "Core functionality for Pydantic validation and serialization"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8bfeaf8735be79f225f3fefab7f941c712aaca36f1128c9d7e2352ee1aa87bdf"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:346285d28e4c8017da95144c7f3acd42740d637ff41946af5ce6e5e420502dd5"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a75dafbf87d6276ddc5b2bf6fae5254e3d0876b626eb24969a574fff9149ee5d"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b93a4d08587e2b7e7882de461e82b6ed76d9026ce91ca7915e740ecc7855f60"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8465ab91a4bd96d36dde3263f06caa6a8a6019e4113f24dc753d79a8b3a3f82"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:299e0a22e7ae2b85c1a57f104538b2656e8ab1873511fd718a1c1c6f149b77b5"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:707625ef0983fcfb461acfaf14de2067c5942c6bb0f3b4c99158bed6fedd3cf3"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f41eb9797986d6ebac5e8edff36d5cef9de40def462311b3eb3eeded1431e425"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0384e2e1021894b1ff5a786dbf94771e2986ebe2869533874d7e43bc79c6f504"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:f0cd744688278965817fd0839c4a4116add48d23890d468bc436f78beb28abf5"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:753e230374206729bf0a807954bcc6c150d3743928a73faffee51ac6557a03c3"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-win32.whl", hash = "sha256:873e0d5b4fb9b89ef7c2d2a963ea7d02879d9da0da8d9d4933dee8ee86a8b460"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-win_amd64.whl", hash = "sha256:e4f4a984405e91527a0d62649ee21138f8e3d0ef103be488c1dc11a80d7f184b"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51"},
+    {file = "pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pyee"
@@ -3555,6 +3863,21 @@ files = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+description = "Runtime typing introspection tools"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12.0"
+
+[[package]]
 name = "tzdata"
 version = "2025.2"
 description = "Provider of IANA time zone data"
@@ -3642,6 +3965,28 @@ groups = ["main"]
 files = [
     {file = "visitor-0.1.3.tar.gz", hash = "sha256:2c737903b2b6864ebc6167eef7cf3b997126f1aa94bdf590f90f1436d23e480a"},
 ]
+
+[[package]]
+name = "webargs"
+version = "8.7.1"
+description = "Declarative parsing and validation of HTTP request objects, with built-in support for popular web frameworks, including Flask, Django, Bottle, Tornado, Pyramid, Falcon, and aiohttp."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "webargs-8.7.1-py3-none-any.whl", hash = "sha256:a184aed9d2509e6e14ab99ee3e9dc3a614c7070affe94cd4dfdb0d002e0a6e5f"},
+    {file = "webargs-8.7.1.tar.gz", hash = "sha256:799bf9039c76c23fd8dc1951107a75a9e561203c15d6ae8f89c1e46e234636c1"},
+]
+
+[package.dependencies]
+marshmallow = ">=3.13.0,<5.0.0"
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["pre-commit (>=3.5,<5.0)", "tox", "webargs[tests]"]
+docs = ["Sphinx (==8.2.3)", "furo (==2025.9.25)", "sphinx-issues (==5.0.1)", "webargs[frameworks]"]
+frameworks = ["Django (>=2.2.0)", "Flask (>=0.12.5)", "aiohttp (>=3.0.8)", "bottle (>=0.12.13)", "falcon (>=2.0.0)", "pyramid (>=1.9.1)", "tornado (>=4.5.2)"]
+tests = ["packaging (>=17.0)", "pytest", "pytest-aiohttp (>=0.3.0)", "pytest-asyncio", "webargs[frameworks]", "webtest (==3.0.7)", "webtest-aiohttp (==2.0.0)"]
 
 [[package]]
 name = "webcolors"
@@ -3937,4 +4282,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12.0"
-content-hash = "e6323839e2e4758a9c29d6a2c28e4855abc39611d7251223ec6046de28423995"
+content-hash = "437313f959655405c1442202e1ccccf3fb002b4813b9e7d8a37d55bbc80e337c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ google-auth = "^2.48.0"
 google-api-python-client = "^2.188.0"
 pyasn1 = "^0.6.2" #SNYK-PYTHON-PYASN1-15032639
 werkzeug = "^3.1.5" #SNYK-PYTHON-WERKZEUG-14908843
+apiflask = "^3.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.3.2"

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -1,5 +1,28 @@
 # NOTE: Keep this file in sync between datagov-harvester and datagov-catalog
 
+ACTION_VALUES = ["create", "update", "delete"]
+
+FREQUENCY_VALUES = [
+    "manual",
+    "daily",
+    "weekly",
+    "biweekly",
+    "monthly",
+]
+
+JOB_STATUS_VALUES = [
+    "in_progress",
+    "complete",
+    "new",
+    "error",
+]
+
+NOTIFICATION_FREQUENCY_VALUES = [
+    "on_error",
+    "always",
+    "on_error_or_update",
+]
+
 ORGANIZATION_TYPE_VALUES = (
     "Federal Government",
     "City Government",
@@ -14,7 +37,25 @@ ORGANIZATION_TYPE_SELECT_CHOICES = [
     ("", "Select an organization type"),
 ] + [(value, value) for value in ORGANIZATION_TYPE_VALUES]
 
+RECORD_STATUS_VALUES = ["error", "success"]
+
+SCHEMA_TYPE_VALUES = [
+    "iso19115_1",
+    "iso19115_2",
+    "dcatus1.1: federal",
+    "dcatus1.1: non-federal",
+]
+
+SOURCE_TYPE_VALUES = ["document", "waf", "waf-collection"]
+
 __all__ = [
+    "ACTION_VALUES",
+    "FREQUENCY_VALUES",
+    "JOB_STATUS_VALUES",
+    "NOTIFICATION_FREQUENCY_VALUES",
     "ORGANIZATION_TYPE_VALUES",
     "ORGANIZATION_TYPE_SELECT_CHOICES",
+    "RECORD_STATUS_VALUES",
+    "SCHEMA_TYPE_VALUES",
+    "SOURCE_TYPE_VALUES",
 ]

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -151,26 +151,30 @@ class TestDynamicRouteTable:
 
         # some endpoints respond with JSON
         json_responses_map = {
-            "main.get_harvest_record": '{"error":"Not Found"}\n',
-            "main.get_harvest_record_raw": '{"error":"Not Found"}\n',
-            "main.get_all_harvest_record_errors": '{"error":"Not Found"}\n',
-            "main.get_harvest_error": '{"error":"Not Found"}\n',
+            "api.get_harvest_record": '{"error":"Not Found"}\n',
+            "api.get_harvest_record_raw": '{"error":"Not Found"}\n',
+            "api.get_all_harvest_record_errors": '{"error":"Not Found"}\n',
+            "api.get_harvest_error": '{"error":"Not Found"}\n',
         }
         # some respond with a template
         # ruff: noqa: E501
         templated_responses_map = {
             "api.view_organization": {
                 "GET": "Looks like you navigated to an organization that doesn't exist",
+            },
+            "main.view_organization": {
                 "POST": 'You should be redirected automatically to the target URL: <a href="/organization/1234">/organization/1234</a>',
             },
-            "main.view_harvest_source": {
+            "api.view_harvest_source": {
                 "GET": "Looks like you navigated to a harvest source that doesn't exist",
+            },
+            "main.view_harvest_source": {
                 "POST": 'You should be redirected automatically to the target URL: <a href="/harvest_source/1234">/harvest_source/1234</a>',
             },
-            "main.view_harvest_job": {
+            "api.view_harvest_job": {
                 "GET": "Looks like you navigated to a harvest job that doesn't exist"
             },
-            "main.download_harvest_errors_by_job": {
+            "api.download_harvest_errors_by_job": {
                 "GET": "Invalid error type. Must be 'job' or 'record'"
             },
         }
@@ -184,6 +188,7 @@ class TestDynamicRouteTable:
                 if method in ["HEAD", "OPTIONS"]:
                     continue  # we get no response body from these methods, so skip them
                 client_method = getattr(client, method.lower(), None)
+                print(route, route.endpoint, method)
                 res = client_method(cleaned_route_rule)
 
                 if route.endpoint in json_responses_map:

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -147,7 +147,7 @@ class TestDynamicRouteTable:
 
     def test_client_response_on_error(self, client):
         # ignore routes which aren't public GETS and don't accept args
-        whitelisted_route_regex = r"((main|api|bootstrap)?(?:\.)?(add|edit|cancel|update|delete|trigger|view)?(?:_)?(static|index|callback|json_builder_query|view_metrics|log(in|out)|organization(?:s)?|harvest_source|harvest_job|harvest_record))"
+        whitelisted_route_regex = r"((main|api|bootstrap)?(?:\.)?(add|edit|cancel|update|delete|trigger|view)?(?:_)?(static|index|callback|json_builder_query|view_metrics|log(in|out)|organization(?:s)?|harvest_source|harvest_job|harvest_record)|openapi.\w+)"
 
         # some endpoints respond with JSON
         json_responses_map = {
@@ -159,7 +159,7 @@ class TestDynamicRouteTable:
         # some respond with a template
         # ruff: noqa: E501
         templated_responses_map = {
-            "main.view_organization": {
+            "api.view_organization": {
                 "GET": "Looks like you navigated to an organization that doesn't exist",
                 "POST": 'You should be redirected automatically to the target URL: <a href="/organization/1234">/organization/1234</a>',
             },
@@ -257,7 +257,7 @@ class TestJSONResponses:
         organization_data,
     ):
         res = client.get(
-            f"/organization/{organization_data['id']}-missing",
+            f"/organization/{organization_data['id'].replace('a', 'b')}",
             headers={"Content-type": "application/json"},
         )
         assert res.status_code == 404

--- a/tests/playwright/test_harvest_create_and_destroy.py
+++ b/tests/playwright/test_harvest_create_and_destroy.py
@@ -25,7 +25,7 @@ def apage_with_org(apage):
     apage.get_by_role("button", name="Submit").click()
     yield apage
     apage.get_by_role("link", name="Organizations").click()
-    apage.get_by_role("listitem").filter(has_text="Test Org New").nth(1).get_by_role(
+    apage.get_by_role("listitem").filter(has_text="Test Org New").nth(0).get_by_role(
         "link"
     ).click()
     apage.once("dialog", lambda dialog: dialog.accept())
@@ -49,7 +49,7 @@ class TestHarvestCreateAndDestroy:
 
         apage.get_by_role("link", name="Organizations").click()
         apage.get_by_role("listitem").filter(has_text="Test Org New").nth(
-            1
+            0
         ).get_by_role("link").click()
         apage.once("dialog", lambda dialog: dialog.accept())
         apage.get_by_role("button", name="Delete", exact=True).click()


### PR DESCRIPTION
# Pull Request

Related to GSA/Data.gov#4732

## About

As requested in the ticket, to produce an OpenAPI spec for the read-only part of our API, we use the [APIFlask](https://apiflask.com/) library. It extends Flask's `Blueprint` with a new `APIBlueprint` class that instruments the routes in that blueprint and documents them in to the `openapi.json` file. To make it work right, we had to make some other substantial changes:

1. Commands have been taken out of the `app/routes.py` file and put into an `app/commands/` module following the pattern we use in `datagov-catalog`.
2. All enumerated values from `database/models.py` got moved into `shared/constants.py` so they can be re-used in the documentation.
3. Lots of `url_for` calls changed as the methods moved from the `main` blueprint into the `api` blueprint.
4. Our `login_required` decorator was restructured to work the APIFlask `auth` system so if we eventually want to produce OpenAPI spec for the full authenticated API, that configuration is ready.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [x] Files linted
