### PR TITLE
add harvest source count per org

### DIFF
--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -102,6 +102,7 @@ class OrgCreate(Schema):
 
 class OrgInfo(OrgCreate):
     id = UUID(required=True)
+    source_count = Integer()
 
 
 class QueryInfo(Schema):

--- a/database/models.py
+++ b/database/models.py
@@ -5,10 +5,10 @@ from typing import Optional
 
 from flask_sqlalchemy import SQLAlchemy
 from geoalchemy2 import Geometry
-from sqlalchemy import CheckConstraint, Column, Enum, String, func
+from sqlalchemy import CheckConstraint, Column, Enum, String, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
-from sqlalchemy.orm import DeclarativeBase, backref
+from sqlalchemy.orm import DeclarativeBase, backref, column_property
 
 from shared.constants import (
     FREQUENCY_VALUES,
@@ -113,6 +113,16 @@ class HarvestSource(db.Model):
         nullable=False,
     )
     collection_parent_url = db.Column(db.String)
+
+
+# to avoid moving models around adding this here since it references
+# 2 models (Organization & HarvestSource)
+Organization.source_count = column_property(
+    select(func.count(HarvestSource.id))
+    .where(HarvestSource.organization_id == Organization.id)
+    .correlate_except(HarvestSource)
+    .scalar_subquery()
+)
 
 
 class HarvestJob(db.Model):

--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -358,7 +358,10 @@ def prepare_distributions(dcatus_doc: dict) -> list[dict]:
 
         if mtype:
             dist["mediaType"] = mtype
-            dist["format"] = RESOURCE_MAPPING.get(mtype)[0]
+            if mtype in RESOURCE_MAPPING:
+                dist["format"] = RESOURCE_MAPPING.get(mtype)[0]
+            else:
+                logger.warning(f"unknown mimetype '{mtype}' in distribution")
 
     return dcatus_doc
 

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -365,6 +365,26 @@ class TestJSONResponses:
         except Exception:
             assert res.data.decode() == response
 
+    def test_organizations(self, client, interface_with_fixture_json):
+        """
+        checks the content of the json response when navigating to "/organizations/"
+        """
+        res = client.get("/organizations/")
+        assert res.status_code == 200
+
+        assert json.loads(res.data) == [
+            {
+                "aliases": ["testorg"],
+                "description": "Fixture org description",
+                "id": "d925f84d-955b-4cb7-812f-dcfd6681a18f",
+                "logo": "https://raw.githubusercontent.com/GSA/datagov-harvester/refs/heads/main/app/static/assets/img/placeholder-organization.png",
+                "name": "Test Org",
+                "organization_type": "Federal Government",
+                "slug": "fixture-org",
+                "source_count": 1,
+            }
+        ]
+
 
 class TestHarvestRecordRawAPI:
     """Test the HarvestRecord API Raw endpoint."""

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -372,7 +372,7 @@ class TestJSONResponses:
         res = client.get("/organizations/")
         assert res.status_code == 200
 
-        assert json.loads(res.data) == [
+        assert res.json == [
             {
                 "aliases": ["testorg"],
                 "description": "Fixture org description",

--- a/tests/playwright/test_organization.py
+++ b/tests/playwright/test_organization.py
@@ -34,6 +34,8 @@ class TestOrganizationUnauthed:
                 "['testorg']",
                 "id:",
                 "d925f84d-955b-4cb7-812f-dcfd6681a18f",
+                "source_count:",
+                "1",
             ]
         )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -524,14 +524,6 @@ class TestGeneralUtils:
                     "mediaType": "placeholder/value",
                     "title": "TIGERweb/tigerWMS_Current (MapServer)",
                 },
-                {
-                    "@type": "dcat:Distribution",
-                    "description": "NOAA/NOS Smooth Sheet survey image in MrSID format",
-                    "downloadURL": "https://data.ngdc.noaa.gov/platforms/ocean/nos/coast/F00001-F02000/F00001/Smooth_Sheets/F00001.sid.gz",
-                    "mediaType": "placeholder/value",
-                    "title": "F00001.sid.gz",
-                    "describedByType": "application/octet-stream",
-                },
             ]
         }
 
@@ -544,7 +536,6 @@ class TestGeneralUtils:
             "application/rdf+xml",
             "application/xml",
             "arcgis_rest",
-            "image/x-mrsid-image",
         ]
 
         for i in range(len(prepared_dcatus_doc["distribution"])):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -524,6 +524,14 @@ class TestGeneralUtils:
                     "mediaType": "placeholder/value",
                     "title": "TIGERweb/tigerWMS_Current (MapServer)",
                 },
+                {
+                    "@type": "dcat:Distribution",
+                    "description": "NOAA/NOS Smooth Sheet survey image in MrSID format",
+                    "downloadURL": "https://data.ngdc.noaa.gov/platforms/ocean/nos/coast/F00001-F02000/F00001/Smooth_Sheets/F00001.sid.gz",
+                    "mediaType": "placeholder/value",
+                    "title": "F00001.sid.gz",
+                    "describedByType": "application/octet-stream",
+                },
             ]
         }
 
@@ -536,10 +544,14 @@ class TestGeneralUtils:
             "application/rdf+xml",
             "application/xml",
             "arcgis_rest",
+            "image/x-mrsid-image",
         ]
 
         for i in range(len(prepared_dcatus_doc["distribution"])):
             assert prepared_dcatus_doc["distribution"][i]["mediaType"] == expected[i]
+
+        # the mediatype isn't in RESOURCE_MAPPING so format shouldn't exist
+        "format" not in prepared_dcatus_doc["distribution"][-1]
 
 
 class TestRetrySession:


### PR DESCRIPTION
# Pull Request

Related to [5753](https://github.com/GSA/data.gov/issues/5753)

## About
adds a harvest source count per org for `/organizations/`. it's not a new column so no need for a migration it's computed at query time.

### correlate except explanation
correlation is needed when subqueries reference thing in outer queries. here's what the child counting query looks like as a sql statement
```sql
SELECT
  organization.id,
  (
    SELECT count(harvest_source.id)
    FROM harvest_source
    WHERE harvest_source.organization_id = organization.id
  ) AS source_count
FROM organization;
```

`organization` is referenced within the inner query calculating `source_count` but it's not in the `FROM` statement. how does it know where to derive from? from the outer query. that's correlation. `.correlate_except` says to correlate the subquery with everything from the outer query EXCEPT `HarvestSource`. without correlation sqlalchemy could produce this sql command which would break.

```sql
SELECT count(harvest_source.id)
WHERE harvest_source.organization_id = organization.id
```

### organization view change
source count is now included which is an unintended addition but nice i think
<img width="513" height="455" alt="Screenshot 2026-04-14 at 11 08 41 AM" src="https://github.com/user-attachments/assets/6f60c02b-63dc-4c8e-aff0-6972d3ce3127" />

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
