### PR TITLE
more timeout for page.goto()

### DIFF
--- a/tests/playwright/conftest.py
+++ b/tests/playwright/conftest.py
@@ -77,6 +77,7 @@ def unauthed_page(browser, base_url):
     context = browser.new_context(base_url=base_url)
     page = context.new_page()
     page.set_default_timeout(2500)
+    page.set_default_navigation_timeout(10000)
     yield page
     context.close()
 
@@ -88,6 +89,7 @@ def authed_page(browser, base_url):
     )
     page = context.new_page()
     page.set_default_timeout(2500)
+    page.set_default_navigation_timeout(10000)
     yield page
     context.close()
 


### PR DESCRIPTION
For
- https://github.com/GSA/data.gov/issues/5925

Too often we see this timeout error.

<img width="643" height="300" alt="image" src="https://github.com/user-attachments/assets/b1e8d725-f3af-4146-bcab-ae6b553211d0" />
