### PR TITLE
Remove broken README test badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # datagov-harvester
 
-| Test Suite | Count | Coverage |
-| --- | --- | --- |
-| Unit | [![Unit Test Count](./tests/badges/unit/tests.svg)](./tests/unit)| [![Unit Test Coverage](./tests/badges/unit/coverage.svg)](./tests/unit)|
-| Integration | [![Unit Test Count](./tests/badges/integration/tests.svg)](./tests/integration)| [![Unit Test Coverage](./tests/badges/integration/coverage.svg)](./tests/integration)|
-| Playwright | [![Playwright Test Count](./tests/badges/playwright/tests.svg)](./tests/playwright)| [![Playwright Test Coverage](./tests/badges/playwright/coverage.svg)](./tests/playwright)|
-| Functional | [![Functional Test Count](tests/badges/functional/tests.svg)](./tests/functional)| [![Unit Test Coverage](./tests/badges/functional/coverage.svg)](./tests/functional/)|
-
 This repository holds the source code the Data.gov Harvester 2.0, which includes three applications applications:
 
 - datagov-harvest-runner: This is a python application, chiefly composed of files in the `harvester` directory.


### PR DESCRIPTION
# Pull Request

Fixes GSA/data.gov#6025

## About

The README badge table linked to `tests/badges/...` SVGs that are gitignored and not present in the repository. That caused broken image badges at the top of the project page.

This removes the stale badge table so the README no longer renders broken links.

## Verification

- `python3 -c "from pathlib import Path; text = Path('README.md').read_text(); assert 'tests/badges' not in text; print('README badge references validated')"`
