### PR TITLE
API use X-API-Key, not Authorization

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -12,12 +12,13 @@ logger = logging.getLogger("harvest_admin.auth")
 
 
 class LoginRequiredAuth(APIKeyHeaderAuth):
+    API_KEY_HEADER_NAME = "X-API-Key"
 
     def get_security_scheme(self) -> dict[str, t.Any]:
         """Hardcode our particular security scheme."""
         security_scheme = {
             "type": "apiKey",
-            "name": "Authorization",
+            "name": self.API_KEY_HEADER_NAME,
             "in": "header",
         }
         return security_scheme
@@ -28,19 +29,21 @@ class LoginRequiredAuth(APIKeyHeaderAuth):
         def login_required_internal(f):
             @wraps(f)
             def decorated_function(*args, **kwargs):
-                provided_token = request.headers.get("Authorization")
+                provided_token = request.headers.get(self.API_KEY_HEADER_NAME)
                 if request.is_json or provided_token is not None:
                     if provided_token is None:
                         logger.warning(
-                            "API auth rejected: missing Authorization header for %s %s",
+                            "API auth rejected: missing %s header for %s %s",
+                            self.API_KEY_HEADER_NAME,
                             request.method,
                             request.path,
                         )
-                        return "error: Authorization header missing", 401
+                        return f"error: {self.API_KEY_HEADER_NAME} header missing", 401
                     api_token = os.getenv("FLASK_APP_SECRET_KEY")
                     if provided_token != api_token:
                         logger.warning(
-                            "API auth rejected: invalid Authorization header for %s %s",
+                            "API auth rejected: invalid %s header for %s %s",
+                            self.API_KEY_HEADER_NAME,
                             request.method,
                             request.path,
                         )

--- a/app/auth.py
+++ b/app/auth.py
@@ -33,8 +33,7 @@ class LoginRequiredAuth(APIKeyHeaderAuth):
                 if request.is_json or provided_token is not None:
                     if provided_token is None:
                         logger.warning(
-                            "API auth rejected: missing %s header for %s %s",
-                            self.API_KEY_HEADER_NAME,
+                            "API auth rejected: missing API key header for %s %s",
                             request.method,
                             request.path,
                         )
@@ -42,8 +41,7 @@ class LoginRequiredAuth(APIKeyHeaderAuth):
                     api_token = os.getenv("FLASK_APP_SECRET_KEY")
                     if provided_token != api_token:
                         logger.warning(
-                            "API auth rejected: invalid %s header for %s %s",
-                            self.API_KEY_HEADER_NAME,
+                            "API auth rejected: invalid API key header for %s %s",
                             request.method,
                             request.path,
                         )

--- a/app/readme.txt
+++ b/app/readme.txt
@@ -29,13 +29,15 @@ datagov-harvester
 
 examples:
 
-curl -X POST http://{site}/organization/add -H "Content-Type: application/json" -d '
+Set an API token header for JSON API requests:
+
+curl -X POST http://{site}/organization/add -H "X-API-Key: {api_token}" -H "Content-Type: application/json" -d '
 {
     "name": "New Org",
     "logo": "test url"
 }'
 
-curl -X POST http://{site}/harvest_source/add -H "Content-Type: application/json" -d '
+curl -X POST http://{site}/harvest_source/add -H "X-API-Key: {api_token}" -H "Content-Type: application/json" -d '
 {
     "organization_id": "4ed9d20a-7de8-4c2d-884f-86b50ec8065d",
     "name": "Example Harvest Source",
@@ -47,20 +49,20 @@ curl -X POST http://{site}/harvest_source/add -H "Content-Type: application/json
 }
 '
 
-curl -X POST http://{site}/harvest_job/add -H "Content-Type: application/json" -d '
+curl -X POST http://{site}/harvest_job/add -H "X-API-Key: {api_token}" -H "Content-Type: application/json" -d '
 {
     "harvest_source_id": "59e93b86-83f1-4b70-afa7-c7ca027aeacb",
     "status": "in_progress"
 }'
 
