### PR TITLE
Coerce non-string dcat.spatial so OpenSearch indexing doesn't fail

### DIFF
--- a/harvester/opensearch.py
+++ b/harvester/opensearch.py
@@ -245,6 +245,26 @@ class OpenSearchInterface:
         return normalized_dcat
 
     @staticmethod
+    def _normalize_dcat_spatial(dcat: dict) -> dict:
+        """Normalize the spatial field so it always indexes as text.
+
+        The OpenSearch mapping treats dcat.spatial as text and most datasets
+        carry it as a string, but some carry it as a JSON-LD object such as
+        {"@type": "Location", "prefLabel": "United States"}, which fails text
+        parsing and aborts the whole index batch. Coerce a non-string spatial
+        value to a string, preferring a readable label. See #5987.
+        """
+        spatial = dcat.get("spatial")
+        if spatial is None or isinstance(spatial, str):
+            return dcat
+        normalized_dcat = dcat.copy()
+        if isinstance(spatial, dict) and spatial.get("prefLabel"):
+            normalized_dcat["spatial"] = str(spatial["prefLabel"])
+        else:
+            normalized_dcat["spatial"] = str(spatial)
+        return normalized_dcat
+
+    @staticmethod
     def _geometry_centroid(geometry: Any) -> dict | None:
         """Calculate the centroid of a geometry."""
         if not isinstance(geometry, dict):
@@ -300,6 +320,7 @@ class OpenSearchInterface:
             or has_spatial_theme
         )
         normalized_dcat = self._normalize_dcat_dates(dataset.dcat)
+        normalized_dcat = self._normalize_dcat_spatial(normalized_dcat)
         spatial_centroid = self._geometry_centroid(dataset.translated_spatial)
         last_harvested = (
             dataset.last_harvested_date.isoformat()

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -87,6 +87,22 @@ def test_normalize_dcat_dates():
     assert normalized["temporal"] == "123"
 
 
+def test_normalize_dcat_spatial():
+    # object spatial with prefLabel -> readable label (regression for #5987)
+    dcat = {"spatial": {"@type": "Location", "prefLabel": "United States"}}
+    assert OpenSearchInterface._normalize_dcat_spatial(dcat)["spatial"] == "United States"
+    # string spatial is left unchanged
+    assert (
+        OpenSearchInterface._normalize_dcat_spatial({"spatial": "-180,-90,180,90"})["spatial"]
+        == "-180,-90,180,90"
+    )
+    # object spatial without prefLabel is coerced to a string (still indexes)
+    coerced = OpenSearchInterface._normalize_dcat_spatial({"spatial": {"bbox": [1, 2]}})["spatial"]
+    assert isinstance(coerced, str)
+    # missing spatial is a no-op
+    assert "spatial" not in OpenSearchInterface._normalize_dcat_spatial({"title": "x"})
+
+
 def test_geometry_centroid_returns_average():
     geometry = {"type": "MultiPoint", "coordinates": [[0, 0], [2, 2]]}
 


### PR DESCRIPTION
## Description

A dataset whose `dcat.spatial` is a JSON-LD object (e.g. `{"@type": "Location", "prefLabel": "United States"}`) fails to index into OpenSearch:

```
mapper_parsing_exception: failed to parse field [dcat.spatial] of type [text]
```

`dcat.spatial` is mapped as text and most datasets carry it as a string, so an object value aborts the whole index batch (the symptom in GSA/data.gov#5987).

This adds a `_normalize_dcat_spatial` step (mirroring the existing `_normalize_dcat_dates`) that coerces a non-string spatial value to a string before indexing - using `prefLabel` when present, otherwise `str(...)`. String spatial values are left unchanged.

Added a unit test (`test_normalize_dcat_spatial`). I wasn't able to run the Flask/DB suite locally, but the normalizer is a pure function tested the same way as `test_normalize_dcat_dates`.

Closes GSA/data.gov#5987
