### PR TITLE
Sort Org Names in Add/Edit HarvestSource Form

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -651,9 +651,10 @@ def add_harvest_source():
     else:
         form = HarvestSourceForm()
         organizations = db.get_all_organizations()
-        organization_choices = [
-            (str(org.id), f"{org.name} - {org.id}") for org in organizations
-        ]
+        organization_choices = sorted(
+            [(str(org.id), f"{org.name} - {org.id}") for org in organizations],
+            key=lambda x: x[1].lower()
+        )
         form.organization_id.choices = organization_choices
         if form.validate_on_submit():
             new_source = make_new_source_contract(form)
@@ -1049,10 +1050,13 @@ def edit_harvest_source(source_id: str):
         source = db.get_harvest_source(source_id)
         organizations = db.get_all_organizations()
         if source and organizations:
-            organization_choices = [
-                (str(org["id"]), f"{org['name']} - {org['id']}")
-                for org in db._to_dict(organizations)
-            ]
+            organization_choices = sorted(
+                [
+                    (str(org["id"]), f"{org['name']} - {org['id']}")
+                    for org in db._to_dict(organizations)
+                ],
+                key=lambda x: x[1].lower()
+            )
             source_data = db._to_dict(source)
             source_data["notification_emails"] = ", ".join(
                 source_data.get("notification_emails") or []

--- a/app/routes.py
+++ b/app/routes.py
@@ -653,7 +653,7 @@ def add_harvest_source():
         organizations = db.get_all_organizations()
         organization_choices = sorted(
             [(str(org.id), f"{org.name} - {org.id}") for org in organizations],
-            key=lambda x: x[1].lower()
+            key=lambda x: x[1].lower(),
         )
         form.organization_id.choices = organization_choices
         if form.validate_on_submit():
@@ -1055,7 +1055,7 @@ def edit_harvest_source(source_id: str):
                     (str(org["id"]), f"{org['name']} - {org['id']}")
                     for org in db._to_dict(organizations)
                 ],
-                key=lambda x: x[1].lower()
+                key=lambda x: x[1].lower(),
             )
             source_data = db._to_dict(source)
             source_data["notification_emails"] = ", ".join(

--- a/tests/integration/app/test_forms.py
+++ b/tests/integration/app/test_forms.py
@@ -166,9 +166,7 @@ class TestForms:
         assert "testorg" in edit_response.text
         assert "['testorg']" not in edit_response.text
 
-    def test_harvest_source_add_org_dropdown_is_sorted(
-        self, app, client, interface
-    ):
+    def test_harvest_source_add_org_dropdown_is_sorted(self, app, client, interface):
         """
         Organization dropdown on /harvest_source/add is sorted A–Z by name.
         """

--- a/tests/integration/app/test_forms.py
+++ b/tests/integration/app/test_forms.py
@@ -166,6 +166,47 @@ class TestForms:
         assert "testorg" in edit_response.text
         assert "['testorg']" not in edit_response.text
 
+    def test_harvest_source_add_org_dropdown_is_sorted(
+        self, app, client, interface
+    ):
+        """
+        Organization dropdown on /harvest_source/add is sorted A–Z by name.
+        """
+        app.config.update({"WTF_CSRF_ENABLED": False})
+        with client.session_transaction() as sess:
+            sess["user"] = "tester@gsa.gov"
+
+        # Insert orgs intentionally out of alphabetical order
+        orgs = [
+            {
+                "name": "Zebra Agency",
+                "logo": "https://example.com/z.png",
+                "slug": "zebra-agency",
+            },
+            {
+                "name": "apple Bureau",
+                "logo": "https://example.com/a.png",
+                "slug": "apple-bureau",
+            },
+            {
+                "name": "Mango Department",
+                "logo": "https://example.com/m.png",
+                "slug": "mango-department",
+            },
+        ]
+        for org in orgs:
+            interface.add_organization(org)
+
+        res = client.get("/harvest_source/add")
+        assert res.status_code == 200
+
+        soup = BeautifulSoup(res.data, "html.parser")
+        select = soup.find("select", {"id": "organization_id"})
+        assert select is not None, "organization_id <select> not found"
+
+        option_labels = [opt.text.split(" - ")[0] for opt in select.find_all("option")]
+        assert option_labels == sorted(option_labels, key=str.lower)
+
 
 @pytest.mark.usefixtures("mock_opensearch")
 class TestDatasetSlugForm:


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5911

## About
- QOL enhancement for adding HarvestSource items
- Sorts the Organization Drop down for the Create/Edit harvest source select options
    - Organizes org names in alphabetical order.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
