### PR TITLE
add another datetime regex for wafs

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -495,11 +495,12 @@ def get_waf_datetimes(soup: BeautifulSoup, expected_length: int) -> list:
     dt_data = [
         [r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", "%Y-%m-%d %H:%M"],
         [r"\d{2}-[A-Za-z]{3}-\d{4}\s\d{2}:\d{2}", "%d-%b-%Y %H:%M"],
+        [r"\d{1,2}/\d{1,2}/\d{4}\s+\d{1,2}:\d{2}\s(?:AM|PM)", "%m/%d/%Y %I:%M %p"],
     ]
     rows = soup.find_all("td") or soup.find_all("pre")
 
     if rows and rows[0].name == "pre":
-        rows = rows[0].text.split("\n")
+        rows = rows[0].text.split(".xml")
 
     for row in rows:
         if isinstance(row, Tag):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -226,6 +226,16 @@ class TestGeneralUtils:
             datetime(2025, 1, 1, 9, 15),
         ]
 
+        page_pre = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<html>\n <head>\n  <title>Index of /data/existing/decennial/GEO/GPMB/TIGERline/TIGER2013/zcta510</title>\n </head>\n <body>\n<h1>Index of /data/existing/decennial/GEO/GPMB/TIGERline/TIGER2013/zcta510</h1>\n<pre>      <a href="?C=N;O=A">Name</a>                                                   <a href="?C=M;O=A">Last modified</a>      <a href="?C=S;O=A">Size</a>  <a href="?C=D;O=A">Description</a><hr>      <a href="/data/existing/decennial/GEO/GPMB/TIGERline/TIGER2013/">Parent Directory</a>                                                            -   \n      <a href="2013_zcta510.ea.iso.xml">2013_zcta510.ea.iso.xml</a>                                6/17/2021 12:20 PM    16K  \n      <a href="tl_2013_us_zcta510.shp.iso.xml">tl_2013_us_zcta510.shp.iso.xml</a>                         8/1/2025 11:24 AM    34K  \n<hr></pre>\n</body></html>\n'
+
+        soup = BeautifulSoup(page_pre)
+        datetimes = get_waf_datetimes(soup, 2)
+
+        assert datetimes == [
+            datetime(2021, 6, 17, 12, 20),
+            datetime(2025, 8, 1, 11, 24),
+        ]
+
     def test_assemble_validation_messages(
         self, dol_distribution_json, dcatus_non_federal_schema
     ):


### PR DESCRIPTION
# Pull Request

Related to [5982](https://github.com/GSA/data.gov/issues/5982)

## About
- add another datetime regex to waf datetime parsing. I also updated the split str which wasn't compatible with the files here https://edg.epa.gov/WAFer_harvest/ISO/. [source](https://harvest.data.gov/harvest_source/63703e7b-b96b-4918-bc73-c743435ed497) . i think splitting based on `.xml` makes sense.
- i also changed the permission of `to_be_filtered_by_datetime.xml` to read-only across the board but that won't be detected by git. i've noticed the file can be modified by some test and then break the datetime filtering test. hopefully whatever is responsible for modifying it doesn't break something?


## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
