### PR TITLE
Fix per_page=0 returning a full page instead of zero results

### DIFF
--- a/database/interface.py
+++ b/database/interface.py
@@ -41,7 +41,12 @@ def paginate(fn):
         elif kwargs.get("paginate") is False:
             return query.all()
         else:
-            per_page = kwargs.get("per_page") or PAGINATE_ENTRIES_PER_PAGE
+            # `or` would treat an explicit per_page=0 as falsy and fall back to
+            # the default, returning a full page instead of none. Only default
+            # when per_page was not supplied. See GSA/data.gov#5910.
+            per_page = kwargs.get("per_page")
+            if per_page is None:
+                per_page = PAGINATE_ENTRIES_PER_PAGE
             page = kwargs.get("page") or PAGINATE_START_PAGE
             query = query.limit(per_page)
             query = query.offset(page * per_page)

--- a/tests/integration/database/test_db.py
+++ b/tests/integration/database/test_db.py
@@ -520,6 +520,14 @@ class TestDatabase:
         assert filtered_list[0].status == "new"
         assert filtered_list[0].harvest_source_id == source_data_dcatus["id"]
 
+    def test_pget_harvest_jobs_per_page_zero_returns_none(
+        self, interface_with_multiple_jobs
+    ):
+        # Regression test for GSA/data.gov#5910: an explicit per_page=0 must
+        # return zero results, not fall back to the default page size.
+        results = interface_with_multiple_jobs.pget_harvest_jobs(per_page=0)
+        assert len(results) == 0
+
     def get_new_harvest_jobs_in_past(self, interface_with_multiple_jobs):
         filtered_job_list = interface_with_multiple_jobs.get_new_harvest_jobs_in_past()
         all_jobs_list = interface_with_multiple_jobs.get_all_harvest_jobs()


### PR DESCRIPTION
## Description

Passing `per_page=0` to a list endpoint returns a full page of results instead of zero. The `paginate` decorator computed:

```python
per_page = kwargs.get("per_page") or PAGINATE_ENTRIES_PER_PAGE
```

Because `0` is falsy, an explicit `per_page=0` falls through to the default page size. This only defaults when `per_page` was not supplied, so `per_page=0` now yields `LIMIT 0` and returns zero results.

Added a regression test (`test_pget_harvest_jobs_per_page_zero_returns_none`) following the existing `interface_with_multiple_jobs` pattern. I wasn't able to spin up the Flask/DB suite locally, so I'd appreciate a CI run to confirm.

Closes GSA/data.gov#5910
