### PR TITLE
Validate order_by query param on list endpoints (422 on invalid)

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1784,6 +1784,9 @@ def json_builder_query(**kwargs):
     job_id = request.args.get("harvest_job_id")
     source_id = request.args.get("harvest_source_id")
     facets = request.args.get("facets", default="")
+    order_by = request.args.get("order_by")
+    if order_by is not None and order_by not in ("asc", "desc"):
+        return f"Invalid order_by '{order_by}', must be 'asc' or 'desc'", 422
 
     if job_id is not None:
         if facets:
@@ -1804,7 +1807,7 @@ def json_builder_query(**kwargs):
             per_page=request.args.get("per_page", type=convert_to_int),
             paginate=request.args.get("paginate", type=is_it_true),
             count=request.args.get("count", type=is_it_true),
-            order_by=request.args.get("order_by"),
+            order_by=order_by,
             facets=facets,
         )
         if not res:

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -527,6 +527,11 @@ class TestJSONResponses:
                 404,
                 "No harvest_sources found for this query",
             ),
+            (
+                "/harvest_sources/?order_by=notafield",
+                422,
+                "Invalid order_by 'notafield', must be 'asc' or 'desc'",
+            ),
         ],
     )
     def test_json_builder_query(


### PR DESCRIPTION
## Description

The Harvest-API list endpoints accept an `order_by` query param, but `order_by_helper` treats any value other than `"asc"` as `"desc"`:

```python
return model.date_created.asc() if order_by == "asc" else model.date_created.desc()
```

So `?order_by=notafield` (or any invalid value) silently returns default ordering instead of an error. The shared `json_builder_query` handler validates input directly (the query input is intentionally `validation=False`), so this adds an explicit check there: anything other than `asc`/`desc` returns HTTP 422 before the query runs. One handler serves all five list endpoints, so it's covered in one place.

Added a parametrized case to `test_json_builder_query`. I wasn't able to spin up the Flask/DB suite locally, so a CI run to confirm would be appreciated.

Closes GSA/data.gov#5908