-curl -X POST http://{site}/harvest_record/add -H "Content-Type: application/json" -d '
+curl -X POST http://{site}/harvest_record/add -H "X-API-Key: {api_token}" -H "Content-Type: application/json" -d '
 {
     "id": "identifier-1",
     "harvest_job_id": "a8c03b83-907c-41c9-95aa-d71c3be626b1",
     "harvest_source_id": "59e93b86-83f1-4b70-afa7-c7ca027aeacb"
 }'
 
-curl -X POST http://{site}/harvest_error/add -H "Content-Type: application/json" -d '
+curl -X POST http://{site}/harvest_error/add -H "X-API-Key: {api_token}" -H "Content-Type: application/json" -d '
 {
     "harvest_job_id": "a8c03b83-907c-41c9-95aa-d71c3be626b1",
     "harvest_record_id": "identifier-1",
@@ -72,12 +74,12 @@ curl -X POST http://{site}/harvest_error/add -H "Content-Type: application/json"
 
 curl -X GET http://{site}/harvest_job/a8c03b83-907c-41c9-95aa-d71c3be626b1
 
-curl -X DELETE http://{site}/organization/da183992-e598-467a-b245-a3fe8ee2fb91
+curl -X DELETE http://{site}/organization/da183992-e598-467a-b245-a3fe8ee2fb91 -H "X-API-Key: {api_token}"
 
-curl -X DELETE http://{site}/harvest_source/ca299fd6-5553-401e-ac36-05b841e31cd1
+curl -X DELETE http://{site}/harvest_source/ca299fd6-5553-401e-ac36-05b841e31cd1 -H "X-API-Key: {api_token}"
 
 
-curl -X PUT http://{site}/harvest_job/c82e0481-5884-4029-931e-234c53767e50 -H "Content-Type: application/json" -d '
+curl -X PUT http://{site}/harvest_job/c82e0481-5884-4029-931e-234c53767e50 -H "X-API-Key: {api_token}" -H "Content-Type: application/json" -d '
 {
     "status": "complete",
     "date_finished": "Wed, 27 Mar 2024 22:37:52 GMT",

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -20,7 +20,7 @@ specified amount of time in the future (see the `-v` option to the Mac OS X
 ```bash
 $ export API_TOKEN=...
 $ export id=.....  # harvest source id
-$ curl -s -H "Authorization: ${API_TOKEN}" \
+$ curl -s -H "X-API-Key: ${API_TOKEN}" \
   https://datagov-harvest-admin-dev.app.cloud.gov/harvest_job/add \
   --json "{\"harvest_source_id\": \"$id\", \
            \"status\": \"new\", \

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -22,7 +22,8 @@ it is.
 - `/organizations/`: Lists organizations, GET only, no login required
 - `/organization/add`: Add a new organization. Login-required. POST
   with JSON updates in the DB. POST with form data adds or checks for errors.
-  GET should load the `edit_data` template.
+  GET should load the `edit_data` template. JSON callers authenticate with
+  the `X-API-Key` header.
 - `/organization/<id>`: Detail page for a single org, GET only, no login
   required
 - `/organization/config/edit/<id>`: Edit an organization, POSTing JSON updates

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ $ sed -e "s:^.*/harvest_source/::" < harvest_source_paths.txt > harvest_source_i
 $ cf env datagov-harvest | grep FLASK_APP_SECRET_KEY
 $ export API_TOKEN=...
 $ cat harvest_source_ids.txt | while read id; do \
-    curl -s -H "Authorization: ${API_TOKEN}" \
+    curl -s -H "X-API-Key: ${API_TOKEN}" \
     https://harvest-dev.data.gov/harvest_job/add \
     --json "{\"harvest_source_id\": \"$id\", \"status\": \"new\", \"date_created\": \"$(TZ=UTC date -Iseconds -j -v +45M)\"}" ;
   done

--- a/scripts/ckan_migration/migrate_harvest_sources.py
+++ b/scripts/ckan_migration/migrate_harvest_sources.py
@@ -337,13 +337,13 @@ def migrate_source(
     workers=None,
 ):
     if harvester_api_token:
-        CONFIG.harvester_auth_headers = {"Authorization": harvester_api_token}
+        CONFIG.harvester_auth_headers = {"X-API-Key": harvester_api_token}
     else:
         logger.error("Please set a non-empty Harvester API token.")
         return 1
 
     if new_catalog_api_token:
-        CONFIG.new_catalog_auth_headers = {"Authorization": new_catalog_api_token}
+        CONFIG.new_catalog_auth_headers = {"X-API-Key": new_catalog_api_token}
     else:
         logger.error("Please set a non-empty Catalog API token.")
         return 1

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -220,17 +220,26 @@ class TestDynamicRouteTable:
 
 
 class TestLoginAuthHeaders:
+    def test_login_required_basic_auth_header_uses_web_session(self, client):
+        with client.session_transaction() as session:
+            session["user"] = "test.user@gsa.gov"
+
+        headers = {"Authorization": "Basic Zm9vOmJhcg=="}
+        response = client.get("/organization/add", headers=headers)
+
+        assert response.status_code == 200
+
     def test_login_required_no_token(self, client):
         headers = {"Content-Type": "application/json"}
         data = {"name": "Test Org", "logo": "test_logo.png", "slug": "test-org"}
         response = client.get("/organization/add", json=data, headers=headers)
         assert response.status_code == 401
-        assert response.data.decode() == "error: Authorization header missing"
+        assert response.data.decode() == "error: X-API-Key header missing"
 
     def test_login_required_valid_token(self, client):
         api_token = os.getenv("FLASK_APP_SECRET_KEY")
         headers = {
-            "Authorization": api_token,
+            "X-API-Key": api_token,
             "Content-Type": "application/json",
         }
         data = {"name": "Test Org", "logo": "test_logo.png", "slug": "test-org"}
@@ -240,7 +249,7 @@ class TestLoginAuthHeaders:
     def test_add_organization_invalid_slug_rejected(self, client):
         api_token = os.getenv("FLASK_APP_SECRET_KEY")
         headers = {
-            "Authorization": api_token,
+            "X-API-Key": api_token,
             "Content-Type": "application/json",
         }
         data = {"name": "Test Org", "logo": "test_logo.png", "slug": "Test_Org"}
@@ -249,7 +258,7 @@ class TestLoginAuthHeaders:
 
     def test_login_required_invalid_token(self, client):
         headers = {
-            "Authorization": "invalid_token",
+            "X-API-Key": "invalid_token",
             "Content-Type": "application/json",
         }
         data = {"name": "Test Org", "logo": "test_logo.png", "slug": "test-org"}
@@ -260,7 +269,7 @@ class TestLoginAuthHeaders:
     def test_login_required_invalid_token_logs_rejection(self, client, caplog):
         caplog.set_level("INFO", logger="harvest_admin")
         headers = {
-            "Authorization": "invalid_token",
+            "X-API-Key": "invalid_token",
             "Content-Type": "application/json",
         }
         data = {"name": "Test Org", "logo": "test_logo.png", "slug": "test-org"}
@@ -268,7 +277,7 @@ class TestLoginAuthHeaders:
         response = client.get("/organization/add", json=data, headers=headers)
 
         assert response.status_code == 401
-        assert "API auth rejected: invalid Authorization header" in caplog.text
+        assert "API auth rejected: invalid X-API-Key header" in caplog.text
 
 
 class TestLoginLogging:
@@ -366,7 +375,7 @@ class TestAuditLogging:
     def test_api_add_organization_logs_actor(self, client, caplog):
         api_token = os.getenv("FLASK_APP_SECRET_KEY")
         headers = {
-            "Authorization": api_token,
+            "X-API-Key": api_token,
             "Content-Type": "application/json",
         }
         data = {
@@ -412,7 +421,7 @@ class TestAuditLogging:
         self, client, interface, organization_data, caplog
     ):
         api_token = os.getenv("FLASK_APP_SECRET_KEY")
-        headers = {"Authorization": api_token}
+        headers = {"X-API-Key": api_token}
         interface.add_organization(organization_data)
         caplog.set_level(logging.INFO, logger="harvest_admin")
 
@@ -663,7 +672,7 @@ class TestAPIBehavior:
         # the value itself doesn't matter. we just want to mock stop_job so it completes.
         LMMock.stop_job.return_value = "a test value"
 
-        headers = {"Authorization": os.getenv("FLASK_APP_SECRET_KEY")}
+        headers = {"X-API-Key": os.getenv("FLASK_APP_SECRET_KEY")}
         response = client.get(f"/harvest_job/cancel/{job.id}", headers=headers)
         assert response.status_code == 302
         assert response.location == f"/harvest_job/{job.id}"
@@ -671,7 +680,7 @@ class TestAPIBehavior:
     def test_invalid_harvest_job_type(self, client, source_data_dcatus):
         api_token = os.getenv("FLASK_APP_SECRET_KEY")
         headers = {
-            "Authorization": api_token,
+            "X-API-Key": api_token,
             "Content-Type": "application/json",
         }
         response = client.get(

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -277,7 +277,7 @@ class TestLoginAuthHeaders:
         response = client.get("/organization/add", json=data, headers=headers)
 
         assert response.status_code == 401
-        assert "API auth rejected: invalid X-API-Key header" in caplog.text
+        assert "API auth rejected: invalid API key header" in caplog.text
 
 
 class TestLoginLogging:

--- a/tests/playwright/test_harvest_api_create_and_destroy.py
+++ b/tests/playwright/test_harvest_api_create_and_destroy.py
@@ -23,7 +23,7 @@ class TestHarvestAPICreateAndDestroy:
         res = apage.request.post(
             "/organization/add",
             headers={
-                "Authorization": api_token,
+                "X-API-Key": api_token,
                 "Content-Type": "application/json",
             },
             data=fixture_org,
@@ -37,7 +37,7 @@ class TestHarvestAPICreateAndDestroy:
         res = apage.request.delete(
             f"/organization/{org_id}",
             headers={
-                "Authorization": api_token,
+                "X-API-Key": api_token,
                 "Content-Type": "application/json",
             },
         )
@@ -59,7 +59,7 @@ class TestHarvestAPICreateAndDestroy:
         res = apage.request.post(
             "/organization/add",
             headers={
-                "Authorization": api_token,
+                "X-API-Key": api_token,
                 "Content-Type": "application/json",
             },
             data=fixture_org,
@@ -78,7 +78,7 @@ class TestHarvestAPICreateAndDestroy:
         res = apage.request.post(
             "/harvest_source/add",
             headers={
-                "Authorization": api_token,
+                "X-API-Key": api_token,
                 "Content-Type": "application/json",
             },
             data=fixture_source,
@@ -92,7 +92,7 @@ class TestHarvestAPICreateAndDestroy:
         res = apage.request.delete(
             f"/harvest_source/{source_id}",
             headers={
-                "Authorization": api_token,
+                "X-API-Key": api_token,
                 "Content-Type": "application/json",
             },
         )


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5864

## About

When the harvest app is protected by Basic Auth, the Authorization request header is shared by both the API key and Basic Auth credentials. This creates conflicts and makes credential configuration and CloudFront origin policy settings more complicated (though still manageable). Renaming the API key header from Authorization to X-API-Key is the cleanest way to fix it.