### PR TITLE
Add static asset cache busting

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,0 +1,90 @@
+name: "Deploy datagov-harvester"
+description: "Build assets, export dependencies, and deploy to Cloud.gov"
+
+inputs:
+  cf_space:
+    description: "Cloud Foundry space (development, staging, prod)"
+    required: true
+  cf_org:
+    description: "Cloud Foundry org"
+    required: false
+    default: "gsa-datagov"
+  command:
+    description: "cf command to execute"
+    required: false
+    default: "cf push datagov-harvest --strategy rolling --no-wait"
+  node-version-file:
+    description: "Path to node version file"
+    required: false
+    default: "app/static/package.json"
+  python-version:
+    description: "Python version to use"
+    required: false
+    default: "3.12.13"
+  poetry-version:
+    description: "Poetry version to use"
+    required: false
+    default: "latest"
+  cf_username:
+    description: "Cloud Foundry service user"
+    required: true
+  cf_password:
+    description: "Cloud Foundry service auth"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: Install node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
+
+    - name: Build static assets
+      shell: bash
+      run: make install-static
+
+    - name: Set deploy asset version
+      shell: bash
+      run: |
+        asset_version="$(.github/scripts/compute-asset-version.sh)"
+        echo "asset_version=${asset_version}" >> "$GITHUB_ENV"
+        echo "Static asset version: ${asset_version}"
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Poetry
+      uses: abatilo/actions-poetry@v4
+      with:
+        poetry-version: ${{ inputs.poetry-version }}
+        poetry-plugins: "poetry-plugin-export"
+
+    - name: Add requirements.txt
+      shell: bash
+      run: make update-dependencies && cat requirements.txt
+
+    - name: Deploy datagov-harvest app
+      uses: cloud-gov/cg-cli-tools@main
+      with:
+        command: >-
+          ${{ inputs.command }} --vars-file vars.${{ inputs.cf_space }}.yml --var asset_version=${{ env.asset_version }}
+        cf_org: ${{ inputs.cf_org }}
+        cf_space: ${{ inputs.cf_space }}
+        cf_username: ${{ inputs.cf_username }}
+        cf_password: ${{ inputs.cf_password }}
+
+    - name: Deploy datagov-harvest proxy
+      uses: cloud-gov/cg-cli-tools@main
+      with:
+        command: >-
+          cf push datagov-harvest-proxy --strategy rolling --no-wait --vars-file vars.${{ inputs.cf_space }}.yml
+        cf_org: ${{ inputs.cf_org }}
+        cf_space: ${{ inputs.cf_space }}
+        cf_username: ${{ inputs.cf_username }}
+        cf_password: ${{ inputs.cf_password }}

--- a/.github/scripts/compute-asset-version.sh
+++ b/.github/scripts/compute-asset-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+static_dirs=()
+for dir in app/static/assets app/static/js app/static/css app/static/data; do
+  if [ -d "$dir" ]; then
+    static_dirs+=("$dir")
+  fi
+done
+
+if [ "${#static_dirs[@]}" -eq 0 ]; then
+  echo "No static asset directories found" >&2
+  exit 1
+fi
+
+# Hash served static files after `make install-static`.
+# Includes built output (assets/) plus JS/CSS/data files served directly from source.
+find "${static_dirs[@]}" -type f \
+  | sort \
+  | xargs sha256sum \
+  | sha256sum \
+  | awk '{print substr($1, 1, 7)}'

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -101,15 +101,22 @@ jobs:
     name: deploy (development)
     needs:
       - create-cloudgov-services-development
