### PR TITLE
5849 - updating github action to create an issue if the index failed

### DIFF
--- a/.github/opensearch_index_batch_failure.md
+++ b/.github/opensearch_index_batch_failure.md
@@ -1,0 +1,18 @@
+---
+title: OpenSearch Index Batch Failures ({{ env.ENVIRONMENT }})
+labels: ["bug", "o&m"]
+---
+
+The scheduled OpenSearch sync task completed but one or more dataset batches reported
+`failed to index in this batch` in the task logs.
+
+Workflow with Issue: {{ workflow }}
+Job Failed: {{ env.GITHUB_JOB }}
+Command: {{ env.COMMAND }}
+Cloud.gov Environment: {{ env.ENVIRONMENT }}
+
+Last observed: {{ date | date('YYYY-MM-DD HH:mm:ss Z') }}
+Last Commit: {{ env.LAST_COMMIT }}
+Number of times run: {{ env.GITHUB_ATTEMPTS }}
+Last run by: {{ env.LAST_RUN_BY }}
+GitHub Action Run: https://github.com/GSA/datagov-harvester/actions/runs/{{ env.RUN_ID }}

--- a/.github/opensearch_index_batch_failure.md
+++ b/.github/opensearch_index_batch_failure.md
@@ -3,8 +3,8 @@ title: OpenSearch Index Batch Failures ({{ env.ENVIRONMENT }})
 labels: ["bug", "o&m"]
 ---
 
-The scheduled OpenSearch sync task completed but one or more dataset batches reported
-`failed to index in this batch` in the task logs.
+The OpenSearch sync task logs included the index failure message
+`failed to index in this batch`.
 
 Workflow with Issue: {{ workflow }}
 Job Failed: {{ env.GITHUB_JOB }}

--- a/.github/workflows/synchronize_opensearch_index.yml
+++ b/.github/workflows/synchronize_opensearch_index.yml
@@ -116,7 +116,7 @@ jobs:
           if [ -f .cf_monitor_result ]; then
             echo "result=$(cat .cf_monitor_result)" >> "$GITHUB_OUTPUT"
           fi
-          if [ "${{ steps.monitor.outcome }}" = "failure" ] && [ ! -f .cf_monitor_result ]; then
+          if [ "${{ steps.monitor.outcome }}" = "failure" ]; then
             echo "task_failed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create issue for task failure
@@ -135,7 +135,7 @@ jobs:
           filename: .github/opensearch_sync_failure.md
           update_existing: true
       - name: Create issue for index batch failures
-        if: steps.monitor_result.outputs.result == 'index_batch_warning'
+        if: steps.monitor_result.outputs.result == 'warning_pattern_matched'
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -150,7 +150,5 @@ jobs:
           filename: .github/opensearch_index_batch_failure.md
           update_existing: true
       - name: Fail workflow on monitor errors
-        if: >-
-          steps.monitor_result.outputs.task_failed == 'true' ||
-          steps.monitor_result.outputs.result == 'index_batch_warning'
+        if: steps.monitor_result.outputs.task_failed == 'true'
         run: exit 1

--- a/.github/workflows/synchronize_opensearch_index.yml
+++ b/.github/workflows/synchronize_opensearch_index.yml
@@ -98,16 +98,29 @@ jobs:
           cf_username: ${{ secrets.CF_SERVICE_USER }}
           cf_password: ${{ secrets.CF_SERVICE_AUTH }}
       - name: Monitor task output
+        id: monitor
+        continue-on-error: true
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: >
             bin/monitor_cf_logs.sh datagov-harvest "$OPENSEARCH_INSTANCE_NAME"
+            "failed to index in this batch"
           cf_org: gsa-datagov
           cf_space: ${{ env.CF_SPACE }}
           cf_username: ${{ secrets.CF_SERVICE_USER }}
           cf_password: ${{ secrets.CF_SERVICE_AUTH }}
-      - name: Create issue for failure
-        if: failure()
+      - name: Interpret monitor result
+        id: monitor_result
+        if: always()
+        run: |
+          if [ -f .cf_monitor_result ]; then
+            echo "result=$(cat .cf_monitor_result)" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ steps.monitor.outcome }}" = "failure" ] && [ ! -f .cf_monitor_result ]; then
+            echo "task_failed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create issue for task failure
+        if: steps.monitor_result.outputs.task_failed == 'true'
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -121,3 +134,23 @@ jobs:
         with:
           filename: .github/opensearch_sync_failure.md
           update_existing: true
