### PR TITLE
6035 - Adding missing urls for csp for gtag to work correctly

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -265,11 +265,17 @@ def create_app():
                 "data:",
                 "https://s3-us-gov-west-1.amazonaws.com",  # GSA Starmark
                 "https://raw.githubusercontent.com",  # github logos repo
+                "https://*.google-analytics.com",  # GA4 beacons
+                "https://*.googletagmanager.com",  # GTM beacons
             ]
         ),
         "connect-src": " ".join(
             [
                 "'self'",
+                "https://*.google-analytics.com",  # GA4 collect endpoint
+                "https://*.analytics.google.com",  # GA4 analytics
+                "https://*.googletagmanager.com",  # GTM
+                "https://www.google.com",  # GA4 collect fallback
             ]
         ),
         "frame-src": "https://www.googletagmanager.com",


### PR DESCRIPTION
work for https://github.com/GSA/data.gov/issues/6035:

Adding the necessary https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4 CSP records to not get CSP errors:

