### PR TITLE
tell bot to ignore babel major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/app/static"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@babel/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/plugin-transform-runtime"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@babel/preset-env"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-packages:
         patterns:


### PR DESCRIPTION
babelify@10 requires @babel/core 7. We stay with 7 unless there is a security update demanding 8.