### PR TITLE
6001 - Flatten DCAT-US 3.0 fields into existing OpenSearch shapes

### DIFF
--- a/harvester/opensearch.py
+++ b/harvester/opensearch.py
@@ -10,6 +10,7 @@ from botocore.credentials import Credentials
 from opensearchpy import AWSV4SignerAuth, OpenSearch, RequestsHttpConnection, helpers
 from opensearchpy.exceptions import ConnectionTimeout
 
+from database.models import Dataset
 from harvester.opensearch_transform import DcatIndexTransformer
 
 logger = logging.getLogger(__name__)
@@ -345,27 +346,26 @@ class OpenSearchInterface:
         count = len(points)
         return {"lat": lat_total / count, "lon": lon_total / count}
 
-    def dataset_to_document(self, dataset):
-        """Map a dataset into a document for indexing.
+    def dataset_to_document(self, dataset: Dataset) -> dict:
+        """Map a Dataset ORM row into an OpenSearch index document.
 
-        DCAT-derived search fields are produced by ``DCAT_INDEX_TRANSFORMER``
-        so DCAT-US 1.1 and 3.0 share the existing OpenSearch field shapes.
+        Top-level search fields come from ``DCAT_INDEX_TRANSFORMER``
+        (``index_fields``); nested ``dcat`` keeps original DCAT shapes
+        (``nested_dcat``), with only date/metadata normalization applied.
         """
-        indexed = self.DCAT_INDEX_TRANSFORMER.transform(dataset.dcat)
+        # Flat top-level search fields; nested_dcat keeps original DCAT shapes.
+        index_fields = self.DCAT_INDEX_TRANSFORMER.transform(dataset.dcat)
 
         spatial_value = dataset.dcat.get("spatial")
         has_spatial_theme = any(
-            label.strip().lower() == "geospatial" for label in indexed["theme"]
+            label.strip().lower() == "geospatial" for label in index_fields["theme"]
         )
         has_spatial = (
             bool(spatial_value and str(spatial_value).strip())
             or dataset.translated_spatial is not None
             or has_spatial_theme
         )
-        normalized_dcat = self._normalize_dcat_dates(dataset.dcat)
-        # Keep nested dcat theme/identifier compatible with text/keyword shapes.
-        normalized_dcat["theme"] = indexed["theme"]
-        normalized_dcat["identifier"] = indexed["identifier"]
+        nested_dcat = self._normalize_dcat_dates(dataset.dcat)
         spatial_centroid = self._geometry_centroid(dataset.translated_spatial)
         last_harvested = (
             dataset.last_harvested_date.isoformat()
@@ -379,18 +379,18 @@ class OpenSearchInterface:
         document = {
             "_index": self.INDEX_NAME,
             "_id": dataset.id,
-            "title": indexed["title"],
+            "title": index_fields["title"],
             "slug": dataset.slug,
             "last_harvested_date": last_harvested,
-            "description": indexed["description"],
-            "publisher": indexed["publisher"],
-            "dcat": normalized_dcat,
-            "keyword": indexed["keyword"],
-            "theme": indexed["theme"],
-            "identifier": indexed["identifier"],
+            "description": index_fields["description"],
+            "publisher": index_fields["publisher"],
+            "dcat": nested_dcat,
+            "keyword": index_fields["keyword"],
+            "theme": index_fields["theme"],
+            "identifier": index_fields["identifier"],
             "has_spatial": has_spatial,
             "organization": organization,
-            "distribution_titles": indexed["distribution_titles"],
+            "distribution_titles": index_fields["distribution_titles"],
             "popularity": popularity,
             "spatial_shape": dataset.translated_spatial,
             "spatial_centroid": spatial_centroid,

--- a/harvester/opensearch.py
+++ b/harvester/opensearch.py
@@ -10,6 +10,8 @@ from botocore.credentials import Credentials
 from opensearchpy import AWSV4SignerAuth, OpenSearch, RequestsHttpConnection, helpers
 from opensearchpy.exceptions import ConnectionTimeout
 
+from harvester.opensearch_transform import DcatIndexTransformer
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,6 +31,7 @@ class OpenSearchInterface:
     STOP_FILTER = "datagov_stop"
     KEYWORD_NORMALIZER = "lowercase_normalizer"
     DEFAULT_CATALOG_BASE_URL = "https://catalog.data.gov"
+    DCAT_INDEX_TRANSFORMER = DcatIndexTransformer()
 
     SETTINGS = {
         "analysis": {
@@ -65,6 +68,10 @@ class OpenSearchInterface:
             "last_harvested_date": {"type": "date"},
             "dcat": {
                 "type": "nested",
+                # DCAT-US 1.1 and 3.0 nest differently shaped fields under dcat.
+                # Disable dynamic mapping so the first indexed schema version
+                # cannot lock incompatible types for later records.
+                "dynamic": False,
                 "properties": {
                     "modified": {"type": "keyword"},
                     "issued": {"type": "keyword"},
@@ -339,14 +346,16 @@ class OpenSearchInterface:
         return {"lat": lat_total / count, "lon": lon_total / count}
 
     def dataset_to_document(self, dataset):
-        """Map a dataset into a document for indexing."""
+        """Map a dataset into a document for indexing.
+
+        DCAT-derived search fields are produced by ``DCAT_INDEX_TRANSFORMER``
+        so DCAT-US 1.1 and 3.0 share the existing OpenSearch field shapes.
+        """
+        indexed = self.DCAT_INDEX_TRANSFORMER.transform(dataset.dcat)
+
         spatial_value = dataset.dcat.get("spatial")
-        themes = dataset.dcat.get("theme") or []
-        if isinstance(themes, str):
-            themes = [themes]
         has_spatial_theme = any(
-            isinstance(theme, str) and theme.strip().lower() == "geospatial"
-            for theme in themes
+            label.strip().lower() == "geospatial" for label in indexed["theme"]
         )
         has_spatial = (
             bool(spatial_value and str(spatial_value).strip())
@@ -354,6 +363,9 @@ class OpenSearchInterface:
             or has_spatial_theme
         )
         normalized_dcat = self._normalize_dcat_dates(dataset.dcat)
+        # Keep nested dcat theme/identifier compatible with text/keyword shapes.
+        normalized_dcat["theme"] = indexed["theme"]
+        normalized_dcat["identifier"] = indexed["identifier"]
         spatial_centroid = self._geometry_centroid(dataset.translated_spatial)
         last_harvested = (
             dataset.last_harvested_date.isoformat()
@@ -367,22 +379,18 @@ class OpenSearchInterface:
         document = {
             "_index": self.INDEX_NAME,
             "_id": dataset.id,
-            "title": dataset.dcat.get("title", ""),
+            "title": indexed["title"],
             "slug": dataset.slug,
             "last_harvested_date": last_harvested,
-            "description": dataset.dcat.get("description", ""),
-            "publisher": dataset.dcat.get("publisher", {}).get("name", ""),
+            "description": indexed["description"],
+            "publisher": indexed["publisher"],
             "dcat": normalized_dcat,
-            "keyword": dataset.dcat.get("keyword", []),
-            "theme": dataset.dcat.get("theme", []),
-            "identifier": dataset.dcat.get("identifier", ""),
+            "keyword": indexed["keyword"],
+            "theme": indexed["theme"],
+            "identifier": indexed["identifier"],
             "has_spatial": has_spatial,
             "organization": organization,
-            "distribution_titles": [
-                dist["title"]
-                for dist in (dataset.dcat.get("distribution") or [])
-                if isinstance(dist, dict) and dist.get("title")
-            ],
+            "distribution_titles": indexed["distribution_titles"],
             "popularity": popularity,
             "spatial_shape": dataset.translated_spatial,
             "spatial_centroid": spatial_centroid,

--- a/harvester/opensearch.py
+++ b/harvester/opensearch.py
@@ -69,10 +69,6 @@ class OpenSearchInterface:
             "last_harvested_date": {"type": "date"},
             "dcat": {
                 "type": "nested",
-                # DCAT-US 1.1 and 3.0 nest differently shaped fields under dcat.
-                # Disable dynamic mapping so the first indexed schema version
-                # cannot lock incompatible types for later records.
-                "dynamic": False,
                 "properties": {
                     "modified": {"type": "keyword"},
                     "issued": {"type": "keyword"},

--- a/harvester/opensearch_transform.py
+++ b/harvester/opensearch_transform.py
@@ -1,0 +1,145 @@
+"""Translate DCAT-US metadata into legacy OpenSearch index field shapes.
+
+The OpenSearch ``datasets`` index stores a handful of fields derived from a
+dataset's DCAT metadata (``title``, ``identifier``, ``theme``, ...). DCAT-US
+1.1 and DCAT-US 3.0 describe several of these fields with different shapes,
+such as ``theme`` moving from a list of strings to a list of Concept objects.
+
+OpenSearch cannot index a field as two different data types, so this module
+normalizes each derived field into the existing (legacy) index shapes so both
+schema versions can share one mapping:
+
+* ``identifier``      -> string (from plain string or object ``@id``)
+* ``theme``           -> list of strings (from strings or Concept ``prefLabel``)
+* ``publisher``       -> organization display name (string)
+* ``keyword``         -> list of strings
+* ``title``/``description`` -> string
+* ``distribution_titles``   -> list of distribution titles
+
+To add a new indexed field, register it in :data:`INDEX_FIELDS`. The module
+performs no I/O and knows nothing about OpenSearch itself.
+
+``inSeries`` is intentionally ignored (legacy ``isPartOf`` is left as harvested).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+__all__ = [
+    "INDEX_FIELDS",
+    "DcatIndexTransformer",
+]
+
+
+def _clean_string(value: Any) -> str | None:
+    """Return a non-empty, stripped string or ``None``."""
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def coerce_text(value: Any) -> str:
+    """Return a plain string, or ``""`` for any non-string value."""
+    return value if isinstance(value, str) else ""
+
+
+def coerce_identifier(value: Any) -> str:
+    """Coerce a DCAT identifier into the legacy scalar index field.
+
+    * DCAT-US 1.1: a plain string ``"cftc-dc1"`` -> ``"cftc-dc1"``.
+    * DCAT-US 3.0: an ``Identifier`` object contributes only its ``@id``.
+
+    Returns ``""`` when there is nothing indexable.
+    """
+    text = _clean_string(value)
+    if text is not None:
+        return text
+
+    if isinstance(value, dict):
+        return _clean_string(value.get("@id")) or ""
+
+    return ""
+
+
+def coerce_theme_labels(value: Any) -> list[str]:
+    """Coerce theme values into a list of searchable label strings.
+
+    * DCAT-US 1.1: ``["climate", "weather"]`` -> unchanged (trimmed).
+    * DCAT-US 3.0: Concept objects contribute ``prefLabel``.
+
+    A single string or single object is accepted and wrapped in a list.
+    """
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    labels = []
+    for item in items:
+        if isinstance(item, str):
+            label = _clean_string(item)
+        elif isinstance(item, dict):
+            label = _clean_string(item.get("prefLabel"))
+        else:
+            label = None
+        if label is not None:
+            labels.append(label)
+    return labels
+
+
+def coerce_keywords(value: Any) -> list[str]:
+    """Coerce keywords into a list of non-empty strings."""
+    if value is None:
+        return []
+    items = value if isinstance(value, list) else [value]
+    return [item.strip() for item in items if isinstance(item, str) and item.strip()]
+
+
+def coerce_publisher_name(value: Any) -> str:
+    """Extract the publisher display name.
+
+    Both DCAT-US 1.1 and 3.0 publishers expose ``name``; DCAT-US 3.0 may also
+    carry ``prefLabel``. ``name`` is preferred to preserve the existing facet
+    contract.
+    """
+    if not isinstance(value, dict):
+        return ""
+    name = _clean_string(value.get("name"))
+    return name or _clean_string(value.get("prefLabel")) or ""
+
+
+def distribution_titles(value: Any) -> list[str]:
+    """Extract non-empty distribution titles."""
+    if not isinstance(value, list):
+        return []
+    titles = []
+    for dist in value:
+        if isinstance(dist, dict):
+            title = _clean_string(dist.get("title"))
+            if title is not None:
+                titles.append(title)
+    return titles
+
+
+# dest_field -> (source_dcat_key, coercer)
+INDEX_FIELDS: dict[str, tuple[str, Callable[[Any], Any]]] = {
+    "title": ("title", coerce_text),
+    "description": ("description", coerce_text),
+    "publisher": ("publisher", coerce_publisher_name),
+    "keyword": ("keyword", coerce_keywords),
+    "theme": ("theme", coerce_theme_labels),
+    "identifier": ("identifier", coerce_identifier),
+    "distribution_titles": ("distribution", distribution_titles),
+}
+
+
+class DcatIndexTransformer:
+    """Map a DCAT metadata dict into legacy OpenSearch index fields."""
+
+    def transform(self, dcat: dict | None) -> dict:
+        """Return the index-field dict for ``dcat`` using :data:`INDEX_FIELDS`."""
+        dcat = dcat or {}
+        return {
+            dest: coercer(dcat.get(source_key))
+            for dest, (source_key, coercer) in INDEX_FIELDS.items()
+        }

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -341,8 +341,9 @@ def test_dataset_to_document_flattens_dcat3_theme_and_identifier(sample_dataset)
 
     assert document["theme"] == ["Climate Science", "weather"]
     assert document["identifier"] == "https://example.gov/identifiers/dataset-1"
