### PR TITLE
use harvest-dev and harvest-stage

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -105,7 +105,7 @@ jobs:
     uses: gsa/data.gov/.github/workflows/deploy-template.yml@main
     with:
       environ: development
-      app_url: https://datagov-harvest-dev.app.cloud.gov
+      app_url: https://harvest-dev.data.gov
       app_names: '{"include":[{"app":"datagov-harvest"},{"app":"datagov-harvest-proxy"}]}'
     secrets: inherit
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
     uses: gsa/data.gov/.github/workflows/deploy-template.yml@main
     with:
       environ: staging
-      app_url: https://datagov-harvest-staging.app.cloud.gov
+      app_url: https://harvest-stage.data.gov
       app_names: '{"include":[{"app":"datagov-harvest"},{"app":"datagov-harvest-proxy"}]}'
     secrets: inherit
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ A user provided service by the name of `datagov-harvest-secrets` is also expecte
     ```bash
     app_name: datagov-harvest
     database_name: datagov-harvest-db
-    route_external: datagov-harvest-dev.app.cloud.gov
+    route_external: harvest-dev.data.gov
     route_internal: datagov-harvest-dev.apps.internal
     proxy_instances: 1
     basic_auth_enabled: on

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,14 +10,14 @@ harvest sources. Here's some commands to pull the list of harvest sources. (We
 should make a JSON form of this list page.)
 
 ```bash
-$ curl https://datagov-harvest-dev.app.cloud.gov/harvest_source_list/ > harvest_source_list.html
+$ curl https://harvest-dev.data.gov/harvest_source_list/ > harvest_source_list.html
 $ grep href=\"/harvest_source/ harvest_source_list.html | sed -e s/\<a// -e s/href=\"// -e s/\"// > harvest_source_paths.txt
 $ sed -e "s:^.*/harvest_source/::" < harvest_source_paths.txt > harvest_source_ids.txt
 $ cf env datagov-harvest | grep FLASK_APP_SECRET_KEY
 $ export API_TOKEN=...
 $ cat harvest_source_ids.txt | while read id; do \
     curl -s -H "Authorization: ${API_TOKEN}" \
-    https://datagov-harvest-dev.app.cloud.gov/harvest_job/add \
+    https://harvest-dev.data.gov/harvest_job/add \
     --json "{\"harvest_source_id\": \"$id\", \"status\": \"new\", \"date_created\": \"$(TZ=UTC date -Iseconds -j -v +45M)\"}" ;
   done
 ```
@@ -25,4 +25,3 @@ $ cat harvest_source_ids.txt | while read id; do \
 This downloads the IDs for all of the harvest sources and then creates a new
 job for each source by ID at 45 minutes in the future. When that time in the
 near future passes, the harvest jobs will begin being worked through.
-

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -1,6 +1,6 @@
 app_name: datagov-harvest
 space_name: development
-route_external: datagov-harvest-dev.app.cloud.gov
+route_external: harvest-dev.data.gov
 route_internal: datagov-harvest-dev.apps.internal
 proxy_instances: 1
 basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these as 'true' 'false'
@@ -20,7 +20,7 @@ MDTRANSLATOR_URL: https://mdtranslator-development.apps.internal:61443/translate
 CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:datagov-dev-harvest-admin
 ISSUER: https://idp.int.identitysandbox.gov
 # Redirect URI should match route_external from above
-REDIRECT_URI: https://datagov-harvest-dev.app.cloud.gov/callback
+REDIRECT_URI: https://harvest-dev.data.gov/callback
 
 # New Relic
 new_relic_monitor_mode: false

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,6 +1,6 @@
 app_name: datagov-harvest
 space_name: staging
-route_external: datagov-harvest-staging.app.cloud.gov
+route_external: harvest-stage.data.gov
 route_internal: datagov-harvest-staging.apps.internal
 proxy_instances: 2
 basic_auth_enabled: on # nginx terminology 'on' 'off'. cf will interpret these as 'true' 'false'
@@ -21,7 +21,7 @@ MDTRANSLATOR_URL: https://mdtranslator-staging.apps.internal:61443/translates
 CLIENT_ID: urn:gov:gsa:openidconnect.profiles:sp:sso:gsa:datagov-staging-harvest-admin
 ISSUER: https://idp.int.identitysandbox.gov
 # Redirect URI should match route_external from above
-REDIRECT_URI: https://datagov-harvest-staging.app.cloud.gov/callback
+REDIRECT_URI: https://harvest-stage.data.gov/callback
 
 # New Relic
 new_relic_monitor_mode: false


### PR DESCRIPTION
Using external domain harvest-dev and harvest-stage.data.gov allows us to use SSB cloudfront and makes dev/staging spaces closer to prod space config.