### PR TITLE
slightly improve validation message format for regexes

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
 from typing import List
+import re
 
 import requests
 from jsonschema import Draft202012Validator, FormatChecker
@@ -956,9 +957,12 @@ class Record:
         execution proceeds. If callers want to raise, they need
         to `raise e` after calling this method.
         """
+
+        e_msg = re.sub(r"\\+", r"\\", repr(e))
+
         self.status = "error"
         log_non_critical_error(
-            repr(e),
+            e_msg,
             self.harvest_source.job_id,
             self.id,
             e.__class__.__name__,

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -132,7 +132,7 @@ class TestValidateDataset:
         assert len(errors) == 1
 
         # ruff: noqa E501
-        expected = "<ValidationError: \"$.license, 'center' does not match any of the acceptable formats: 'uri', 'null', '^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$'\">"
+        expected = "<ValidationError: \"$.license, 'center' does not match any of the acceptable formats: 'uri', 'null', '^(\\[\\[REDACTED).*?(\\]\\])$'\">"
         assert errors[0].message == expected
 
     def test_multiple_invalid(
@@ -162,9 +162,9 @@ class TestValidateDataset:
 
         # ruff: noqa E501
         expected = [
-            "<ValidationError: '$.contactPoint.hasEmail, \\'ocagoadmin@oakgov.com\\' does not match any of the acceptable formats: \"^mailto:[\\\\\\\\w\\\\\\\\_\\\\\\\\~\\\\\\\\!\\\\\\\\$\\\\\\\\&\\\\\\\\\\'\\\\\\\\(\\\\\\\\)\\\\\\\\*\\\\\\\\+\\\\\\\\,\\\\\\\\;\\\\\\\\=\\\\\\\\:.-]+@[\\\\\\\\w.-]+\\\\\\\\.[\\\\\\\\w.-]+?$\", \\'^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$\\''>",
-            "<ValidationError: \"$.distribution[0].accessURL, '//////not-a-url.example.com/' does not match any of the acceptable formats: 'uri', 'null', '^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$'\">",
-            "<ValidationError: \"$.license, 'center' does not match any of the acceptable formats: 'uri', 'null', '^(\\\\\\\\[\\\\\\\\[REDACTED).*?(\\\\\\\\]\\\\\\\\])$'\">",
+            "<ValidationError: '$.contactPoint.hasEmail, \\'ocagoadmin@oakgov.com\\' does not match any of the acceptable formats: \"^mailto:[\\w\\_\\~\\!\\$\\&\\'\\(\\)\\*\\+\\,\\;\\=\\:.-]+@[\\w.-]+\\.[\\w.-]+?$\", \\'^(\\[\\[REDACTED).*?(\\]\\])$\\''>",
+            "<ValidationError: \"$.distribution[0].accessURL, '//////not-a-url.example.com/' does not match any of the acceptable formats: 'uri', 'null', '^(\\[\\[REDACTED).*?(\\]\\])$'\">",
+            "<ValidationError: \"$.license, 'center' does not match any of the acceptable formats: 'uri', 'null', '^(\\[\\[REDACTED).*?(\\]\\])$'\">",
         ]
 
         for i in range(len(errors)):
@@ -350,9 +350,9 @@ class TestValidateDataset:
         self, organization_data, valid_iso_2_record
     ):
         valid_iso_2_record.transform()
-        valid_iso_2_record.transformed_data["distribution"][0][
-            "downloadURL"
-        ] = "www.example.com/"
+        valid_iso_2_record.transformed_data["distribution"][0]["downloadURL"] = (
+            "www.example.com/"
+        )
         # makes the record invalid
         assert not valid_iso_2_record.validate()
 
@@ -367,9 +367,9 @@ class TestValidateDataset:
 
     def test_transformed_iso_accessURL_placeholder(self, valid_iso_2_record):
         valid_iso_2_record.transform()
-        valid_iso_2_record.transformed_data["distribution"][0][
-            "accessURL"
-        ] = "www.example.com/"
+        valid_iso_2_record.transformed_data["distribution"][0]["accessURL"] = (
+            "www.example.com/"
+        )
         # makes the record invalid
         assert not valid_iso_2_record.validate()
 
@@ -406,9 +406,9 @@ class TestValidateDataset:
         self, valid_iso_2_record
     ):
         valid_iso_2_record.transform()
-        valid_iso_2_record.transformed_data["distribution"][0][
-            "describedByType"
-        ] = "WWW:LINK-1.0-http--link"
+        valid_iso_2_record.transformed_data["distribution"][0]["describedByType"] = (
+            "WWW:LINK-1.0-http--link"
+        )
         assert not valid_iso_2_record.validate()
 
         valid_iso_2_record.fill_placeholders()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -252,6 +252,7 @@ class TestGeneralUtils:
         # validation messages are stored in the db via repr which will include the
         # object type (e.g. '<ValidationError: "$, \'identifier\' is a required property">')
         # omitting that here for brevity.
+        # backslashes are doubled here but not in the final validation record error message.
         # ruff: noqa E501
         expected = [
             "$, 'identifier' is a required property",


### PR DESCRIPTION
# Pull Request

Related to [5349](https://github.com/GSA/data.gov/issues/5349)

## About
reduces backslashes from 4 to 2 (e.g. `\\\\` to `\\`). was fiddling around with it but couldn't figure out how to get it to just have one.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
