### PR TITLE
Login auth cloudfront

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -70,24 +70,69 @@ def create_app():
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["SECRET_KEY"] = os.getenv("FLASK_APP_SECRET_KEY")
     app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024
+    app.config["SESSION_COOKIE_NAME"] = os.getenv(
+        "SESSION_COOKIE_NAME", "harvest_session"
+    )
+    app.config["SESSION_COOKIE_SECURE"] = True
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+    app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+    app.config["AUTH_COOKIE_NAME"] = os.getenv("AUTH_COOKIE_NAME", "harvest_auth")
     app.config["SESSION_IDLE_TIMEOUT_SECONDS"] = int(
         os.getenv("SESSION_IDLE_TIMEOUT_SECONDS", "900")
     )
 
     def get_session_cookie_name():
-        return app.config.get("SESSION_COOKIE_NAME", "session")
+        return app.config["SESSION_COOKIE_NAME"]
+
+    def get_auth_cookie_name():
+        return app.config["AUTH_COOKIE_NAME"]
+
+    def get_cookie_path():
+        return app.config.get("SESSION_COOKIE_PATH") or "/"
+
+    def get_cookie_domain():
+        return app.config.get("SESSION_COOKIE_DOMAIN")
+
+    def get_cookie_secure():
+        return app.config.get("SESSION_COOKIE_SECURE", False)
+
+    def get_cookie_samesite():
+        return app.config.get("SESSION_COOKIE_SAMESITE", "Lax")
 
     def clear_session_cookie(response):
         response.delete_cookie(
             get_session_cookie_name(),
-            path=app.config.get("SESSION_COOKIE_PATH", "/"),
-            domain=app.config.get("SESSION_COOKIE_DOMAIN"),
+            path=get_cookie_path(),
+            domain=get_cookie_domain(),
+        )
+        return response
+
+    def set_auth_cookie(response):
+        """mark the response as authenticated for CloudFront cache separation."""
+        response.set_cookie(
+            get_auth_cookie_name(),
+            "1",
+            path=get_cookie_path(),
+            domain=get_cookie_domain(),
+            secure=get_cookie_secure(),
+            httponly=True,
+            samesite=get_cookie_samesite(),
+        )
+        return response
+
+    def clear_auth_cookie(response):
+        """remove the authenticated marker cookie when login state is gone."""
+        response.delete_cookie(
+            get_auth_cookie_name(),
+            path=get_cookie_path(),
+            domain=get_cookie_domain(),
         )
         return response
 
     @app.before_request
     def expire_stale_session():
         g.clear_session_cookie = False
+        g.sync_auth_cookie = False
 
         if request.path.startswith("/assets/"):
             return
@@ -116,6 +161,7 @@ def create_app():
             )
             session.clear()
             g.clear_session_cookie = True
+            g.sync_auth_cookie = True
             return
 
         session["last_activity"] = now
@@ -140,6 +186,13 @@ def create_app():
 
         if getattr(g, "clear_session_cookie", False):
             response = clear_session_cookie(response)
+
+        if has_session_user:
+            response = set_auth_cookie(response)
+        elif getattr(g, "sync_auth_cookie", False) or request.cookies.get(
+            get_auth_cookie_name()
+        ):
+            response = clear_auth_cookie(response)
 
         sets_cookie = bool(response.headers.getlist("Set-Cookie"))
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -104,7 +104,11 @@ def create_app():
         except (TypeError, ValueError):
             last_activity = None
 
