### PR TITLE
patch snyk vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM python:3.12.13-slim
+FROM python:3.12.13-alpine3.22
 
-# Refresh APT indexes and pull the latest patched packages from the base distro.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# Pull the latest patched packages from the base distro.
+RUN apk upgrade --no-cache
 
 WORKDIR /app
 
@@ -29,4 +26,4 @@ EXPOSE 8080
 ENV FLASK_APP=run.py
 
 # Run run.py when the container launches
-CMD ["/bin/bash", "-c", "flask db upgrade && flask run --host=0.0.0.0 --port=8080"]
+CMD ["/bin/sh", "-c", "flask db upgrade && flask run --host=0.0.0.0 --port=8080"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1947,18 +1947,18 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.17"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+    {file = "idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c"},
+    {file = "idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -2137,14 +2137,14 @@ dev = ["Sphinx (==8.1.3) ; python_version >= \"3.11\"", "build (==1.2.2) ; pytho
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77"},
-    {file = "mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069"},
+    {file = "mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"},
+    {file = "mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"},
 ]
 
 [package.dependencies]
@@ -4604,4 +4604,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "3.12.13"
-content-hash = "fbf026dbea6825dee061bd7945ea84bfd294aa6b59e8014614df50a94c16c6d8"
+content-hash = "bb73f8d5c335d8dea092e3c1546a524cc4145b21020c6d397c9fa113980d23b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ flask-wtf = "^1.2.1"
 flask-migrate = "^4.0.7"
 bootstrap-flask = "^2.5.0"
 cloudfoundry-client = "^1.40.0"
-pyjwt = "^2.12.1"
+pyjwt = ">=2.13.0,<3.0.0"
 cryptography = ">=46.0.7,<49.0.0"
 boltons = "^25.0.0"
 jinja2-fragments = "^1.12.0"
@@ -51,6 +51,8 @@ werkzeug = "^3.1.8" #SNYK-PYTHON-WERKZEUG-14908843
 apiflask = "^3.1.0"
 flask-talisman = "^1.1.0"
 newrelic = ">=12.1,<14.0"
+idna = ">=3.15,<4.0"
+mako = ">=1.3.12,<2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=9.0.3"


### PR DESCRIPTION
fix a few snyk finding

<img width="930" height="303" alt="image" src="https://github.com/user-attachments/assets/6e5d3695-3028-4c60-866a-30eee86338e8" />

- Switch the app container from the Debian-based python:3.12.13-slim image to python:3.12.13-alpine3.22. The Debian image was introducing perl/perl-base@5.40.1-6, which Snyk reports as CVE-2026-42496 / SNYK-DEBIAN13-PERL-17037434. Alpine does not install Perl in this image, so the vulnerable Debian package is no longer present.
- pyjwt
- idna
- mako
