### PR TITLE
Opensearch connection

### DIFF
--- a/.profile
+++ b/.profile
@@ -8,6 +8,9 @@ function vcap_get_service () {
   name="$1"
   path="$2"
   service_name=${APP_NAME}-${name}
+  if [ "$name" = "opensearch" ]; then
+    service_name=datagov-catalog-opensearch
+  fi
   echo $VCAP_SERVICES | jq --raw-output --arg service_name "$service_name" ".[][] | select(.name == \$service_name) | $path"
 }
 

--- a/.profile
+++ b/.profile
@@ -56,7 +56,7 @@ if [ -z ${proxy_url+x} ]; then
   echo "Egress proxy is not connected."
 else
   echo "Egress proxy is enabled, excluding internal domains.."
-  export no_proxy=".apps.internal"
+  export no_proxy=".apps.internal,${OPENSEARCH_HOST}"
   export http_proxy=$proxy_url
   export https_proxy=$proxy_url
 fi

--- a/.profile
+++ b/.profile
@@ -38,6 +38,11 @@ export HARVEST_SMTP_PASSWORD=$(vcap_get_service smtp .credentials.smtp_password)
 export HARVEST_SMTP_SENDER=harvester@$(vcap_get_service smtp .credentials.domain_arn | grep -o "ses-[[:alnum:]]\+.appmail.cloud.gov")
 export HARVEST_SMTP_RECIPIENT=datagovhelp@gsa.gov
 
+# OpenSearch host and credentials
+export OPENSEARCH_HOST=$(vcap_get_service opensearch .credentials.host)
+export OPENSEARCH_ACCESS_KEY=$(vcap_get_service opensearch .credentials.access_key)
+export OPENSEARCH_SECRET_KEY=$(vcap_get_service opensearch .credentials.secret_key)
+
 echo "Setting CA Bundle.."
 export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Any created service needs to be bound to an app with `cf bind-service <app> <ser
 
 Alternately, you can just push the app up and it will bind with the services so long as they are named following the expected pattern in `manifest.yml`.
 
+The harvester also expects an OpenSearch service named `datagov-catalog-opensearch`. The provisioning script creates it with Cloud.gov's `aws-elasticsearch` broker and requests `OpenSearch_2.11`, using `es-medium` in development and `es-medium-ha` in staging and `es-large` in production.
+
 #### User provided
 
 A user provided service by the name of `datagov-harvest-secrets` is also expected to be in place and populated with the following secrets:

--- a/create_cloudgov_services.sh
+++ b/create_cloudgov_services.sh
@@ -15,6 +15,17 @@ cf service "${app_name}-smtp"  > /dev/null 2>&1 || cf create-service --wait aws-
 # create the secrets service if necessary
 cf service "${app_name}-secrets"  > /dev/null 2>&1 || cf cups "${app_name}-secrets"
 
+# create the OpenSearch service if necessary
+if [ "$space" = "prod" ]; then
+    cf service "datagov-catalog-opensearch" > /dev/null 2>&1 || cf create-service --wait aws-elasticsearch es-large "datagov-catalog-opensearch" -c '{"ElasticsearchVersion":"OpenSearch_2.11"}'
+fi
+if [ "$space" = "staging" ]; then
+    cf service "datagov-catalog-opensearch" > /dev/null 2>&1 || cf create-service --wait aws-elasticsearch es-medium-ha "datagov-catalog-opensearch" -c '{"ElasticsearchVersion":"OpenSearch_2.11"}'
+fi
+if [ "$space" = "development" ]; then
+    cf service "datagov-catalog-opensearch" > /dev/null 2>&1 || cf create-service --wait aws-elasticsearch es-medium "datagov-catalog-opensearch" -c '{"ElasticsearchVersion":"OpenSearch_2.11"}'
+fi
+
 # Production and staging should use bigger DB instances
 if [ "$space" = "prod" ] || [ "$space" = "staging" ]; then
     cf service "${app_name}-db"    > /dev/null 2>&1 || cf create-service --wait aws-rds xlarge-gp-psql "${app_name}-db"

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,7 @@ applications:
     services:
       - ((app_name))-db
       - ((app_name))-secrets
-      - ((app_name))-opensearch
+      - datagov-catalog-opensearch
       - ((app_name))-smtp
       - logstack-space-drain
     instances: ((admin_instances))

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ applications:
     services:
       - ((app_name))-db
       - ((app_name))-secrets
+      - ((app_name))-opensearch
       - ((app_name))-smtp
       - logstack-space-drain
     instances: ((admin_instances))


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5607#issuecomment-4208365843

## About

Record update goes to OpenSearch in local, but not in cloud.gov environments. It turns out we need some extra steps in order to for harvester app to talk to OpenSearch.

- make it a required service for the app
- get credentials into cg env
- use correct service name
- bypass proxy

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
