### PR TITLE
add db indexes

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from flask_sqlalchemy import SQLAlchemy
 from geoalchemy2 import Geometry
-from sqlalchemy import CheckConstraint, Column, Enum, String, func, select
+from sqlalchemy import CheckConstraint, Column, Enum, Index, String, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import DeclarativeBase, backref, column_property
@@ -192,6 +192,16 @@ class HarvestRecord(db.Model):
     status = db.Column(Enum("error", "success", name="record_status"), index=True)
     errors = db.relationship("HarvestRecordError", backref="record", lazy=True)
 
+    __table_args__ = (
+        Index(
+            "ix_hr_source_status_identifier_created_desc",
+            "harvest_source_id",
+            "status",
+            "identifier",
+            date_created.desc(),
+        ),
+    )
+
     @property
     def dataset_slug(self) -> Optional[str]:
         dataset = getattr(self, "dataset", None)
@@ -289,6 +299,8 @@ class HarvestRecordError(Error):
     harvest_job_id = db.Column(
         db.String(36), db.ForeignKey("harvest_job.id"), nullable=False
     )
+
+    __table_args__ = (Index("ix_hre_job_id", "harvest_job_id"),)
 
 
 class HarvestUser(db.Model):

--- a/migrations/versions/4bc26ce5f9f7_add_composite_index_to_harvest_job_job_.py
+++ b/migrations/versions/4bc26ce5f9f7_add_composite_index_to_harvest_job_job_.py
@@ -1,0 +1,46 @@
+"""add composite index to harvest job & job_id index to harvest record
+
+Revision ID: 4bc26ce5f9f7
+Revises: f2b1f0f2a9f7
+Create Date: 2026-06-16 13:32:29.664001
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4bc26ce5f9f7"
+down_revision = "f2b1f0f2a9f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("""
+            CREATE INDEX CONCURRENTLY ix_hr_source_status_identifier_created_desc
+                ON harvest_record (
+                harvest_source_id,
+                status,
+                identifier,
+                date_created DESC
+            )
+            """)
+
+        op.execute("""
+            CREATE INDEX CONCURRENTLY ix_hre_job_id
+            ON harvest_record_error (harvest_job_id)
+            """)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute("""
+            DROP INDEX CONCURRENTLY IF EXISTS
+            ix_hr_source_status_identifier_created_desc
+            """)
+        op.execute("""
+            DROP INDEX CONCURRENTLY IF EXISTS
+            ix_hre_job_id
+            """)


### PR DESCRIPTION
# Pull Request

Related to [5957](https://github.com/GSA/data.gov/issues/5957)

## About
- adds composite index to harvest record to improve `get_latest_harvest_records_by_source`
- adds index to harvest record error table by job id

i'm using `concurrently` for zero write downtime. if lock prevent the indexes from being created then i'll need to use the util `terminate_processes_sql`

i can update the catalog with these new indexes but it would be useless (not to mention adding space for the index) other than keeping them in sync. we may want to consider allowing them to deviate.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
