### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/egress-check.yml
+++ b/.github/workflows/egress-check.yml
@@ -6,6 +6,9 @@ on:
     - cron: '40 02,14 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   egress-check:
     name: ${{matrix.environ}} - ${{matrix.command}}

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -17,6 +17,10 @@ on:
           - 'organization'
           - 'dataset'
         default: 'all'
+
+permissions:
+  contents: read
+
 jobs:
   run-qa:
     env:


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to `.github/workflows/egress-check.yml` and `.github/workflows/qa.yml`.
- Set `contents: read` as the minimal `GITHUB_TOKEN` scope for both workflows.

## Why
These workflows currently rely on implicit token defaults. Defining least-privilege permissions reduces risk and resolves CodeQL workflow-permissions findings.