+      - name: Create issue for index batch failures
+        if: steps.monitor_result.outputs.result == 'index_batch_warning'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_JOB: ${{ github.job }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+          COMMAND: ${{ env.TASK_COMMAND }}
+          ENVIRONMENT: ${{ matrix.environment }}
+        with:
+          filename: .github/opensearch_index_batch_failure.md
+          update_existing: true
+      - name: Fail workflow on monitor errors
+        if: >-
+          steps.monitor_result.outputs.task_failed == 'true' ||
+          steps.monitor_result.outputs.result == 'index_batch_warning'
+        run: exit 1

--- a/bin/monitor_cf_logs.sh
+++ b/bin/monitor_cf_logs.sh
@@ -5,12 +5,13 @@
 # Usage: monitor_cf_logs.sh <app_name> <task_name> [warning_pattern]
 #
 # Exit codes:
-#   0 - Task exited 0 and warning_pattern did not match (or no pattern given)
+#   0 - Task exited 0
 #   1 - Task exited non-zero
-#   2 - Task exited 0 but warning_pattern matched one or more log lines
 #
-# On exit 2, writes "index_batch_warning" to .cf_monitor_result in GITHUB_WORKSPACE
-# (or the current directory) so CI can branch on the failure type.
+# If warning_pattern matches one or more log lines, writes
+# "warning_pattern_matched" to .cf_monitor_result in GITHUB_WORKSPACE (or the
+# current directory) so CI can branch on the result without changing the task
+# exit status.
 
 app_to_monitor=$1
 task_to_monitor=$2
@@ -19,25 +20,19 @@ warning_pattern=${3:-}
 result_file="${GITHUB_WORKSPACE:-.}/.cf_monitor_result"
 rm -f "$result_file"
 
-warning_detected=false
-
 # install a better version of grep which supports --line-buffered
 apk add grep
 
 write_warning_result() {
-  echo "index_batch_warning" > "$result_file"
+  echo "warning_pattern_matched" > "$result_file"
 }
 
 while read -r line ; do
   echo "$line"
   if [[ -n "$warning_pattern" ]] && echo "$line" | grep -qF "$warning_pattern"; then
-    warning_detected=true
+    write_warning_result
   fi
   if echo "$line" | grep -q "OUT Exit status 0"; then
-    if [[ "$warning_detected" == true ]]; then
-      write_warning_result
-      exit 2
-    fi
     exit 0
   elif echo "$line" | grep -q "OUT Exit status"; then
     exit 1

--- a/bin/monitor_cf_logs.sh
+++ b/bin/monitor_cf_logs.sh
@@ -1,20 +1,45 @@
 #!/bin/bash
 
-# Custom script to look at logs from run task...
+# Monitor Cloud Foundry task logs until the task exits.
+#
+# Usage: monitor_cf_logs.sh <app_name> <task_name> [warning_pattern]
+#
+# Exit codes:
+#   0 - Task exited 0 and warning_pattern did not match (or no pattern given)
+#   1 - Task exited non-zero
+#   2 - Task exited 0 but warning_pattern matched one or more log lines
+#
+# On exit 2, writes "index_batch_warning" to .cf_monitor_result in GITHUB_WORKSPACE
+# (or the current directory) so CI can branch on the failure type.
 
-# Input any app name, any task name and any log key
-# log key helps to prevent printing sensitive info such as redis password
 app_to_monitor=$1
 task_to_monitor=$2
+warning_pattern=${3:-}
+
+result_file="${GITHUB_WORKSPACE:-.}/.cf_monitor_result"
+rm -f "$result_file"
+
+warning_detected=false
 
 # install a better version of grep which supports --line-buffered
-apk add grep 
+apk add grep
+
+write_warning_result() {
+  echo "index_batch_warning" > "$result_file"
+}
 
 while read -r line ; do
   echo "$line"
-  if echo "$line" | grep "OUT Exit status 0"; then
+  if [[ -n "$warning_pattern" ]] && echo "$line" | grep -qF "$warning_pattern"; then
+    warning_detected=true
+  fi
+  if echo "$line" | grep -q "OUT Exit status 0"; then
+    if [[ "$warning_detected" == true ]]; then
+      write_warning_result
+      exit 2
+    fi
     exit 0
-  elif echo "$line" | grep "OUT Exit status"; then
+  elif echo "$line" | grep -q "OUT Exit status"; then
     exit 1
   fi
-done < <(cf logs "$app_to_monitor" | grep  --line-buffered "\[APP/TASK/$task_to_monitor/0\]")
+done < <(cf logs "$app_to_monitor" | grep --line-buffered "\[APP/TASK/$task_to_monitor/0\]")


### PR DESCRIPTION
work for https://github.com/GSA/data.gov/issues/5849

Updating the existing monitor cf logs script to check for a passed in string of "failed to index in this batch", and if it is present, we create (or update) a github issue with that error so we know something went wrong.