### PR TITLE
5992 change default waf datetime to now

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -37,7 +37,7 @@ FREQUENCY_ENUM = {"daily": 1, "weekly": 7, "biweekly": 14, "monthly": 30}
 # User-Agent header for all HTTP requests
 USER_AGENT = "HarvesterBot/0.0 (https://data.gov; datagovhelp@gsa.gov) Data.gov/2.0"
 
-DT_PLACEHOLDER = datetime(1900, 1, 1, 0, 0)
+DT_PLACEHOLDER = datetime.now()
 
 PACKAGE_NAME_MAX_LENGTH = 90
 PACKAGE_NAME_MIN_LENGTH = 2

--- a/tests/integration/harvest/test_extract.py
+++ b/tests/integration/harvest/test_extract.py
@@ -1,4 +1,4 @@
-from harvester.harvest import HarvestSource
+from harvester.harvest import DT_PLACEHOLDER, HarvestSource
 from harvester.utils.general_utils import traverse_waf
 
 
@@ -63,3 +63,27 @@ class TestExtract:
             "missing 'identifier' field"
         )
         assert errors[0][0].message == msg
+
+    def test_extract_waf_collection_parent_has_recent_datetime(
+        self,
+        interface,
+        organization_data,
+        source_data_waf_collection,
+    ):
+        """Test that waf-collection parent record gets a datetime of now."""
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_waf_collection)
+        harvest_job = interface.add_harvest_job(
+            {"status": "new", "harvest_source_id": source_data_waf_collection["id"]}
+        )
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_minimum_external_data()
+
+        parent_record = harvest_source.external_records[0]
+        assert (
+            parent_record["identifier"]
+            == source_data_waf_collection["collection_parent_url"]
+        )
+
+        assert parent_record["modified_date"] == DT_PLACEHOLDER

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,6 +13,7 @@ from requests.exceptions import ConnectionError
 
 from database.models import HarvestSource
 from harvester.utils.general_utils import (
+    DT_PLACEHOLDER,
     USER_AGENT,
     RetrySession,
     assemble_validation_errors,
@@ -235,6 +236,25 @@ class TestGeneralUtils:
             datetime(2021, 6, 17, 12, 20),
             datetime(2025, 8, 1, 11, 24),
         ]
+
+    def test_default_waf_datetime_is_now(self):
+        """Test that the default waf datetime is now / the time of program execution"""
+
+        page_html = """<html><body><pre>
+          <a href="file1.xml">file1.xml</a>   12K  
+          <a href="file2.xml">file2.xml</a>   12K  
+          </pre></body></html>"""
+
+        soup = BeautifulSoup(page_html)
+        datetimes = get_waf_datetimes(soup, 2)
+
+        # assert that datetimes are not the old default
+        assert datetimes[0] != datetime(1900, 1, 1, 0, 0)
+        assert datetimes[1] != datetime(1900, 1, 1, 0, 0)
+
+        # assert the new default
+        assert datetimes[0] == DT_PLACEHOLDER
+        assert datetimes[1] == DT_PLACEHOLDER
 
     def test_assemble_validation_messages(
         self, dol_distribution_json, dcatus_non_federal_schema


### PR DESCRIPTION
# Pull Request

Work for [Issue #5992](https://github.com/GSA/data.gov/issues/5992)

When traversing waf directories, we want to replace the default time with "now". 