-        if last_activity is None or now - last_activity > timeout_seconds:
+        if last_activity is None:
+            session["last_activity"] = now
+            return
+
+        if now - last_activity > timeout_seconds:
             logger.info(
                 "Session expired for user=%s path=%s",
                 session.get("user"),

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from urllib.parse import urlsplit
 
 from apiflask import APIFlask
 from dotenv import load_dotenv
+from flask import request, session
 from flask_bootstrap import Bootstrap5
 from flask_htmx import HTMX
 from flask_migrate import Migrate
@@ -64,6 +65,39 @@ def create_app():
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["SECRET_KEY"] = os.getenv("FLASK_APP_SECRET_KEY")
     app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024
+
+    def set_private_no_store(response):
+        response.headers["Cache-Control"] = "private, no-store, max-age=0"
+        response.headers["Pragma"] = "no-cache"
+        response.headers["Expires"] = "0"
+        return response
+
+    def set_public_cache(response, ttl):
+        response.headers["Cache-Control"] = f"public, max-age={ttl}, s-maxage={ttl}"
+        response.headers.pop("Pragma", None)
+        response.headers.pop("Expires", None)
+        return response
+
+    @app.after_request
+    def apply_cache_headers(response):
+        path = request.path or "/"
+        method = request.method
+        has_session_user = bool(session.get("user"))
+        sets_cookie = bool(response.headers.getlist("Set-Cookie"))
+
+        if path.startswith(("/login", "/callback", "/logout")):
+            return set_private_no_store(response)
+
+        if path.startswith("/assets/"):
+            return set_public_cache(response, 3600)
+
+        if method not in {"GET", "HEAD"}:
+            return set_private_no_store(response)
+
+        if has_session_user or sets_cookie or response.status_code >= 400:
+            return set_private_no_store(response)
+
+        return set_public_cache(response, 60)
 
     Bootstrap5(app)
     global htmx

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,12 @@
 import logging
 import logging.config
 import os
+import time
 from urllib.parse import urlsplit
 
 from apiflask import APIFlask
 from dotenv import load_dotenv
-from flask import request, session
+from flask import g, request, session
 from flask_bootstrap import Bootstrap5
 from flask_htmx import HTMX
 from flask_migrate import Migrate
@@ -26,6 +27,10 @@ logging.config.dictConfig(LOGGING_CONFIG)
 
 # fixes a bug with Flask-HTMX not being able to find the app context
 htmx = None
+
+
+def current_unix_timestamp() -> int:
+    return int(time.time())
 
 
 def _external_route_to_server_url(route: str | None) -> str | None:
@@ -65,6 +70,51 @@ def create_app():
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["SECRET_KEY"] = os.getenv("FLASK_APP_SECRET_KEY")
     app.config["MAX_CONTENT_LENGTH"] = 10 * 1024 * 1024
+    app.config["SESSION_IDLE_TIMEOUT_SECONDS"] = int(
+        os.getenv("SESSION_IDLE_TIMEOUT_SECONDS", "900")
+    )
+
+    def get_session_cookie_name():
+        return app.config.get("SESSION_COOKIE_NAME", "session")
+
+    def clear_session_cookie(response):
+        response.delete_cookie(
+            get_session_cookie_name(),
+            path=app.config.get("SESSION_COOKIE_PATH", "/"),
+            domain=app.config.get("SESSION_COOKIE_DOMAIN"),
+        )
+        return response
+
+    @app.before_request
+    def expire_stale_session():
+        g.clear_session_cookie = False
+
+        if request.path.startswith("/assets/"):
+            return
+
+        if not session.get("user"):
+            return
+
+        now = current_unix_timestamp()
+        last_activity = session.get("last_activity")
+        timeout_seconds = app.config["SESSION_IDLE_TIMEOUT_SECONDS"]
+
+        try:
+            last_activity = int(last_activity)
+        except (TypeError, ValueError):
+            last_activity = None
+
+        if last_activity is None or now - last_activity > timeout_seconds:
+            logger.info(
+                "Session expired for user=%s path=%s",
+                session.get("user"),
+                request.path,
+            )
+            session.clear()
+            g.clear_session_cookie = True
+            return
+
+        session["last_activity"] = now
 
     def set_private_no_store(response):
         response.headers["Cache-Control"] = "private, no-store, max-age=0"
@@ -83,6 +133,10 @@ def create_app():
         path = request.path or "/"
         method = request.method
         has_session_user = bool(session.get("user"))
+
+        if getattr(g, "clear_session_cookie", False):
+            response = clear_session_cookie(response)
+
         sets_cookie = bool(response.headers.getlist("Set-Cookie"))
 
         if path.startswith(("/login", "/callback", "/logout")):

--- a/app/routes.py
+++ b/app/routes.py
@@ -44,8 +44,7 @@ from harvester.utils.general_utils import (
     process_job_complete_percentage,
 )
 
-from . import htmx
-from . import current_unix_timestamp
+from . import current_unix_timestamp, htmx
 from .api_schemas import (
     ErrorInfo,
     JobInfo,

--- a/app/routes.py
+++ b/app/routes.py
@@ -260,7 +260,8 @@ def login():
 
 @main.route("/logout")
 def logout():
-    user = session.pop("user", None)
+    user = session.get("user")
+    session.clear()
     logger.info(
         "Logout completed for user=%s ip=%s",
         user or "<anonymous>",

--- a/app/routes.py
+++ b/app/routes.py
@@ -45,6 +45,7 @@ from harvester.utils.general_utils import (
 )
 
 from . import htmx
+from . import current_unix_timestamp
 from .api_schemas import (
     ErrorInfo,
     JobInfo,
@@ -377,6 +378,7 @@ def callback():
 
     if usr:
         session["user"] = usr_email
+        session["last_activity"] = current_unix_timestamp()
         logger.info(
             "Login succeeded for user=%s ssoid=%s ip=%s",
             usr_email,

--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 from urllib.parse import urlparse
 
 import pytest
@@ -23,7 +24,9 @@ def _build_signed_session_cookie() -> str:
         raise RuntimeError("Unable to create Flask session serializer")
 
     session_user = os.getenv("PLAYWRIGHT_AUTH_USER", "user@test.local")
-    return serializer.dumps({"user": session_user})
+    return serializer.dumps(
+        {"user": session_user, "last_activity": int(time.time())}
+    )
 
 
 def _authed_storage_state(base_url: str) -> dict:
@@ -31,8 +34,18 @@ def _authed_storage_state(base_url: str) -> dict:
     return {
         "cookies": [
             {
-                "name": "session",
+                "name": "harvest_session",
                 "value": _build_signed_session_cookie(),
+                "domain": host,
+                "path": "/",
+                "expires": -1,
+                "httpOnly": True,
+                "secure": False,
+                "sameSite": "Lax",
+            },
+            {
+                "name": "harvest_auth",
+                "value": "1",
                 "domain": host,
                 "path": "/",
                 "expires": -1,

--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -24,9 +24,7 @@ def _build_signed_session_cookie() -> str:
         raise RuntimeError("Unable to create Flask session serializer")
 
     session_user = os.getenv("PLAYWRIGHT_AUTH_USER", "user@test.local")
-    return serializer.dumps(
-        {"user": session_user, "last_activity": int(time.time())}
-    )
+    return serializer.dumps({"user": session_user, "last_activity": int(time.time())})
 
 
 def _authed_storage_state(base_url: str) -> dict:
@@ -52,7 +50,7 @@ def _authed_storage_state(base_url: str) -> dict:
                 "httpOnly": True,
                 "secure": False,
                 "sameSite": "Lax",
-            }
+            },
         ],
         "origins": [],
     }

--- a/tests/unit/test_cache_headers.py
+++ b/tests/unit/test_cache_headers.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from flask import request, session
 
 from app import create_app
 
@@ -13,6 +14,12 @@ def app():
 
     @app.route("/_cache_test")
     def cache_test():
+        return "ok"
+
+    @app.route("/_set_session")
+    def set_session():
+        for key, value in request.args.items():
+            session[key] = value
         return "ok"
 
     return app
@@ -42,14 +49,21 @@ def test_anonymous_page_is_publicly_cacheable(client):
 
 
 def test_logged_in_page_is_private_no_store(client):
-    with client.session_transaction() as sess:
-        sess["user"] = "test.user@gsa.gov"
+    client.get(
+        "/_set_session?user=test.user@gsa.gov&last_activity=1000",
+        base_url="https://localhost",
+    )
 
-    response = client.get("/_cache_test")
+    with patch("app.current_unix_timestamp", return_value=1_100):
+        response = client.get("/_cache_test", base_url="https://localhost")
 
     assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
     assert response.headers["Pragma"] == "no-cache"
     assert response.headers["Expires"] == "0"
+
+    with client.session_transaction() as sess:
+        assert sess["user"] == "test.user@gsa.gov"
+        assert sess["last_activity"] == 1_100
 
 
 def test_login_route_is_private_no_store(client):
@@ -74,11 +88,34 @@ def test_logout_clears_full_session(client):
         sess["user"] = "test.user@gsa.gov"
         sess["state"] = "expected-state"
         sess["nonce"] = "expected-nonce"
+        sess["last_activity"] = 1_000
         sess["next"] = "main.view_metrics"
 
     response = client.get("/logout")
 
     assert response.status_code == 302
+
+    with client.session_transaction() as sess:
+        assert dict(sess) == {}
+
+
+def test_stale_logged_in_session_is_cleared_and_cookie_deleted(client):
+    client.get(
+        "/_set_session?user=test.user@gsa.gov&last_activity=1000",
+        base_url="https://localhost",
+    )
+
+    with patch("app.current_unix_timestamp", return_value=1_901):
+        response = client.get("/_cache_test", base_url="https://localhost")
+
+    assert (
+        response.headers["Cache-Control"]
+        == "private, no-store, max-age=0"
+    )
+    assert any(
+        header.startswith("session=;")
+        for header in response.headers.getlist("Set-Cookie")
+    )
 
     with client.session_transaction() as sess:
         assert dict(sess) == {}

--- a/tests/unit/test_cache_headers.py
+++ b/tests/unit/test_cache_headers.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+import pytest
+
+from app import create_app
+
+
+@pytest.fixture
+def app():
+    with patch("app.load_manager.start", lambda: True):
+        app = create_app()
+    app.config.update({"TESTING": True})
+
+    @app.route("/_cache_test")
+    def cache_test():
+        return "ok"
+
+    return app
+
+
+@pytest.fixture
+def dbapp(app):
+    yield app
+
+
+@pytest.fixture
+def default_function_fixture():
+    yield
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_anonymous_page_is_publicly_cacheable(client):
+    response = client.get("/_cache_test")
+
+    assert response.headers["Cache-Control"] == "public, max-age=60, s-maxage=60"
+    assert "Pragma" not in response.headers
+    assert "Expires" not in response.headers
+
+
+def test_logged_in_page_is_private_no_store(client):
+    with client.session_transaction() as sess:
+        sess["user"] = "test.user@gsa.gov"
+
+    response = client.get("/_cache_test")
+
+    assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Expires"] == "0"
+
+
+def test_login_route_is_private_no_store(client):
+    response = client.get("/login")
+
+    assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Expires"] == "0"
+
+
+def test_assets_are_cached_for_one_hour(client):
+    response = client.get("/assets/img/icon-glossary.svg")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=3600, s-maxage=3600"
+    assert "Pragma" not in response.headers
+    assert "Expires" not in response.headers

--- a/tests/unit/test_cache_headers.py
+++ b/tests/unit/test_cache_headers.py
@@ -67,3 +67,18 @@ def test_assets_are_cached_for_one_hour(client):
     assert response.headers["Cache-Control"] == "public, max-age=3600, s-maxage=3600"
     assert "Pragma" not in response.headers
     assert "Expires" not in response.headers
+
+
+def test_logout_clears_full_session(client):
+    with client.session_transaction() as sess:
+        sess["user"] = "test.user@gsa.gov"
+        sess["state"] = "expected-state"
+        sess["nonce"] = "expected-nonce"
+        sess["next"] = "main.view_metrics"
+
+    response = client.get("/logout")
+
+    assert response.status_code == 302
+
+    with client.session_transaction() as sess:
+        assert dict(sess) == {}

--- a/tests/unit/test_cache_headers.py
+++ b/tests/unit/test_cache_headers.py
@@ -60,6 +60,10 @@ def test_logged_in_page_is_private_no_store(client):
     assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
     assert response.headers["Pragma"] == "no-cache"
     assert response.headers["Expires"] == "0"
+    assert any(
+        header.startswith("harvest_auth=1;")
+        for header in response.headers.getlist("Set-Cookie")
+    )
 
     with client.session_transaction() as sess:
         assert sess["user"] == "test.user@gsa.gov"
@@ -88,6 +92,10 @@ def test_login_route_is_private_no_store(client):
     assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
     assert response.headers["Pragma"] == "no-cache"
     assert response.headers["Expires"] == "0"
+    assert any(
+        header.startswith("harvest_session=")
+        for header in response.headers.getlist("Set-Cookie")
+    )
 
 
 def test_assets_are_cached_for_one_hour(client):
@@ -110,6 +118,10 @@ def test_logout_clears_full_session(client):
     response = client.get("/logout")
 
     assert response.status_code == 302
+    assert any(
+        header.startswith("harvest_auth=;")
+        for header in response.headers.getlist("Set-Cookie")
+    )
 
     with client.session_transaction() as sess:
         assert dict(sess) == {}
@@ -126,7 +138,11 @@ def test_stale_logged_in_session_is_cleared_and_cookie_deleted(client):
 
     assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
     assert any(
-        header.startswith("session=;")
+        header.startswith("harvest_session=;")
+        for header in response.headers.getlist("Set-Cookie")
+    )
+    assert any(
+        header.startswith("harvest_auth=;")
         for header in response.headers.getlist("Set-Cookie")
     )
 

--- a/tests/unit/test_cache_headers.py
+++ b/tests/unit/test_cache_headers.py
@@ -66,6 +66,22 @@ def test_logged_in_page_is_private_no_store(client):
         assert sess["last_activity"] == 1_100
 
 
+def test_logged_in_session_without_last_activity_is_initialized(client):
+    client.get(
+        "/_set_session?user=test.user@gsa.gov",
+        base_url="https://localhost",
+    )
+
+    with patch("app.current_unix_timestamp", return_value=1_100):
+        response = client.get("/_cache_test", base_url="https://localhost")
+
+    assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
+
+    with client.session_transaction() as sess:
+        assert sess["user"] == "test.user@gsa.gov"
+        assert sess["last_activity"] == 1_100
+
+
 def test_login_route_is_private_no_store(client):
     response = client.get("/login")
 

--- a/tests/unit/test_cache_headers.py
+++ b/tests/unit/test_cache_headers.py
@@ -124,10 +124,7 @@ def test_stale_logged_in_session_is_cleared_and_cookie_deleted(client):
     with patch("app.current_unix_timestamp", return_value=1_901):
         response = client.get("/_cache_test", base_url="https://localhost")
 
-    assert (
-        response.headers["Cache-Control"]
-        == "private, no-store, max-age=0"
-    )
+    assert response.headers["Cache-Control"] == "private, no-store, max-age=0"
     assert any(
         header.startswith("session=;")
         for header in response.headers.getlist("Set-Cookie")


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5848
- https://github.com/GSA/data.gov/issues/5914

## About
We want to optimize harvest app caching so that all checkboxes at [5914](https://github.com/GSA/data.gov/issues/5914) are checked. 

- set response headers to work with cloudfront caching: 120 sec cache for anonymous requests, 0 sec cache for logged in request.
- idle out, default to 15 mins
- created two session cookies, `harvest_session` and `harvest_auth`.  `harvest_auth` is added to cloudfront cache key to ensure logged user never see public cached pages. 
 
## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
