### PR TITLE
uswds/compile ask for vulnerarable postcss@8.5.8

### DIFF
--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -7143,9 +7143,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7163,7 +7163,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9517,35 +9517,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vm-browserify": {

--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -7104,9 +7104,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -50,5 +50,10 @@
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.13.2"
+  },
+  "overrides": {
+    "@uswds/compile": {
+      "postcss": "8.5.15"
+    }
   }
 }

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -54,6 +54,7 @@
   "overrides": {
     "@uswds/compile": {
       "postcss": "8.5.15"
-    }
+    },
+    "picomatch@2.3.1": "2.3.2"
   }
 }


### PR DESCRIPTION
1. Resolve
- https://github.com/GSA/datagov-harvester/security/dependabot/139

  The dependency tree contains two PostCSS versions:

  - @uswds/compile@1.3.2 → exactly `postcss@8.5.8` (vulnerable)
  - vite@8.1.0 → `postcss@8.5.15` (fixed)

To resolve the conflict, set an override
```
  "overrides": {
    "@uswds/compile": {
      "postcss": "8.5.15"
    }
  }
```
______________________
2. Resolve
- https://github.com/GSA/datagov-harvester/security/dependabot/112

  - Vulnerable 2.3.1 paths now resolve to 2.3.2. 
  - Vite retains Picomatch 4.0.4.