-    assert document["dcat"]["theme"] == ["Climate Science", "weather"]
-    assert document["dcat"]["identifier"] == "https://example.gov/identifiers/dataset-1"
+    # Nested dcat keeps original DCAT shapes; only top-level fields are flattened.
+    assert document["dcat"]["theme"] == sample_dataset.dcat["theme"]
+    assert document["dcat"]["identifier"] == sample_dataset.dcat["identifier"]
     # inSeries is not aliased onto isPartOf.
     assert document["dcat"]["isPartOf"] == "collection-1"
 

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -276,6 +276,9 @@ def test_dataset_to_document_has_translated_spatial(sample_dataset):
         ["GEOSPATIAL"],
         ["Health", " geospatial "],
         "Geospatial",
+        [{"prefLabel": "geospatial"}],
+        [{"@type": "Concept", "prefLabel": "Geospatial"}],
+        ["Health", {"prefLabel": " geospatial "}],
     ],
 )
 def test_dataset_to_document_has_spatial_theme(sample_dataset, theme):
@@ -291,7 +294,15 @@ def test_dataset_to_document_has_spatial_theme(sample_dataset, theme):
 
 @pytest.mark.parametrize(
     "theme",
-    [None, [], ["Health"], "Environment", "Spatial"],
+    [
+        None,
+        [],
+        ["Health"],
+        "Environment",
+        "Spatial",
+        [{"prefLabel": "Environment"}],
+        [{"@type": "Concept", "prefLabel": "Health"}],
+    ],
 )
 def test_dataset_to_document_without_spatial_data_or_theme(sample_dataset, theme):
     iface = OpenSearchInterface.__new__(OpenSearchInterface)
