### PR TITLE
include waf datasets filtered by datetime in job unchanged count

### DIFF
--- a/example_data/iso_2_waf/to_be_filtered_by_datetime.xml
+++ b/example_data/iso_2_waf/to_be_filtered_by_datetime.xml
@@ -1,0 +1,3 @@
+<!-- this doc is intended to be filtered based on its modified date
+ so there's no content here. no point in needlessly adding to the size of the repo.
+  -->

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -307,6 +307,8 @@ class HarvestSource:
         is determined via the modified_date found on the waf web page. if the file date
         at the source is more recent than what we have then we want to add it for processing.
 
+        the number of datasets filtered by datetime is added to the unchanged count of the job
+
         this function is only called when the harvest source type is "waf" so
         self.external_records would be a list of dictionaries like...
         [ { "identifier": "a.xml", "modified_date": datetime_obj}, ... ]
@@ -322,6 +324,13 @@ class HarvestSource:
                     records.append(data)  # update
             else:
                 records.append(data)  # create
+
+        # update unchanged to include filtered waf docs
+        for _ in range(len(self.external_records) - len(records)):
+            self.reporter.update(None)
+
+        self.db_interface.update_harvest_job(self.job_id, self.reporter.report())
+
         self.external_records = records
 
     def filter_datasets_with_no_identifier(self) -> None:

--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -487,11 +487,15 @@ def find_indexes_for_duplicates(records: list):
 
 
 def get_waf_datetimes(soup: BeautifulSoup, expected_length: int) -> list:
+    """
+    gets the datetime strings as datetime obejct of the waf datasets
+    """
     output = []
 
-    dt_pattern = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}"
-    dt_format = "%Y-%m-%d %H:%M"
-
+    dt_data = [
+        [r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", "%Y-%m-%d %H:%M"],
+        [r"\d{2}-[A-Za-z]{3}-\d{4}\s\d{2}:\d{2}", "%d-%b-%Y %H:%M"],
+    ]
     rows = soup.find_all("td") or soup.find_all("pre")
 
     if rows and rows[0].name == "pre":
@@ -500,9 +504,10 @@ def get_waf_datetimes(soup: BeautifulSoup, expected_length: int) -> list:
     for row in rows:
         if isinstance(row, Tag):
             row = row.text
-        res = re.search(dt_pattern, row)
-        if res is not None:
-            output.append(datetime.strptime(res.group(0), dt_format))
+        for dt_pattern, dt_format in dt_data:
+            res = re.search(dt_pattern, row)
+            if res is not None:
+                output.append(datetime.strptime(res.group(0), dt_format))
 
     if len(output) != expected_length:
         logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -875,6 +875,18 @@ def single_internal_record(internal_compare_data):
 
 
 @pytest.fixture
+def waf_datetime_filtered_internal_record(source_data_waf_iso19115_2):
+    return {
+        "harvest_source_id": source_data_waf_iso19115_2["id"],
+        "identifier": "http://localhost:80/iso_2_waf/to_be_filtered_by_datetime.xml",
+        "date_finished": datetime.now(),
+        "source_hash": "a",
+        "status": "success",
+        "action": "create",
+    }
+
+
+@pytest.fixture
 def dhl_cf_task_data() -> dict:
     return {
         "task_id": "cf_task_integration",

--- a/tests/integration/harvest/test_transform.py
+++ b/tests/integration/harvest/test_transform.py
@@ -98,7 +98,15 @@ class TestTransform:
         assert DeepDiff(test_iso_2_record.transformed_data, iso19115_2_transform) == {}
 
         # "valid_iso1.xml" is always the second one
-        test_iso_1_record = iso_records[1]
+        test_iso_1_record = next(
+            (
+                record
+                for record in iso_records
+                if "http://localhost:80/iso_2_waf/valid_iso1.xml" == record.identifier
+            ),
+            None,
+        )
+
         test_iso_1_record.transform()
 
         assert test_iso_1_record.mdt_msgs == ""

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -131,15 +131,28 @@ class TestHarvestJobFullFlow:
         interface,
         organization_data,
         source_data_waf_iso19115_2,
+        waf_datetime_filtered_internal_record,
     ):
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_waf_iso19115_2)
+
+        harvest_job_old = interface.add_harvest_job(
+            {
+                "status": "complete",
+                "harvest_source_id": source_data_waf_iso19115_2["id"],
+            }
+        )
+
+        waf_datetime_filtered_internal_record["harvest_job_id"] = harvest_job_old.id
+
         harvest_job = interface.add_harvest_job(
             {
                 "status": "new",
                 "harvest_source_id": source_data_waf_iso19115_2["id"],
             }
         )
+
+        interface.add_harvest_record(waf_datetime_filtered_internal_record)
 
         job_id = harvest_job.id
         harvest_job_starter(job_id, "harvest")
@@ -150,6 +163,7 @@ class TestHarvestJobFullFlow:
         assert harvest_job.records_total == 5
         assert len(harvest_job.record_errors) == 3
         assert harvest_job.records_errored == 3
+        assert harvest_job.records_ignored == 1
 
         successful_records = [
             record for record in harvest_job.records if record.status == "success"
@@ -270,9 +284,9 @@ class TestHarvestJobFullFlow:
 
         # assert job rollup
         assert harvest_job.status == "complete"
-        assert harvest_job.records_total == 6
-        assert len(harvest_job.record_errors) == 3
-        assert harvest_job.records_errored == 3
+        assert harvest_job.records_total == 7
+        assert len(harvest_job.record_errors) == 4
+        assert harvest_job.records_errored == 4
 
         for record in harvest_job.records:
             if record.status == "success":


### PR DESCRIPTION
# Pull Request

Related to [5891](https://github.com/GSA/data.gov/issues/5891)

## About
include waf datasets filtered by datetime in job unchanged count

unfortunately needed to add another regex in the waf datetime function to handle how nginx displays dates. maybe this happens in the wild? 

if you `date -r [file]` the xml fixture you'll see `Mon Dec 25 10:00:00 MST 2023`

### update
- the xml intended to be filtered by modified date no longer contains any information because it doesn't need any. the point of that fixture is to confirm date time filtering works. chromes xml viewer may play tricks with cache and display something that's not the doc. if you open incognito you should get a render error because it's not valid xml. but that's not the point of the doc.
- no longer writes to db per unchanged in datetime filtering. it increments the reporter then writes once at the end.
- waf-collection test was updated to account for the new xml doc. it's not being filtered by datetime because that doc isn't in the internal record so it's considered a create.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
