### PR TITLE
Support -field order_by syntax on list endpoints

### DIFF
--- a/database/interface.py
+++ b/database/interface.py
@@ -971,10 +971,6 @@ class HarvesterDBInterface:
 
         facet_list = query_filter_builder(model_class, facets)
 
-        # TODO: should we add date_created to these models??
-        if model in ["organizations", "harvest_sources"]:
-            return self.db.query(model_class).filter(*facet_list)
-
         order_by_val = order_by_helper(model_class, order_by)
 
         return self.db.query(model_class).filter(*facet_list).order_by(order_by_val)
@@ -1064,4 +1060,21 @@ class HarvesterDBInterface:
 
 
 def order_by_helper(model, order_by):
-    return model.date_created.asc() if order_by == "asc" else model.date_created.desc()
+    sort_column_name = "date_created"
+    if hasattr(model, "name"):
+        sort_column_name = "name"
+
+    if order_by in (None, "", "asc"):
+        return getattr(model, sort_column_name).asc()
+
+    if order_by == "desc":
+        return getattr(model, sort_column_name).desc()
+
+    is_descending = order_by.startswith("-")
+    candidate_column_name = order_by[1:] if is_descending else order_by
+    candidate_column = getattr(model, candidate_column_name, None)
+
+    if candidate_column is None:
+        return getattr(model, sort_column_name).desc()
+
+    return candidate_column.desc() if is_descending else candidate_column.asc()

--- a/tests/integration/app/test_routes.py
+++ b/tests/integration/app/test_routes.py
@@ -553,6 +553,33 @@ class TestJSONResponses:
         except Exception:
             assert res.data.decode() == response
 
+    def test_harvest_sources_order_by_supports_desc_prefix(
+        self,
+        client,
+        interface,
+        organization_data,
+        source_data_dcatus,
+        source_data_dcatus_2,
+    ):
+        interface.add_organization(organization_data)
+
+        source_alpha = source_data_dcatus.copy()
+        source_alpha["name"] = "Alpha source"
+
+        source_zulu = source_data_dcatus_2.copy()
+        source_zulu["name"] = "Zulu source"
+
+        interface.add_harvest_source(source_alpha)
+        interface.add_harvest_source(source_zulu)
+
+        asc_response = client.get("/harvest_sources/?order_by=name&paginate=false")
+        desc_response = client.get("/harvest_sources/?order_by=-name&paginate=false")
+
+        assert asc_response.status_code == 200
+        assert desc_response.status_code == 200
+        assert asc_response.json[0]["name"] == "Alpha source"
+        assert desc_response.json[0]["name"] == "Zulu source"
+
     def test_organizations(self, client, interface_with_fixture_json):
         """
         checks the content of the json response when navigating to "/organizations/"


### PR DESCRIPTION
This updates list endpoint ordering so `order_by=-field` works as expected.

`pget_db_query` now applies ordering for `organizations` and `harvest_sources`, and `order_by_helper` now supports explicit sort fields with an optional leading `-` for descending order.

I also added an integration test for `/harvest_sources` that checks `order_by=name` and `order_by=-name` return opposite sort orders.

Fixes GSA/data.gov#5907

## Testing
- `.venv/bin/python -m pytest tests/integration/app/test_routes.py -k order_by_supports_desc_prefix`
- `.venv/bin/python -m pytest tests/integration/database/test_db.py -k endpoint_order_by`