@@ -302,6 +313,38 @@ def test_dataset_to_document_without_spatial_data_or_theme(sample_dataset, theme
     document = iface.dataset_to_document(sample_dataset)
 
     assert document["has_spatial"] is False
+
+
+def test_dataset_to_document_flattens_dcat3_theme_and_identifier(sample_dataset):
+    iface = OpenSearchInterface.__new__(OpenSearchInterface)
+    sample_dataset.dcat["theme"] = [
+        {
+            "@id": "https://example.gov/concepts/climate-science",
+            "@type": "Concept",
+            "prefLabel": "Climate Science",
+        },
+        "weather",
+    ]
+    sample_dataset.dcat["identifier"] = {
+        "@type": "Identifier",
+        "@id": "https://example.gov/identifiers/dataset-1",
+    }
+    sample_dataset.dcat["inSeries"] = [
+        {
+            "@id": "https://example.gov/series/annual",
+            "@type": "DatasetSeries",
+            "title": "Annual Series",
+        }
+    ]
+
+    document = iface.dataset_to_document(sample_dataset)
+
+    assert document["theme"] == ["Climate Science", "weather"]
+    assert document["identifier"] == "https://example.gov/identifiers/dataset-1"
+    assert document["dcat"]["theme"] == ["Climate Science", "weather"]
+    assert document["dcat"]["identifier"] == "https://example.gov/identifiers/dataset-1"
+    # inSeries is not aliased onto isPartOf.
+    assert document["dcat"]["isPartOf"] == "collection-1"
 
 
 def test_dataset_to_document_omits_transformed_url_without_payload(sample_dataset):
@@ -337,6 +380,12 @@ def test_mappings_include_catalog_compatible_fields():
     ]
 
     assert mappings["dcat"]["properties"]["isPartOf"] == {"type": "keyword"}
