### PR TITLE
normalize DCAT values

### DIFF
--- a/harvester/opensearch.py
+++ b/harvester/opensearch.py
@@ -243,6 +243,12 @@ class OpenSearchInterface:
                     normalized_dcat[field] = value.isoformat()
                 elif value is not None and not isinstance(value, str):
                     normalized_dcat[field] = str(value)
+        spatial = normalized_dcat.get("spatial")
+        if spatial is not None and not isinstance(spatial, str):
+            if isinstance(spatial, (dict, list)):
+                normalized_dcat["spatial"] = json.dumps(spatial, sort_keys=True)
+            else:
+                normalized_dcat["spatial"] = str(spatial)
         return normalized_dcat
 
     @staticmethod

--- a/harvester/opensearch.py
+++ b/harvester/opensearch.py
@@ -232,8 +232,14 @@ class OpenSearchInterface:
         self._ensure_index()
 
     @staticmethod
-    def _normalize_dcat_dates(dcat: dict) -> dict:
-        """Normalize date fields in DCAT to ensure they're always strings."""
+    def _serialize_dcat_value(value: Any) -> str:
+        if isinstance(value, (dict, list)):
+            return json.dumps(value, sort_keys=True)
+        return str(value)
+
+    @classmethod
+    def _normalize_dcat_dates(cls, dcat: dict) -> dict:
+        """Normalize DCAT values for OpenSearch metadata indexing."""
         normalized_dcat = dcat.copy()
         date_fields = ["modified", "issued", "temporal"]
         for field in date_fields:
@@ -245,10 +251,27 @@ class OpenSearchInterface:
                     normalized_dcat[field] = str(value)
         spatial = normalized_dcat.get("spatial")
         if spatial is not None and not isinstance(spatial, str):
-            if isinstance(spatial, (dict, list)):
-                normalized_dcat["spatial"] = json.dumps(spatial, sort_keys=True)
-            else:
-                normalized_dcat["spatial"] = str(spatial)
+            normalized_dcat["spatial"] = cls._serialize_dcat_value(spatial)
+
+        distributions = normalized_dcat.get("distribution")
+        if isinstance(distributions, list):
+            # keep each distribution object intact, but serialize any nested
+            # object or list values inside it.
+            normalized_dcat["distribution"] = [
+                (
+                    {
+                        field: (
+                            cls._serialize_dcat_value(field_value)
+                            if isinstance(field_value, (dict, list))
+                            else field_value
+                        )
+                        for field, field_value in distribution.items()
+                    }
+                    if isinstance(distribution, dict)
+                    else distribution
+                )
+                for distribution in distributions
+            ]
         return normalized_dcat
 
     @staticmethod

--- a/harvester/opensearch.py
+++ b/harvester/opensearch.py
@@ -238,6 +238,34 @@ class OpenSearchInterface:
         return str(value)
 
     @classmethod
+    def _normalize_dcat_metadata_value(cls, value: Any) -> Any:
+        # stringify nested objects/lists because
+        # OpenSearch expect those fields to be text.
+        if isinstance(value, dict):
+            return {
+                field: (
+                    cls._serialize_dcat_value(field_value)
+                    if isinstance(field_value, (dict, list))
+                    else field_value
+                )
+                for field, field_value in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                (
+                    cls._normalize_dcat_metadata_value(item)
+                    if isinstance(item, dict)
+                    else (
+                        cls._serialize_dcat_value(item)
+                        if isinstance(item, list)
+                        else item
+                    )
+                )
+                for item in value
+            ]
+        return value
+
+    @classmethod
     def _normalize_dcat_dates(cls, dcat: dict) -> dict:
         """Normalize DCAT values for OpenSearch metadata indexing."""
         normalized_dcat = dcat.copy()
@@ -253,25 +281,10 @@ class OpenSearchInterface:
         if spatial is not None and not isinstance(spatial, str):
             normalized_dcat["spatial"] = cls._serialize_dcat_value(spatial)
 
