### PR TITLE
use external route for openapi doc

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,6 +28,7 @@ htmx = None
 
 
 def _external_route_to_server_url(route: str | None) -> str | None:
+    """Return a normalized external server URL, or None for empty input."""
     if not route:
         return None
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 import os
+from urllib.parse import urlsplit
 
 from apiflask import APIFlask
 from dotenv import load_dotenv
@@ -26,6 +27,20 @@ logging.config.dictConfig(LOGGING_CONFIG)
 htmx = None
 
 
+def _external_route_to_server_url(route: str | None) -> str | None:
+    if not route:
+        return None
+
+    route = route.strip().rstrip("/")
+    if not route:
+        return None
+
+    if urlsplit(route).scheme:
+        return route
+
+    return f"https://{route}"
+
+
 def create_app():
     app = APIFlask(__name__, static_url_path="", static_folder="static", docs_path=None)
 
@@ -34,6 +49,9 @@ def create_app():
         "title": "Datagov Harvester",
         "version": "0.1.0",
     }
+    external_server_url = _external_route_to_server_url(os.getenv("EXTERNAL_ROUTE"))
+    if external_server_url:
+        app.config["SERVERS"] = [{"url": external_server_url}]
 
     # don't include auth information in the OpenAPI spec
     @app.spec_processor

--- a/manifest.yml
+++ b/manifest.yml
@@ -32,6 +32,7 @@ applications:
     disk_quota: ((admin_disk_quota))
     env:
       FLASK_APP: run.py
+      EXTERNAL_ROUTE: ((route_external))
       CF_API_URL: ((CF_API_URL))
       CATALOG_BASE_URL: ((CATALOG_BASE_URL))
       HARVEST_RUNNER_MAX_TASKS: ((HARVEST_RUNNER_MAX_TASKS))

--- a/tests/integration/app/test_openapi.py
+++ b/tests/integration/app/test_openapi.py
@@ -1,6 +1,10 @@
 """OpenAPI spec tests."""
 
+from unittest.mock import patch
+
 from bs4 import BeautifulSoup
+
+from app import create_app
 
 
 class TestOpenAPI:
@@ -28,3 +32,14 @@ class TestOpenAPI:
             "swagger-ui-bundle.js" in script_el.get("src", "")
             for script_el in soup.find_all("script")
         )
+
+    def test_openapi_json_uses_external_route_for_servers(self):
+        with patch.dict("os.environ", {"EXTERNAL_ROUTE": "api.example.gov"}):
+            app = create_app()
+            app.config.update({"TESTING": True})
+
+            with app.test_client() as client:
+                response = client.get("/openapi.json")
+
+        assert response.status_code == 200
+        assert response.json["servers"] == [{"url": "https://api.example.gov"}]


### PR DESCRIPTION
# Pull Request

Related to
- https://gsa-tts.slack.com/archives/C2N85536E/p1777334340409169

## About
<img width="460" height="271" alt="image" src="https://github.com/user-attachments/assets/7a38b0f7-9ec7-4d2b-8279-13bd1859d3b2" />

Use external route as the server address.