+    environment: development
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: read
-    uses: gsa/data.gov/.github/workflows/deploy-template.yml@main
-    with:
-      environ: development
-      app_url: https://harvest-dev.data.gov
-      app_names: '{"include":[{"app":"datagov-harvest"},{"app":"datagov-harvest-proxy"}]}'
-    secrets: inherit
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+      - name: Deploy via composite action
+        uses: ./.github/actions/deploy
+        with:
+          cf_space: development
+          python-version: ${{ env.PY_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
 
   network-policies:
     name: Add network-policies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,30 +54,44 @@ jobs:
     name: deploy (staging)
     needs:
       - create-cloudgov-services-staging
+    environment: staging
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: read
-    uses: gsa/data.gov/.github/workflows/deploy-template.yml@main
-    with:
-      environ: staging
-      app_url: https://harvest-stage.data.gov
-      app_names: '{"include":[{"app":"datagov-harvest"},{"app":"datagov-harvest-proxy"}]}'
-    secrets: inherit
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+      - name: Deploy via composite action
+        uses: ./.github/actions/deploy
+        with:
+          cf_space: staging
+          python-version: ${{ env.PY_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
 
   deploy-prod:
     name: deploy (prod)
     needs:
       - create-cloudgov-services-prod
       - deploy-staging
+    environment: prod
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: read
-    uses: gsa/data.gov/.github/workflows/deploy-template.yml@main
-    with:
-      environ: prod
-      app_url: https://harvest.data.gov
-      app_names: '{"include":[{"app":"datagov-harvest"},{"app":"datagov-harvest-proxy"}]}'
-    secrets: inherit
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+      - name: Deploy via composite action
+        uses: ./.github/actions/deploy
+        with:
+          cf_space: prod
+          python-version: ${{ env.PY_VERSION }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
 
   network-policies:
     name: Add network-policies

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,6 +32,20 @@ HSTS_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
 HSTS_HEADER = f"max-age={HSTS_MAX_AGE_SECONDS}; includeSubDomains; preload"
 
 
+class VersionedStaticAPIFlask(APIFlask):
+    def send_static_file(self, filename):
+        from app.static_assets import (
+            DEFAULT_ASSET_VERSION,
+            unversion_static_filename,
+            validate_asset_version,
+        )
+
+        version = validate_asset_version(
+            self.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+        )
+        return super().send_static_file(unversion_static_filename(filename, version))
+
+
 def current_unix_timestamp() -> int:
     return int(time.time())
 
@@ -53,7 +67,9 @@ def _external_route_to_server_url(route: str | None) -> str | None:
 
 def create_app():
     env_values = validate_required_env_vars()
-    app = APIFlask(__name__, static_url_path="", static_folder="static", docs_path=None)
+    app = VersionedStaticAPIFlask(
+        __name__, static_url_path="", static_folder="static", docs_path=None
+    )
 
     # OpenAPI fields
     app.config["INFO"] = {
@@ -85,6 +101,9 @@ def create_app():
     app.config["SESSION_IDLE_TIMEOUT_SECONDS"] = int(
         os.getenv("SESSION_IDLE_TIMEOUT_SECONDS", "900")
     )
+    from app.static_assets import get_asset_version
+
+    app.config["ASSET_VERSION"] = get_asset_version(app.static_folder)
 
     def get_session_cookie_name():
         return app.config["SESSION_COOKIE_NAME"]
@@ -139,7 +158,7 @@ def create_app():
         g.clear_session_cookie = False
         g.sync_auth_cookie = False
 
-        if request.path.startswith("/assets/"):
+        if request.endpoint == "static":
             return
 
         if not session.get("user"):
@@ -204,7 +223,7 @@ def create_app():
         if path.startswith(("/login", "/callback", "/logout")) or path == "/login/oidc":
             return set_private_no_store(response)
 
-        if path.startswith("/assets/"):
+        if request.endpoint == "static":
             return set_public_cache(response, 3600)
 
         if method not in {"GET", "HEAD"}:
@@ -315,5 +334,8 @@ def create_app():
 
 
 def add_template_filters(app):
+    from app.static_assets import static_url
+
     for fn in [usa_icon, else_na, utc_isoformat]:
         app.add_template_filter(fn)
+    app.add_template_global(static_url, "static_url")

--- a/app/filters.py
+++ b/app/filters.py
@@ -1,9 +1,14 @@
 import datetime
 
+from app.static_assets import static_url
+
 
 def usa_icon(str):
-    # ruff: noqa: E501
-    return f'<svg class="usa-icon" aria-hidden="true" role="img"><use xlink:href="/assets/uswds/img/sprite.svg#{str}"></use></svg>'
+    sprite_path = static_url("assets/uswds/img/sprite.svg")
+    return (
+        '<svg class="usa-icon" aria-hidden="true" role="img">'
+        f'<use xlink:href="{sprite_path}#{str}"></use></svg>'
+    )
 
 
 def else_na(val):

--- a/app/static_assets.py
+++ b/app/static_assets.py
@@ -1,0 +1,83 @@
+"""Helpers for cache-busted static asset URLs."""
+
+import hashlib
+import os
+import re
+from pathlib import Path
+
+from flask import current_app, url_for
+
+DEFAULT_ASSET_VERSION = "dev"
+ASSET_VERSION_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+STATIC_ASSET_DIRECTORIES = ("assets", "js", "css", "data")
+
+
+def validate_asset_version(version: str) -> str:
+    """Return a filename-safe static asset version."""
+    if not ASSET_VERSION_PATTERN.fullmatch(version):
+        raise ValueError(
+            "ASSET_VERSION must contain only letters, numbers, underscores, or hyphens"
+        )
+    return version
+
+
+def compute_static_asset_version(static_folder: str | os.PathLike | None) -> str:
+    """Return a short content hash for static files served by the app."""
+    if not static_folder:
+        return DEFAULT_ASSET_VERSION
+
+    root = Path(static_folder)
+    files: list[Path] = []
+    for directory in STATIC_ASSET_DIRECTORIES:
+        path = root / directory
+        if path.exists():
+            files.extend(sorted(file for file in path.rglob("*") if file.is_file()))
+
+    if not files:
+        return DEFAULT_ASSET_VERSION
+
+    digest = hashlib.sha256()
+    for file in files:
+        digest.update(file.relative_to(root).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file.read_bytes())
+        digest.update(b"\0")
+
+    return digest.hexdigest()[:7]
+
+
+def get_asset_version(static_folder: str | os.PathLike | None = None) -> str:
+    """Return the cache-bust version for static assets."""
+    env_version = os.getenv("ASSET_VERSION", "").strip()
+    if env_version:
+        return validate_asset_version(env_version)
+
+    return validate_asset_version(compute_static_asset_version(static_folder))
+
+
+def versioned_static_filename(filename: str, version: str) -> str:
+    """Embed the static asset version before the file extension."""
+    path, extension = os.path.splitext(filename)
+    if extension:
+        return f"{path}.{version}{extension}"
+    return f"{filename}.{version}"
+
+
+def unversion_static_filename(filename: str, version: str) -> str:
+    """Return the on-disk filename for a versioned static asset request."""
+    path, extension = os.path.splitext(filename)
+    version_suffix = f".{version}"
+
+    if extension and path.endswith(version_suffix):
+        return f"{path[: -len(version_suffix)]}{extension}"
+    if not extension and filename.endswith(version_suffix):
+        return filename[: -len(version_suffix)]
+    return filename
+
+
+def static_url(filename: str) -> str:
+    """Return a static asset URL with the cache-bust version in the filename."""
+    version = validate_asset_version(
+        current_app.config.get("ASSET_VERSION", DEFAULT_ASSET_VERSION)
+    )
+    return url_for("static", filename=versioned_static_filename(filename, version))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,11 +6,11 @@
   {% block title %}
   <title>{{action}} {{data_type}}</title>
   {% endblock %}
-  <link rel="stylesheet" href="{{ url_for('static', filename='assets/uswds/css/styles.css') }}">
+  <link rel="stylesheet" href="{{ static_url('assets/uswds/css/styles.css') }}">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
-  <script src="{{ url_for('static', filename='assets/uswds/js/uswds-init.js') }}"></script>
-  <script src="{{ url_for('static', filename='assets/htmx/htmx.min.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/datetime.js') }}"></script>
+  <script src="{{ static_url('assets/uswds/js/uswds-init.js') }}"></script>
+  <script src="{{ static_url('assets/htmx/htmx.min.js') }}"></script>
+  <script src="{{ static_url('js/datetime.js') }}"></script>
   <!-- Google Tag Manager -->
   <script nonce="{{ csp_nonce() }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -75,7 +75,7 @@
       </div>
       <button type="button" class="usa-alert__close js-alert-close" aria-label="Close alert">
         <svg class="usa-icon" aria-hidden="true" role="img" focusable="false">
-          <use href="/assets/uswds/img/sprite.svg#close"></use>
+          <use href="{{ static_url('assets/uswds/img/sprite.svg') }}#close"></use>
         </svg>
       </button>
     </div>
@@ -84,8 +84,8 @@
     <div id="content">{% block content %}{% endblock %}</div>
   </div>
   {% include '/snippets/footer.html' %}
-  <script src="{{ url_for('static', filename='assets/uswds/js/uswds.js') }}"></script>
-  <script src="{{ url_for('static', filename='assets/js/bundle.js') }}"></script>
+  <script src="{{ static_url('assets/uswds/js/uswds.js') }}"></script>
+  <script src="{{ static_url('assets/js/bundle.js') }}"></script>
   {% block scripts %}
   {% endblock %}
 </body>

--- a/app/templates/components/pagination/pagination_arrow.html
+++ b/app/templates/components/pagination/pagination_arrow.html
@@ -20,7 +20,7 @@
         {% if direction == 'previous' %}
           <svg class="usa-icon" aria-hidden="true" role="img">
             {# Global variable not applying #}
-            <use xlink:href="/assets/uswds/img/sprite.svg#navigate_before"></use>
+            <use xlink:href="{{ static_url('assets/uswds/img/sprite.svg') }}#navigate_before"></use>
           </svg>
         {% endif %}
         <span class="usa-pagination__link-text">
@@ -29,7 +29,7 @@
         {% if direction == 'next' %}
           <svg class="usa-icon" aria-hidden="true" role="img">
             {# Global variable not applying #}
-            <use xlink:href="/assets/uswds/img/sprite.svg#navigate_next"></use>
+            <use xlink:href="{{ static_url('assets/uswds/img/sprite.svg') }}#navigate_next"></use>
           </svg>
         {% endif %}
       </a>

--- a/app/templates/snippets/banner.html
+++ b/app/templates/snippets/banner.html
@@ -4,7 +4,7 @@
             <div class="usa-banner__inner">
                 <div class="grid-col-auto">
                     <img aria-hidden="true" class="usa-banner__header-flag"
-                        src="{{ url_for('static', filename='assets/uswds/img/us_flag_small.png') }}" alt="" />
+                        src="{{ static_url('assets/uswds/img/us_flag_small.png') }}" alt="" />
                 </div>
                 <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
                     <p class="usa-banner__header-text">
@@ -21,7 +21,7 @@
         <div class="usa-banner__content usa-accordion__content" id="gov-banner-default">
             <div class="grid-row grid-gap-lg">
                 <div class="usa-banner__guidance tablet:grid-col-6">
-                    <img class="usa-banner__icon usa-media-block__img" src="{{ url_for('static', filename='assets/uswds/img/icon-dot-gov.svg') }}"
+                    <img class="usa-banner__icon usa-media-block__img" src="{{ static_url('assets/uswds/img/icon-dot-gov.svg') }}"
                         role="img" alt="" aria-hidden="true" />
                     <div class="usa-media-block__body">
                         <p>
@@ -32,7 +32,7 @@
                     </div>
                 </div>
                 <div class="usa-banner__guidance tablet:grid-col-6">
-                    <img class="usa-banner__icon usa-media-block__img" src="{{ url_for('static', filename='assets/uswds/img/icon-https.svg') }}"
+                    <img class="usa-banner__icon usa-media-block__img" src="{{ static_url('assets/uswds/img/icon-https.svg') }}"
                         role="img" alt="" aria-hidden="true" />
                     <div class="usa-media-block__body">
                         <p>

--- a/app/templates/view_org_data.html
+++ b/app/templates/view_org_data.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block script_head %}
-<script src="{{ url_for('static', filename='js/view_org_data.js') }}"></script>
+<script src="{{ static_url('js/view_org_data.js') }}"></script>
 {% endblock %}
 
 {% block content %}
@@ -90,7 +90,7 @@
                                 <svg class="usa-icon align-middle {% if last_job_has_errors %}check{%else%}cancel{%endif%}"
                                     aria-hidden="true" focusable="false" role="img">
                                     <use
-                                        xlink:href="/assets/uswds/img/sprite.svg#{% if last_job_has_errors %}check{%else%}cancel{%endif%}">
+                                        xlink:href="{{ static_url('assets/uswds/img/sprite.svg') }}#{% if last_job_has_errors %}check{%else%}cancel{%endif%}">
                                     </use>
                                 </svg>
                             </a>

--- a/app/templates/view_org_list.html
+++ b/app/templates/view_org_list.html
@@ -46,5 +46,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/filter.js') }}"></script>"
+<script src="{{ static_url('js/filter.js') }}"></script>
 {% endblock %}

--- a/app/templates/view_source_data.html
+++ b/app/templates/view_source_data.html
@@ -3,8 +3,8 @@
 {% import 'components/job-table/job_table.j2' as job_table %}
 
 {% block script_head %}
-<script src="{{ url_for('static', filename='assets/chartjs/chart.umd.js') }}"></script>
-<script src="{{ url_for('static', filename='js/view_source_data.js') }}"></script>
+<script src="{{ static_url('assets/chartjs/chart.umd.js') }}"></script>
+<script src="{{ static_url('js/view_source_data.js') }}"></script>
 {% endblock %}
 
 {% block title %}
@@ -92,7 +92,7 @@
     {% if data.summary_data["active_job_in_progress"] %}
     <a class="text-secondary-dark" href="{{ url_for('api.view_harvest_job', job_id=data.jobs[0].id)}}">
         <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-            <use href="/assets/uswds/img/sprite.svg#alarm"></use>
+            <use href="{{ static_url('assets/uswds/img/sprite.svg') }}#alarm"></use>
         </svg>
         Active Job in Progress. Click here for more info...
     </a>

--- a/app/templates/view_source_list.html
+++ b/app/templates/view_source_list.html
@@ -49,5 +49,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/filter.js') }}"></script>"
+<script src="{{ static_url('js/filter.js') }}"></script>
 {% endblock %}

--- a/app/templates/view_validators.html
+++ b/app/templates/view_validators.html
@@ -100,7 +100,7 @@
                 title="We restrict what documents can be fetched by TLD. Only .gov and .mil are allowed."
             >
                 <svg class="usa-icon" aria-hidden="true">
-                    <use href="/assets/uswds/img/sprite.svg#info"></use>
+                    <use href="{{ static_url('assets/uswds/img/sprite.svg') }}#info"></use>
                 </svg>
             </button>
         </label>

--- a/manifest.yml
+++ b/manifest.yml
@@ -45,4 +45,5 @@ applications:
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       NEW_RELIC_CONFIG_FILE: /home/vcap/app/config/newrelic.ini
+      ASSET_VERSION: ((asset_version))
     command: ./app-start.sh

--- a/tests/unit/test_cache_headers.py
+++ b/tests/unit/test_cache_headers.py
@@ -123,6 +123,17 @@ def test_assets_are_cached_for_one_hour(client):
     assert "Expires" not in response.headers
 
 
+def test_versioned_static_assets_are_cached_for_one_hour(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+
+    response = app.test_client().get("/js/datetime.8eb9d3e.js")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=3600, s-maxage=3600"
+    assert "Pragma" not in response.headers
+    assert "Expires" not in response.headers
+
+
 def test_logout_clears_full_session(client):
     with client.session_transaction() as sess:
         sess["user"] = "test.user@gsa.gov"

--- a/tests/unit/test_static_assets.py
+++ b/tests/unit/test_static_assets.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app import create_app
+from app.static_assets import (
+    DEFAULT_ASSET_VERSION,
+    compute_static_asset_version,
+    get_asset_version,
+    static_url,
+    unversion_static_filename,
+    versioned_static_filename,
+)
+
+
+@pytest.fixture
+def app():
+    with patch("app.load_manager.start", lambda: True):
+        app = create_app()
+    app.config.update({"TESTING": True})
+    return app
+
+
+@pytest.fixture
+def dbapp(app):
+    yield app
+
+
+@pytest.fixture
+def default_function_fixture():
+    yield
+
+
+def test_get_asset_version_uses_env_var(monkeypatch):
+    monkeypatch.setenv("ASSET_VERSION", "abc1234")
+    assert get_asset_version() == "abc1234"
+
+
+def test_get_asset_version_hashes_static_asset_contents(monkeypatch, tmp_path):
+    monkeypatch.delenv("ASSET_VERSION", raising=False)
+    asset = tmp_path / "js" / "app.js"
+    asset.parent.mkdir()
+    asset.write_text("one")
+
+    first_version = get_asset_version(tmp_path)
+    asset.write_text("two")
+    second_version = get_asset_version(tmp_path)
+
+    assert first_version != DEFAULT_ASSET_VERSION
+    assert first_version != second_version
+    assert len(first_version) == 7
+    assert len(second_version) == 7
+
+
+def test_get_asset_version_uses_dev_without_static_files(monkeypatch, tmp_path):
+    monkeypatch.delenv("ASSET_VERSION", raising=False)
+
+    assert get_asset_version(tmp_path) == DEFAULT_ASSET_VERSION
+
+
+@pytest.mark.parametrize("asset_version", ["../secret", "abc/123", "abc.123", ""])
+def test_static_url_rejects_unsafe_asset_version(app, asset_version):
+    app.config["ASSET_VERSION"] = asset_version
+
+    with app.test_request_context("/"), pytest.raises(ValueError):
+        static_url("js/filter.js")
+
+
+def test_get_asset_version_rejects_unsafe_env_var(monkeypatch):
+    monkeypatch.setenv("ASSET_VERSION", "../secret")
+
+    with pytest.raises(ValueError):
+        get_asset_version()
+
+
+def test_static_url_embeds_version_in_filename(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+    with app.test_request_context("/"):
+        url = static_url("js/filter.js")
+
+    assert url.endswith("/js/filter.8eb9d3e.js")
+    assert "?v=" not in url
+
+
+def test_static_url_preserves_existing_filename_dots(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+    with app.test_request_context("/"):
+        url = static_url("assets/htmx/htmx.min.js")
+
+    assert url.endswith("/assets/htmx/htmx.min.8eb9d3e.js")
+
+
+def test_versioned_static_filename_maps_back_to_on_disk_filename():
+    filename = "assets/htmx/htmx.min.js"
+
+    versioned_filename = versioned_static_filename(filename, "8eb9d3e")
+
+    assert versioned_filename == "assets/htmx/htmx.min.8eb9d3e.js"
+    assert unversion_static_filename(versioned_filename, "8eb9d3e") == filename
+    assert unversion_static_filename(filename, "8eb9d3e") == filename
+
+
+def test_compute_static_asset_version_ignores_unserved_build_dependencies(tmp_path):
+    asset = tmp_path / "js" / "app.js"
+    dependency = tmp_path / "node_modules" / "dependency.js"
+    asset.parent.mkdir()
+    dependency.parent.mkdir()
+    asset.write_text("asset")
+    dependency.write_text("one")
+
+    first_version = compute_static_asset_version(tmp_path)
+    dependency.write_text("two")
+
+    assert compute_static_asset_version(tmp_path) == first_version
+
+
+def test_versioned_static_asset_request_serves_on_disk_file(app):
+    app.config["ASSET_VERSION"] = "8eb9d3e"
+
+    response = app.test_client().get("/js/datetime.8eb9d3e.js")
+
+    assert response.status_code == 200
+    assert b"document" in response.data
+    assert Path(app.static_folder, "js", "datetime.js").exists()

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -8,6 +8,9 @@ admin_instances: 2
 admin_memory_quota: 1G
 admin_disk_quota: 4G
 
+# Placeholder for manifest ((asset_version)); CI overrides via --var on deploy
+asset_version: set-at-deploy
+
 CF_API_URL: https://api.fr.cloud.gov
 CATALOG_BASE_URL: https://catalog-dev.data.gov
 

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -8,6 +8,9 @@ admin_instances: 2
 admin_memory_quota: 2G
 admin_disk_quota: 4G
 
+# Placeholder for manifest ((asset_version)); CI overrides via --var on deploy
+asset_version: set-at-deploy
+
 CF_API_URL: https://api.fr.cloud.gov
 CATALOG_BASE_URL: https://catalog.data.gov
 

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -8,6 +8,9 @@ admin_instances: 2
 admin_memory_quota: 1G
 admin_disk_quota: 4G
 
+# Placeholder for manifest ((asset_version)); CI overrides via --var on deploy
+asset_version: set-at-deploy
+
 CF_API_URL: https://api.fr.cloud.gov
 CATALOG_BASE_URL: https://catalog-stage.data.gov
 


### PR DESCRIPTION
for work on https://github.com/GSA/data.gov/issues/6133

# Add static asset cache busting

## Summary

Adds catalog-style cache-busted static asset filenames for the harvester app. Static URLs now include a short asset hash in the filename, and the Flask static handler maps those versioned requests back to the on-disk files.

This also adds repo-local deploy wiring, similar to datagov-catalog, so GitHub Actions computes the static asset hash after building assets and passes it to Cloud Foundry as `ASSET_VERSION`.

<img width="559" height="359" alt="Screenshot 2026-06-30 at 4 48 50 PM" src="https://github.com/user-attachments/assets/750479a8-5594-4d2d-b29c-a20a0a91b6b8" />


deployed to https://harvest-dev.data.gov/organization_list/