-        distributions = normalized_dcat.get("distribution")
-        if isinstance(distributions, list):
-            # keep each distribution object intact, but serialize any nested
-            # object or list values inside it.
-            normalized_dcat["distribution"] = [
-                (
-                    {
-                        field: (
-                            cls._serialize_dcat_value(field_value)
-                            if isinstance(field_value, (dict, list))
-                            else field_value
-                        )
-                        for field, field_value in distribution.items()
-                    }
-                    if isinstance(distribution, dict)
-                    else distribution
-                )
-                for distribution in distributions
-            ]
+        for field, value in normalized_dcat.items():
+            if field in date_fields or field == "spatial":
+                continue
+            normalized_dcat[field] = cls._normalize_dcat_metadata_value(value)
         return normalized_dcat
 
     @staticmethod

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -126,6 +126,21 @@ def test_normalize_dcat_distribution_structured_field():
     )
 
 
+def test_normalize_dcat_serializes_nested_metadata_objects():
+    dcat = {
+        "contactPoint": {
+            "fn": "Data contact",
+            "hasEmail": {"@id": "mailto:data@example.gov"},
+        }
+    }
+
+    normalized = OpenSearchInterface._normalize_dcat_dates(dcat)
+
+    expected_email = '{"@id": "mailto:data@example.gov"}'
+    assert normalized["contactPoint"]["fn"] == "Data contact"
+    assert normalized["contactPoint"]["hasEmail"] == expected_email
+
+
 def test_geometry_centroid_returns_average():
     geometry = {"type": "MultiPoint", "coordinates": [[0, 0], [2, 2]]}
 

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -97,7 +97,10 @@ def test_normalize_dcat_spatial_object():
 
     normalized = OpenSearchInterface._normalize_dcat_dates(dcat)
 
-    assert normalized["spatial"] == '{"@type": "Location", "prefLabel": "United States"}'
+    assert (
+        normalized["spatial"]
+        == '{"@type": "Location", "prefLabel": "United States"}'
+    )
 
 
 def test_geometry_centroid_returns_average():

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -102,6 +102,30 @@ def test_normalize_dcat_spatial_object():
     )
 
 
+def test_normalize_dcat_distribution_structured_field():
+    dcat = {
+        "distribution": [
+            {
+                "title": "CSV download",
+                "conformsTo": {
+                    "@type": "Standard",
+                    "identifier": "https://www.w3.org/TR/tabular-data-primer/",
+                    "title": "CSV on the Web",
+                },
+            }
+        ]
+    }
+
+    normalized = OpenSearchInterface._normalize_dcat_dates(dcat)
+
+    assert normalized["distribution"][0]["title"] == "CSV download"
+    assert normalized["distribution"][0]["conformsTo"] == (
+        '{"@type": "Standard", '
+        '"identifier": "https://www.w3.org/TR/tabular-data-primer/", '
+        '"title": "CSV on the Web"}'
+    )
+
+
 def test_geometry_centroid_returns_average():
     geometry = {"type": "MultiPoint", "coordinates": [[0, 0], [2, 2]]}
 

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -98,8 +98,7 @@ def test_normalize_dcat_spatial_object():
     normalized = OpenSearchInterface._normalize_dcat_dates(dcat)
 
     assert (
-        normalized["spatial"]
-        == '{"@type": "Location", "prefLabel": "United States"}'
+        normalized["spatial"] == '{"@type": "Location", "prefLabel": "United States"}'
     )
 
 

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -87,6 +87,19 @@ def test_normalize_dcat_dates():
     assert normalized["temporal"] == "123"
 
 
+def test_normalize_dcat_spatial_object():
+    dcat = {
+        "spatial": {
+            "@type": "Location",
+            "prefLabel": "United States",
+        },
+    }
+
+    normalized = OpenSearchInterface._normalize_dcat_dates(dcat)
+
+    assert normalized["spatial"] == '{"@type": "Location", "prefLabel": "United States"}'
+
+
 def test_geometry_centroid_returns_average():
     geometry = {"type": "MultiPoint", "coordinates": [[0, 0], [2, 2]]}
 


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/6071

## About
To fix the found errors and potential errors from other fields:
- walks DCAT metadata containers and serializes any nested object/list values
- dcat.spatial uses a explicit top-level handling becasue it can be the structured value