+    assert mappings["dcat"]["dynamic"] is False
+    assert mappings["theme"] == {
+        "type": "text",
+        "analyzer": OpenSearchInterface.TEXT_ANALYZER,
+        "search_analyzer": OpenSearchInterface.TEXT_ANALYZER,
+    }
     assert mappings["distribution_titles"]["type"] == "text"
     assert mappings["publisher"]["fields"]["raw"] == {"type": "keyword"}
     assert mappings["publisher"]["fields"]["normalized"] == {

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -381,7 +381,6 @@ def test_mappings_include_catalog_compatible_fields():
     ]
 
     assert mappings["dcat"]["properties"]["isPartOf"] == {"type": "keyword"}
-    assert mappings["dcat"]["dynamic"] is False
     assert mappings["theme"] == {
         "type": "text",
         "analyzer": OpenSearchInterface.TEXT_ANALYZER,

--- a/tests/unit/test_opensearch_transform.py
+++ b/tests/unit/test_opensearch_transform.py
@@ -1,0 +1,358 @@
+"""Unit tests for the DCAT -> OpenSearch index field transformer.
+
+These tests pin down how DCAT-US values are flattened into the existing
+(legacy) OpenSearch field shapes so DCAT-US 1.1 and 3.0 share one mapping.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from harvester.opensearch_transform import (
+    INDEX_FIELDS,
+    DcatIndexTransformer,
+    coerce_identifier,
+    coerce_keywords,
+    coerce_publisher_name,
+    coerce_text,
+    coerce_theme_labels,
+    distribution_titles,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DCAT3_COMPLETE_EXAMPLE = (
+    REPO_ROOT
+    / "schemas"
+    / "dcatus3.0"
+    / "examples"
+    / "Dataset"
+    / "good"
+    / "complete_example.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# identifier: string search field
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_identifier_keeps_dcat1_string():
+    assert coerce_identifier("cftc-dc1") == "cftc-dc1"
+
+
+def test_coerce_identifier_extracts_dcat3_object_id():
+    value = {
+        "@type": "Identifier",
+        "@id": "https://example.gov/identifiers/dataset-1",
+        "notation": "DATASET-1",
+    }
+
+    assert coerce_identifier(value) == "https://example.gov/identifiers/dataset-1"
+
+
+def test_coerce_identifier_returns_empty_for_dcat3_object_without_id():
+    value = {
+        "@type": "Identifier",
+        "schemaAgency": "National Climate Data Center",
+        "notation": "NCDC-CLIMATE-OBS-2024",
+        "version": "1.0",
+    }
+
+    assert coerce_identifier(value) == ""
+
+
+def test_coerce_identifier_ignores_extra_dcat3_object_fields():
+    value = {
+        "@id": "https://example.gov/identifiers/dataset-1",
+        "creator": {"@type": "Organization", "name": "NCDC"},
+        "issued": {"@type": "date", "value": "2024-01-01"},
+    }
+
+    assert coerce_identifier(value) == "https://example.gov/identifiers/dataset-1"
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_coerce_identifier_returns_empty_for_empty(value):
+    assert coerce_identifier(value) == ""
+
+
+def test_coerce_identifier_returns_empty_for_object_without_scalars():
+    assert coerce_identifier({"@type": "Identifier"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# theme: strings or Concept objects -> list[str]
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_theme_labels_keeps_dcat1_string_list():
+    assert coerce_theme_labels(["climate", "weather"]) == ["climate", "weather"]
+
+
+def test_coerce_theme_labels_wraps_single_string():
+    assert coerce_theme_labels("geospatial") == ["geospatial"]
+
+
+def test_coerce_theme_labels_extracts_dcat3_preflabel():
+    value = [
+        {
+            "@id": "https://example.gov/concepts/climate-science",
+            "@type": "Concept",
+            "prefLabel": "Climate Science",
+            "altLabel": "Climatology",
+            "inScheme": {
+                "@id": "https://example.gov/concept-schemes/science-domains",
+                "@type": "ConceptScheme",
+                "title": "Science Domains",
+            },
+        }
+    ]
+
+    assert coerce_theme_labels(value) == ["Climate Science"]
+
+
+def test_coerce_theme_labels_handles_single_concept_object():
+    assert coerce_theme_labels({"@type": "Concept", "prefLabel": "Published"}) == [
+        "Published"
+    ]
+
+
+def test_coerce_theme_labels_mixes_strings_and_objects():
+    assert coerce_theme_labels(["health", {"prefLabel": "Environment"}]) == [
+        "health",
+        "Environment",
+    ]
+
+
+@pytest.mark.parametrize("value", [None, [], "", "   "])
+def test_coerce_theme_labels_returns_empty(value):
+    assert coerce_theme_labels(value) == []
+
+
+def test_coerce_theme_labels_skips_empty_members():
+    assert coerce_theme_labels(["", None, "keep", {"prefLabel": "  "}]) == ["keep"]
+
+
+# ---------------------------------------------------------------------------
+# keyword: list[str] in both versions
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_keywords_passes_through_list():
+    assert coerce_keywords(["a", "b"]) == ["a", "b"]
+
+
+def test_coerce_keywords_wraps_single_string():
+    assert coerce_keywords("single") == ["single"]
+
+
+@pytest.mark.parametrize("value", [None, []])
+def test_coerce_keywords_empty(value):
+    assert coerce_keywords(value) == []
+
+
+def test_coerce_keywords_drops_empty_entries():
+    assert coerce_keywords(["a", "", None, "b"]) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# publisher: DCAT-US 1.1 {name} / DCAT-US 3.0 Organization -> display name
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_publisher_name_reads_name():
+    assert coerce_publisher_name({"name": "NOAA"}) == "NOAA"
+
+
+def test_coerce_publisher_name_prefers_name_over_preflabel():
+    value = {
+        "@type": "Organization",
+        "name": "NCDC",
+        "prefLabel": "National Climate Data Center",
+        "altLabel": "NCDC",
+    }
+    assert coerce_publisher_name(value) == "NCDC"
+
+
+def test_coerce_publisher_name_falls_back_to_preflabel():
+    assert coerce_publisher_name({"prefLabel": "United States Census Bureau"}) == (
+        "United States Census Bureau"
+    )
+
+
+@pytest.mark.parametrize("value", [None, {}, {"name": ""}])
+def test_coerce_publisher_name_empty(value):
+    assert coerce_publisher_name(value) == ""
+
+
+# ---------------------------------------------------------------------------
+# title / description: string in both versions
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_text_passthrough():
+    assert coerce_text("Daily Climate Observations") == "Daily Climate Observations"
+
+
+@pytest.mark.parametrize("value", [None, 123, {"x": 1}, []])
+def test_coerce_text_non_string_becomes_empty(value):
+    assert coerce_text(value) == ""
+
+
+# ---------------------------------------------------------------------------
+# distribution_titles: distribution[].title (compatible across versions)
+# ---------------------------------------------------------------------------
+
+
+def test_distribution_titles_extracts_titles():
+    distributions = [
+        {"title": "CSV download", "downloadURL": "https://example.gov/a.csv"},
+        {"@type": "Distribution", "title": "API endpoint", "byteSize": "10"},
+        {"accessURL": "https://example.gov/no-title"},
+        "not-a-dict",
+    ]
+    assert distribution_titles(distributions) == ["CSV download", "API endpoint"]
+
+
+@pytest.mark.parametrize("value", [None, [], "nope"])
+def test_distribution_titles_empty(value):
+    assert distribution_titles(value) == []
+
+
+# ---------------------------------------------------------------------------
+# INDEX_FIELDS registry + DcatIndexTransformer.transform
+# ---------------------------------------------------------------------------
+
+
+def test_index_fields_registry_covers_expected_destinations():
+    assert set(INDEX_FIELDS) == {
+        "title",
+        "description",
+        "publisher",
+        "keyword",
+        "theme",
+        "identifier",
+        "distribution_titles",
+    }
+
+
+def test_transform_dcat1_dataset():
+    dcat = {
+        "title": "Commitment of Traders",
+        "description": "COT reports.",
+        "publisher": {
+            "name": "U.S. Commodity Futures Trading Commission",
+            "subOrganizationOf": {"name": "U.S. Government"},
+        },
+        "keyword": ["commitment of traders", "cot"],
+        "theme": ["geospatial"],
+        "identifier": "cftc-dc1",
+        "isPartOf": "collection-1",
+        "distribution": [
+            {"accessURL": "https://www.cftc.gov/index.htm"},
+            {"title": "Report CSV"},
+        ],
+    }
+
+    result = DcatIndexTransformer().transform(dcat)
+
+    assert result == {
+        "title": "Commitment of Traders",
+        "description": "COT reports.",
+        "publisher": "U.S. Commodity Futures Trading Commission",
+        "keyword": ["commitment of traders", "cot"],
+        "theme": ["geospatial"],
+        "identifier": "cftc-dc1",
+        "distribution_titles": ["Report CSV"],
+    }
+
+
+def test_transform_dcat3_dataset():
+    dcat = {
+        "title": "National Climate Observations 2024",
+        "description": "Comprehensive daily climate observations.",
+        "publisher": {
+            "@type": "Organization",
+            "name": "National Climate Data Center",
+            "altLabel": "NCDC",
+            "prefLabel": "National Climate Data Center",
+        },
+        "keyword": ["climate", "weather"],
+        "theme": [
+            {
+                "@id": "https://example.gov/concepts/climate-science",
+                "@type": "Concept",
+                "prefLabel": "Climate Science",
+            }
+        ],
+        "identifier": {
+            "@type": "Identifier",
+            "@id": "https://example.gov/identifiers/ncdc-climate-obs-2024",
+            "schemaAgency": "National Climate Data Center",
+            "notation": "NCDC-CLIMATE-OBS-2024",
+            "version": "1.0",
+        },
+        "inSeries": [
+            {
+                "@id": "https://example.gov/series/annual-climate-observations",
+                "@type": "DatasetSeries",
+                "title": "Annual Climate Observations Series",
+            }
+        ],
+        "distribution": [
+            {"@type": "Distribution", "title": "Climate Observations CSV"},
+            {"@type": "Distribution", "title": "Climate Observations JSON"},
+        ],
+    }
+
+    result = DcatIndexTransformer().transform(dcat)
+
+    assert result == {
+        "title": "National Climate Observations 2024",
+        "description": "Comprehensive daily climate observations.",
+        "publisher": "National Climate Data Center",
+        "keyword": ["climate", "weather"],
+        "theme": ["Climate Science"],
+        "identifier": "https://example.gov/identifiers/ncdc-climate-obs-2024",
+        "distribution_titles": [
+            "Climate Observations CSV",
+            "Climate Observations JSON",
+        ],
+    }
+    # inSeries is intentionally not mapped into isPartOf / index fields.
+    assert "inSeries" not in result
+    assert "isPartOf" not in result
+
+
+def test_transform_real_dcat3_complete_example():
+    dcat = json.loads(DCAT3_COMPLETE_EXAMPLE.read_text())
+
+    result = DcatIndexTransformer().transform(dcat)
+
+    assert result["title"] == "National Climate Observations 2024"
+    assert result["publisher"] == "National Climate Data Center"
+    assert result["identifier"] == ""
+    assert result["theme"] == ["Climate Science", "Environmental Monitoring"]
+    assert result["distribution_titles"] == [
+        "Climate Observations CSV",
+        "Climate Observations JSON",
+    ]
+    assert "inSeries" not in result
+    assert "isPartOf" not in result
+
+
+def test_transform_handles_empty_dcat():
+    assert DcatIndexTransformer().transform({}) == {
+        "title": "",
+        "description": "",
+        "publisher": "",
+        "keyword": [],
+        "theme": [],
+        "identifier": "",
+        "distribution_titles": [],
+    }
+
+
+def test_transform_handles_none_dcat():
+    assert DcatIndexTransformer().transform(None)["identifier"] == ""


### PR DESCRIPTION
## Summary

Adds index-time normalization so DCAT-US 1.1 and 3.0 can share the existing OpenSearch mappings without catalog changes.

- Flattens DCAT3 `theme` Concepts to `prefLabel` strings and Identifier objects to `@id`
- Leaves `inSeries` unmapped (no `isPartOf` alias)
- Sets nested `dcat.dynamic: false` so mixed schema shapes cannot lock incompatible dynamic types

Unlike #718, this keeps legacy string/text contracts instead of promoting `theme` to Concept objects in the index.

## Field mapping

| OpenSearch field | Indexed shape |
| --- | --- |
| `theme` | list of strings (`prefLabel` from Concepts) |
| `identifier` | string (from `@id` when object) |
| `publisher` / `keyword` / `title` / `description` / `distribution_titles` | unchanged contracts |

New mapped fields can be added via `INDEX_FIELDS` in `harvester/opensearch_transform.py`.

