### PR TITLE
5885 - adding the workflow to do the zero downtime alias deploy

### DIFF
--- a/.github/workflows/delete_opensearch_index.yml
+++ b/.github/workflows/delete_opensearch_index.yml
@@ -1,0 +1,73 @@
+name: Delete OpenSearch Physical Index
+
+# Manually delete an unused physical dataset index (for example, one left behind
+# by a rebuild that was run with --no-delete-old-index). The command refuses to
+# delete an index still attached to the datasets alias, so live search cannot be
+# removed by mistake.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Cloud Foundry environment"
+        required: true
+        default: development
+        type: choice
+        options:
+          - development
+          - staging
+          - prod
+      index_name:
+        description: "Exact unused physical index name (for example, datasets-20260723152900)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: opensearch-maintenance-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  delete:
+    name: Delete OpenSearch index (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: ${{ inputs.environment }}
+    env:
+      CF_SPACE: ${{ inputs.environment }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+
+      - name: Validate physical index name
+        env:
+          REQUESTED_INDEX: ${{ inputs.index_name }}
+        run: |
+          if [[ ! "$REQUESTED_INDEX" =~ ^datasets-[a-z0-9._-]+$ ]]; then
+            echo "Index name must match datasets-[a-z0-9._-]+." >&2
+            exit 1
+          fi
+          echo "INDEX_NAME=$REQUESTED_INDEX" >> "$GITHUB_ENV"
+          echo "DELETE_TASK=search-delete-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+
+      - name: Delete unused physical index
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task datagov-harvest --name "$DELETE_TASK" -k 2G -m 2G
+            --command "flask search delete-index --index-name $INDEX_NAME"
+          cf_org: gsa-datagov
+          cf_space: ${{ env.CF_SPACE }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
+
+      - name: Monitor index deletion
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: bin/monitor_cf_logs.sh datagov-harvest "$DELETE_TASK"
+          cf_org: gsa-datagov
+          cf_space: ${{ env.CF_SPACE }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}

--- a/.github/workflows/rebuild_opensearch_index.yml
+++ b/.github/workflows/rebuild_opensearch_index.yml
@@ -1,0 +1,141 @@
+name: Rebuild OpenSearch Index
+
+# Zero-downtime rebuild of the OpenSearch dataset index.
+#
+#   disable harvester (reuse Toggle Harvester)
+#     -> wait for in-flight harvest jobs to drain (optionally force-kill after 15m)
+#     -> rebuild-index: create a fresh index, backfill from PostgreSQL, validate,
+#        atomically switch the datasets alias, optionally delete the old index
+#     -> re-enable harvester (always, even if the rebuild failed)
+#
+# Search stays available throughout: the old index keeps serving reads until the
+# atomic alias switch, so catalog and harvester never see a missing index.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Cloud Foundry environment"
+        required: true
+        default: development
+        type: choice
+        options:
+          - development
+          - staging
+          - prod
+      force_kill_running_jobs:
+        description: "Cancel harvest jobs still running after 15 minutes"
+        required: true
+        default: false
+        type: boolean
+      switch_alias:
+        description: "Switch the datasets alias to the rebuilt index"
+        required: true
+        default: true
+        type: boolean
+      delete_old_index:
+        description: "Delete the previous index after a successful alias switch"
+        required: true
+        default: false
+        type: boolean
+      max_tasks:
+        description: "HARVEST_RUNNER_MAX_TASKS to restore when re-enabling"
+        required: false
+        default: "3"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: opensearch-maintenance-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  disable-harvester:
+    name: Disable harvester (${{ inputs.environment }})
+    uses: ./.github/workflows/toggle_harvester.yml
+    with:
+      state: disable
+      environment: ${{ inputs.environment }}
+    secrets:
+      CF_SERVICE_USER: ${{ secrets.CF_SERVICE_USER }}
+      CF_SERVICE_AUTH: ${{ secrets.CF_SERVICE_AUTH }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  rebuild:
+    name: Rebuild OpenSearch index (${{ inputs.environment }})
+    needs: disable-harvester
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    environment: ${{ inputs.environment }}
+    env:
+      CF_SPACE: ${{ inputs.environment }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+
+      - name: Set operation names and options
+        env:
+          SWITCH_ALIAS: ${{ inputs.switch_alias }}
+          DELETE_OLD_INDEX: ${{ inputs.delete_old_index }}
+        run: |
+          echo "REBUILD_TASK=search-rebuild-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+          echo "TARGET_INDEX=datasets-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+          if [[ "$SWITCH_ALIAS" == "true" ]]; then
+            echo "ALIAS_OPTION=--switch-alias" >> "$GITHUB_ENV"
+          else
+            echo "ALIAS_OPTION=--no-switch-alias" >> "$GITHUB_ENV"
+          fi
+          if [[ "$DELETE_OLD_INDEX" == "true" ]]; then
+            echo "DELETE_OPTION=--delete-old-index" >> "$GITHUB_ENV"
+          else
+            echo "DELETE_OPTION=" >> "$GITHUB_ENV"
+          fi
+
+      - name: Wait for running harvest tasks
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            bin/wait_for_harvest_tasks.sh datagov-harvest 7200
+            ${{ inputs.force_kill_running_jobs && '--force-kill-running-jobs' || '' }}
+          cf_org: gsa-datagov
+          cf_space: ${{ env.CF_SPACE }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
+
+      - name: Start index rebuild
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf run-task datagov-harvest --name "$REBUILD_TASK" -k 4G -m 2G
+            --command "flask search rebuild-index --target-index $TARGET_INDEX
+            --allow-legacy-index-removal $ALIAS_OPTION $DELETE_OPTION"
+          cf_org: gsa-datagov
+          cf_space: ${{ env.CF_SPACE }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
+
+      - name: Monitor index rebuild
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: bin/monitor_cf_logs.sh datagov-harvest "$REBUILD_TASK"
+          cf_org: gsa-datagov
+          cf_space: ${{ env.CF_SPACE }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
+
+  enable-harvester:
+    name: Re-enable harvester (${{ inputs.environment }})
+    needs: rebuild
+    # Always re-enable, even if the rebuild failed, so harvesting resumes.
+    if: always()
+    uses: ./.github/workflows/toggle_harvester.yml
+    with:
+      state: enable
+      max_tasks: ${{ inputs.max_tasks }}
+      environment: ${{ inputs.environment }}
+    secrets:
+      CF_SERVICE_USER: ${{ secrets.CF_SERVICE_USER }}
+      CF_SERVICE_AUTH: ${{ secrets.CF_SERVICE_AUTH }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/toggle_harvester.yml
+++ b/.github/workflows/toggle_harvester.yml
@@ -31,6 +31,37 @@ on:
         required: true
         type: boolean
         default: true
+  # Callable by other workflows (e.g. rebuild_opensearch_index.yml) so the
+  # disable/enable logic lives in exactly one place. workflow_call inputs cannot
+  # use the "choice" type, so state/environment are strings here; the job body
+  # reads inputs.* and behaves identically for both triggers.
+  workflow_call:
+    inputs:
+      state:
+        description: "check, disable, or enable"
+        required: true
+        type: string
+      max_tasks:
+        description: "Maximum tasks when enabling (ignored when checking or disabling)"
+        required: false
+        default: "3"
+        type: string
+      environment:
+        description: "Cloud Foundry environment (development, staging, prod)"
+        required: true
+        type: string
+      notification:
+        description: "Send toggle notification to Slack?"
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      CF_SERVICE_USER:
+        required: true
+      CF_SERVICE_AUTH:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: false
 
 permissions:
   contents: read

--- a/app/commands/search.py
+++ b/app/commands/search.py
@@ -1,10 +1,13 @@
+import re
 from datetime import datetime, timezone
 
 import click
 from flask import Blueprint
+from opensearchpy import helpers
 
 from database.interface import HarvesterDBInterface
 from database.models import Dataset
+from datagov_data_access.search.documents import DatasetDocument
 from harvester.opensearch import OpenSearchClient, OpenSearchReader, OpenSearchWriter
 
 search = Blueprint("search", __name__)
@@ -216,3 +219,314 @@ def compare_opensearch(sample_size: int, update: bool, force_update: bool):
         click.echo("Done.")
     else:
         click.echo("Nothing to update; datasets and index are already in sync.")
+
+
+def _default_rebuild_index_name(alias_name: str) -> str:
+    """Build a versioned physical index name like datasets-20260723152900."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    return f"{alias_name}-{timestamp}"
+
+
+def _alias_indices(client, alias_name: str) -> list[str]:
+    """Return the physical indices currently attached to an alias.
+
+    Returns an empty list when the name is not (yet) an alias, which is the
+    case on the very first cutover while ``datasets`` is still a concrete index.
+    """
+    if not client.client.indices.exists_alias(name=alias_name):
+        return []
+    return sorted(client.client.indices.get_alias(name=alias_name))
+
+
+def _switch_datasets_alias(client, target_index: str, allow_legacy_index_removal: bool):
+    """Atomically point the logical ``datasets`` name at ``target_index``.
+
+    All alias changes are submitted in a single ``update_aliases`` request so
+    readers (catalog + harvester) never observe a moment without an index. The
+    first cutover finds a legacy *concrete* index named ``datasets``; OpenSearch
+    can remove that index and create the alias in the same atomic request.
+
+    Returns ``(old_indices, removed_legacy_index)``.
+    """
+    alias_name = client.INDEX_NAME
+    if not client.client.indices.exists(index=target_index):
+        raise click.ClickException(
+            f"OpenSearch target index does not exist: {target_index}"
+        )
+
+    old_indices = _alias_indices(client, alias_name)
+    if old_indices == [target_index]:
+        return old_indices, False
+
+    actions = [
+        {"remove": {"index": index, "alias": alias_name}} for index in old_indices
+    ]
+
+    removed_legacy_index = False
+    if not old_indices and client.client.indices.exists(index=alias_name):
+        # ``datasets`` is still a concrete index rather than an alias.
+        if not allow_legacy_index_removal:
+            raise click.ClickException(
+                f"'{alias_name}' is still a concrete index. Re-run with "
+                "--allow-legacy-index-removal to perform the one-time atomic "
+                "conversion to an alias."
+            )
+        actions.append({"remove_index": {"index": alias_name}})
+        removed_legacy_index = True
+
+    actions.append({"add": {"index": target_index, "alias": alias_name}})
+
+    response = client.client.indices.update_aliases(body={"actions": actions})
+    if not response.get("acknowledged"):
+        raise click.ClickException("OpenSearch did not acknowledge the alias switch.")
+    return old_indices, removed_legacy_index
+
+
+def _backfill_from_postgres(client, target_index: str, batch_size: int):
+    """Regenerate every dataset document from PostgreSQL into ``target_index``.
+
+    PostgreSQL is the source of truth, so we rebuild documents with the same
+    ``DatasetDocument`` transformer the writer uses in production and simply
+    redirect ``_index`` to the new physical index. This (unlike a server-side
+    OpenSearch ``_reindex``) picks up document-shape changes as well as mapping
+    changes, and mirrors the ``compare --force-update`` repair path. Datasets are
+    read in keyset-paginated batches to bound memory on large tables.
+
+    Returns ``(indexed, failed, errors)``.
+    """
+    total_indexed = 0
+    total_failed = 0
+    errors: list = []
+    last_id = None
+    batch_number = 0
+
+    while True:
+        query = db_interface.db.query(Dataset).order_by(Dataset.id)
+        if last_id is not None:
+            query = query.filter(Dataset.id > last_id)
+        datasets = query.limit(batch_size).all()
+        if not datasets:
+            break
+
+        batch_number += 1
+        click.echo(
+            f"  Backfill batch {batch_number}: indexing {len(datasets)} dataset(s)..."
+        )
+        documents = []
+        for dataset in datasets:
+            document = DatasetDocument(dataset).dataset_to_document()
+            document["_index"] = target_index
+            documents.append(document)
+
+        for success, item in helpers.streaming_bulk(
+            client.client,
+            documents,
+            raise_on_error=False,
+            max_retries=8,
+        ):
+            if success:
+                total_indexed += 1
+            else:
+                total_failed += 1
+                errors.append(item)
+
+        last_id = datasets[-1].id
+        db_interface.db.expunge_all()
+
+        if total_failed:
+            break
+
+    return total_indexed, total_failed, errors
+
+
+@search.cli.command("rebuild-index")
+@click.option(
+    "--target-index",
+    help="Physical index name. Defaults to datasets-<UTC timestamp>.",
+)
+@click.option(
+    "--switch-alias/--no-switch-alias",
+    default=True,
+    show_default=True,
+    help="Switch the datasets alias to the rebuilt index after validation.",
+)
+@click.option(
+    "--allow-legacy-index-removal",
+    is_flag=True,
+    help=(
+        "Allow the first cutover to atomically remove a legacy concrete index "
+        "named datasets so it can become an alias."
+    ),
+)
+@click.option(
+    "--batch-size",
+    default=1000,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Number of datasets read from PostgreSQL per backfill batch.",
+)
+@click.option(
+    "--delete-old-index",
+    is_flag=True,
+    help=(
+        "After a successful alias switch, delete the index(es) the alias "
+        "previously pointed at. Ignored with --no-switch-alias."
+    ),
+)
+def rebuild_opensearch_index(
+    target_index: str | None,
+    switch_alias: bool,
+    allow_legacy_index_removal: bool,
+    batch_size: int,
+    delete_old_index: bool,
+):
+    """Zero-downtime rebuild: backfill datasets into a fresh index, then swap alias.
+
+    Builds a new physical index with the current application mapping, regenerates
+    every document from PostgreSQL (the source of truth) into it, validates the
+    document count, and (by default) atomically switches the ``datasets`` alias to
+    the new index. Search stays available throughout because the old index keeps
+    serving reads until the atomic alias switch.
+
+    Backfilling from PostgreSQL (rather than an OpenSearch ``_reindex``) means the
+    rebuild also picks up document-shape changes, not just mapping changes, and
+    reuses the same repair path as ``compare --force-update``.
+    """
+    client = OpenSearchClient.from_environment()
+    alias_name = client.INDEX_NAME
+
+    target_index = target_index or _default_rebuild_index_name(alias_name)
+    if target_index == alias_name or not target_index.startswith(f"{alias_name}-"):
+        raise click.ClickException(
+            f"Target index must be a physical index starting with '{alias_name}-'."
+        )
+    if client.client.indices.exists(index=target_index):
+        raise click.ClickException(f"OpenSearch index already exists: {target_index}")
+
+    # Fail fast, before creating anything, if the one-time legacy conversion is
+    # needed but has not been explicitly allowed.
+    current_alias_indices = _alias_indices(client, alias_name)
+    has_legacy_concrete_index = not current_alias_indices and (
+        client.client.indices.exists(index=alias_name)
+    )
+    if switch_alias and has_legacy_concrete_index and not allow_legacy_index_removal:
+        raise click.ClickException(
+            f"'{alias_name}' is still a concrete index. Re-run with "
+            "--allow-legacy-index-removal to perform the one-time atomic "
+            "conversion to an alias."
+        )
+
+    click.echo(f"Creating physical index {target_index} with current mapping...")
+    body = {"mappings": client.MAPPINGS}
+    if client.SETTINGS:
+        body["settings"] = client.SETTINGS
+    client.client.indices.create(index=target_index, body=body)
+
+    mapping = client.client.indices.get_mapping(index=target_index)
+    actual_mapping = mapping[target_index]["mappings"]
+    if _normalize_mapping_for_comparison(
+        actual_mapping
+    ) != _normalize_mapping_for_comparison(client.MAPPINGS):
+        raise click.ClickException(
+            "Created index mapping does not match application mapping."
+        )
+
+    db_count = db_interface.db.query(Dataset).count()
+    click.echo(f"Backfilling {db_count} PostgreSQL dataset(s) into {target_index}...")
+    indexed, failed, errors = _backfill_from_postgres(client, target_index, batch_size)
+    if failed:
+        for error in errors:
+            click.echo(f"  OpenSearch error: {error}")
+        raise click.ClickException(
+            f"Backfill {OPENSEARCH_INDEX_BATCH_FAILURE_MESSAGE}: "
+            f"indexed={indexed}, failed={failed}."
+        )
+
+    # Harvesting is paused and drained before this runs, so the DB is stable;
+    # the index must end up with exactly one document per dataset.
+    client.client.indices.refresh(index=target_index)
+    target_count = client.client.count(index=target_index)["count"]
+    if target_count != db_count:
+        raise click.ClickException(
+            f"Validation failed ({OPENSEARCH_INDEX_BATCH_FAILURE_MESSAGE}): "
+            f"PostgreSQL has {db_count} dataset(s) but {target_index} has "
+            f"{target_count} document(s)."
+        )
+    click.echo(f"Validated {target_index}: {target_count} document(s).")
+
+    if not switch_alias:
+        click.echo(
+            f"Rebuild complete: {target_index} is validated. The {alias_name} "
+            "alias was not changed."
+        )
+        return
+
+    click.echo(f"Atomically switching alias {alias_name} to {target_index}...")
+    old_indices, removed_legacy = _switch_datasets_alias(
+        client, target_index, allow_legacy_index_removal
+    )
+    if removed_legacy:
+        click.echo(f"Converted the legacy concrete index '{alias_name}' into an alias.")
+    click.echo(f"Rebuild complete: {alias_name} now points to {target_index}.")
+
+    if old_indices:
+        if delete_old_index:
+            for old_index in old_indices:
+                _delete_physical_index(client, old_index)
+        else:
+            click.echo(
+                "Previous index no longer serving traffic (safe to delete with "
+                f"'flask search delete-index'): {', '.join(old_indices)}"
+            )
+
+
+def _delete_physical_index(client, index_name: str):
+    """Delete a physical dataset index after guarding against unsafe removals.
+
+    Refuses to delete the logical alias name itself or any index still attached
+    to an alias, so this can only ever remove an old index left behind by a
+    rebuild.
+    """
+    alias_name = client.INDEX_NAME
+
+    physical_index_pattern = rf"{re.escape(alias_name)}-[a-z0-9._-]+"
+    if not re.fullmatch(physical_index_pattern, index_name):
+        raise click.ClickException(
+            f"Index name must be a physical index starting with '{alias_name}-'."
+        )
+    if not client.client.indices.exists(index=index_name):
+        raise click.ClickException(f"OpenSearch index does not exist: {index_name}")
+
+    alias_response = client.client.indices.get_alias(index=index_name)
+    attached_aliases = sorted(
+        {
+            alias
+            for index_details in alias_response.values()
+            for alias in index_details.get("aliases", {})
+        }
+    )
+    if attached_aliases:
+        raise click.ClickException(
+            f"Cannot delete {index_name}; it is still attached to alias(es): "
+            + ", ".join(attached_aliases)
+        )
+
+    click.echo(f"Deleting unused physical index {index_name}...")
+    response = client.client.indices.delete(index=index_name)
+    if not response.get("acknowledged"):
+        raise click.ClickException(
+            f"OpenSearch did not acknowledge deletion of {index_name}."
+        )
+    click.echo(f"Deleted OpenSearch index {index_name}.")
+
+
+@search.cli.command("delete-index")
+@click.option(
+    "--index-name",
+    required=True,
+    help="Exact name of an unused physical index, such as datasets-20260723152900.",
+)
+def delete_opensearch_index(index_name: str):
+    """Delete an unused physical dataset index."""
+    client = OpenSearchClient.from_environment()
+    _delete_physical_index(client, index_name)

--- a/app/commands/search.py
+++ b/app/commands/search.py
@@ -2,12 +2,12 @@ import re
 from datetime import datetime, timezone
 
 import click
+from datagov_data_access.search.documents import DatasetDocument
 from flask import Blueprint
 from opensearchpy import helpers
 
 from database.interface import HarvesterDBInterface
 from database.models import Dataset
-from datagov_data_access.search.documents import DatasetDocument
 from harvester.opensearch import OpenSearchClient, OpenSearchReader, OpenSearchWriter
 
 search = Blueprint("search", __name__)

--- a/bin/wait_for_harvest_tasks.sh
+++ b/bin/wait_for_harvest_tasks.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+app_name=${1:?Usage: wait_for_harvest_tasks.sh <app_name> [timeout_seconds] [--force-kill-running-jobs]}
+timeout_seconds=${2:-7200}
+force_kill_running_jobs=false
+if [[ "${3:-}" == "--force-kill-running-jobs" ]]; then
+  force_kill_running_jobs=true
+  timeout_seconds=${HARVEST_TASK_FORCE_KILL_TIMEOUT_SECONDS:-900}
+elif [[ -n "${3:-}" ]]; then
+  echo "Unknown option: $3" >&2
+  exit 2
+fi
+poll_seconds=${HARVEST_TASK_POLL_SECONDS:-15}
+quiet_seconds=${HARVEST_TASK_QUIET_SECONDS:-30}
+deadline=$(( $(date +%s) + timeout_seconds ))
+quiet_since=0
+force_cancel_requested=false
+
+apk add --no-cache jq
+
+app_guid=$(cf app "$app_name" --guid)
+
+while true; do
+  tasks=$(cf curl "/v3/apps/${app_guid}/tasks?states=PENDING,RUNNING,CANCELING&per_page=5000")
+  active_tasks=$(
+    echo "$tasks" |
+      jq -c '[.resources[] | select(
+        (.state == "PENDING" or .state == "RUNNING" or .state == "CANCELING")
+        and (.name | startswith("harvest-job-"))
+      )]'
+  )
+  active_count=$(echo "$active_tasks" | jq 'length')
+
+  if [[ "$active_count" -eq 0 ]]; then
+    now=$(date +%s)
+    if [[ "$quiet_since" -eq 0 ]]; then
+      quiet_since=$now
+      echo "No harvest tasks are running; confirming the queue stays drained..."
+    elif [[ $(( now - quiet_since )) -ge "$quiet_seconds" ]]; then
+      echo "No harvest tasks ran during the ${quiet_seconds}-second quiet period."
+      exit 0
+    fi
+  else
+    quiet_since=0
+    if [[ "$force_cancel_requested" == true ]]; then
+      echo "Waiting for $active_count canceled harvest task(s) to stop..."
+    else
+      echo "Waiting for $active_count active harvest task(s) to finish..."
+    fi
+  fi
+
+  if [[ "$active_count" -gt 0 && $(date +%s) -ge "$deadline" ]]; then
+    if [[ "$force_kill_running_jobs" == true && "$force_cancel_requested" == false ]]; then
+      echo "Force-kill timeout reached; canceling $active_count active harvest task(s)..."
+      while IFS=$'\t' read -r task_guid task_name; do
+        if [[ -z "$task_guid" ]]; then
+          continue
+        fi
+        echo "Canceling harvest task $task_name ($task_guid)..."
+        cf curl -X POST "/v3/tasks/${task_guid}/actions/cancel" >/dev/null
+      done < <(
+        echo "$active_tasks" |
+          jq -r '.[] | select(.state != "CANCELING") | [.guid, .name] | @tsv'
+      )
+      force_cancel_requested=true
+    elif [[ "$force_kill_running_jobs" == false ]]; then
+      echo "Timed out waiting for $active_count harvest task(s) to finish." >&2
+      exit 1
+    fi
+  fi
+
+  sleep "$poll_seconds"
+done

--- a/tests/scripts/test_wait_for_harvest_tasks.py
+++ b/tests/scripts/test_wait_for_harvest_tasks.py
@@ -1,0 +1,95 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "bin" / "wait_for_harvest_tasks.sh"
+
+
+def _write_executable(path, contents):
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+def _run_wait_script(tmp_path, *arguments):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    calls_file = tmp_path / "cf-calls"
+    canceled_file = tmp_path / "canceled"
+
+    _write_executable(fake_bin / "apk", "#!/bin/bash\nexit 0\n")
+    _write_executable(
+        fake_bin / "cf",
+        """#!/bin/bash
+set -euo pipefail
+
+echo "$*" >> "$CF_CALLS_FILE"
+
+if [[ "$1" == "app" ]]; then
+  echo "app-guid"
+elif [[ "$1" == "curl" && "$2" == /v3/apps/* ]]; then
+  if [[ -f "$CF_CANCELED_FILE" ]]; then
+    echo '{"resources":[]}'
+  else
+    echo "$CF_ACTIVE_TASKS"
+  fi
+elif [[ "$1" == "curl" && "$2" == "-X" && "$3" == "POST" ]]; then
+  touch "$CF_CANCELED_FILE"
+  echo '{}'
+else
+  echo "Unexpected cf command: $*" >&2
+  exit 1
+fi
+""",
+    )
+
+    active_tasks = {
+        "resources": [
+            {
+                "guid": "harvest-task-guid",
+                "name": "harvest-job-123-harvest",
+                "state": "RUNNING",
+            },
+            {
+                "guid": "other-task-guid",
+                "name": "search-pause-123",
+                "state": "RUNNING",
+            },
+        ]
+    }
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "CF_ACTIVE_TASKS": json.dumps(active_tasks),
+        "CF_CALLS_FILE": str(calls_file),
+        "CF_CANCELED_FILE": str(canceled_file),
+        "HARVEST_TASK_FORCE_KILL_TIMEOUT_SECONDS": "0",
+        "HARVEST_TASK_POLL_SECONDS": "0",
+        "HARVEST_TASK_QUIET_SECONDS": "0",
+    }
+    result = subprocess.run(
+        [str(SCRIPT), "datagov-harvest", *arguments],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=10,
+    )
+    return result, calls_file.read_text()
+
+
+def test_timeout_abandons_without_canceling_tasks(tmp_path):
+    result, calls = _run_wait_script(tmp_path, "0")
+
+    assert result.returncode == 1
+    assert "Timed out waiting for 1 harvest task(s) to finish." in result.stderr
+    assert "actions/cancel" not in calls
+
+
+def test_force_kill_cancels_harvest_tasks_and_waits_until_drained(tmp_path):
+    result, calls = _run_wait_script(tmp_path, "7200", "--force-kill-running-jobs")
+
+    assert result.returncode == 0
+    assert "Force-kill timeout reached" in result.stdout
+    assert "curl -X POST /v3/tasks/harvest-task-guid/actions/cancel" in calls
+    assert "/v3/tasks/other-task-guid/actions/cancel" not in calls
+    assert "No harvest tasks ran during the 0-second quiet period." in result.stdout

--- a/tests/unit/test_search_commands.py
+++ b/tests/unit/test_search_commands.py
@@ -157,3 +157,265 @@ def test_compare_is_read_only_without_update(app):
     client.index_datasets.assert_not_called()
     client.client.delete.assert_not_called()
     client._refresh.assert_not_called()
+
+
+def _rebuild_client(alias_indices=None, legacy_concrete=False, target_count=5):
+    """Build a mocked OpenSearchClient for rebuild-index tests.
+
+    ``indices.exists`` is stateful because rebuild-index queries it before the
+    new index is created (expects False) and again during the alias switch
+    (expects True). ``created`` tracks that transition. ``target_count`` is what
+    ``count(target_index)`` reports for the post-backfill validation.
+    """
+    client = Mock()
+    client.INDEX_NAME = "datasets"
+    client.MAPPINGS = {"properties": {"title": {"type": "text"}}}
+    client.SETTINGS = {"analysis": {}}
+
+    created = set(alias_indices or [])
+    if legacy_concrete:
+        created.add("datasets")
+
+    def exists(index):
+        return index in created
+
+    def create(index, body):
+        created.add(index)
+        return {"acknowledged": True}
+
+    client.client.indices.exists.side_effect = exists
+    client.client.indices.create.side_effect = create
+    client.client.indices.exists_alias.return_value = bool(alias_indices)
+    client.client.indices.get_alias.return_value = {
+        index: {} for index in (alias_indices or [])
+    }
+    client.client.indices.get_mapping.side_effect = lambda index: {
+        index: {"mappings": {"properties": {"title": {"type": "text"}}}}
+    }
+    client.client.count.return_value = {"count": target_count}
+    client.client.indices.update_aliases.return_value = {"acknowledged": True}
+    return client
+
+
+def _run_rebuild(app, client, args, db_count=5, backfill=None):
+    """Invoke rebuild-index with the PostgreSQL backfill path mocked out.
+
+    ``backfill`` overrides the (indexed, failed, errors) return of
+    ``_backfill_from_postgres``; by default it reports ``db_count`` indexed with
+    no failures. A single query mock answers the two ``.count()`` calls the
+    command makes before and after the backfill.
+    """
+    if backfill is None:
+        backfill = (db_count, 0, [])
+    query_result = Mock()
+    query_result.count.return_value = db_count
+    with (
+        patch(
+            "app.commands.search.OpenSearchClient.from_environment",
+            return_value=client,
+        ),
+        patch("app.commands.search.db_interface.db.query", return_value=query_result),
+        patch(
+            "app.commands.search._backfill_from_postgres", return_value=backfill
+        ) as backfill_mock,
+    ):
+        result = app.test_cli_runner().invoke(args=["search", "rebuild-index", *args])
+    return result, backfill_mock
+
+
+def test_rebuild_index_backfills_and_switches_alias(app):
+    client = _rebuild_client(alias_indices=["datasets-old"])
+
+    result, backfill_mock = _run_rebuild(
+        app, client, ["--target-index", "datasets-new"]
+    )
+
+    assert result.exit_code == 0, result.output
+    create_kwargs = client.client.indices.create.call_args.kwargs
+    assert create_kwargs["index"] == "datasets-new"
+    # Backfill targets the new physical index, sourced from PostgreSQL.
+    backfill_mock.assert_called_once()
+    assert backfill_mock.call_args.args[1] == "datasets-new"
+
+    client.client.indices.update_aliases.assert_called_once()
+    actions = client.client.indices.update_aliases.call_args.kwargs["body"]["actions"]
+    assert {"remove": {"index": "datasets-old", "alias": "datasets"}} in actions
+    assert {"add": {"index": "datasets-new", "alias": "datasets"}} in actions
+    assert "datasets now points to datasets-new" in result.output
+
+
+def test_rebuild_index_aborts_before_alias_switch_on_count_mismatch(app):
+    # PostgreSQL has 5 datasets but only 4 land in the new index.
+    client = _rebuild_client(alias_indices=["datasets-old"], target_count=4)
+
+    result, _ = _run_rebuild(
+        app, client, ["--target-index", "datasets-new"], db_count=5
+    )
+
+    assert result.exit_code != 0
+    assert OPENSEARCH_INDEX_BATCH_FAILURE_MESSAGE in result.output
+    client.client.indices.update_aliases.assert_not_called()
+
+
+def test_rebuild_index_aborts_on_backfill_failures(app):
+    client = _rebuild_client(alias_indices=["datasets-old"])
+
+    result, _ = _run_rebuild(
+        app,
+        client,
+        ["--target-index", "datasets-new"],
+        db_count=5,
+        backfill=(4, 1, [{"index": {"error": "boom"}}]),
+    )
+
+    assert result.exit_code != 0
+    assert OPENSEARCH_INDEX_BATCH_FAILURE_MESSAGE in result.output
+    client.client.indices.update_aliases.assert_not_called()
+
+
+def test_rebuild_index_requires_flag_to_convert_legacy_concrete_index(app):
+    client = _rebuild_client(alias_indices=None, legacy_concrete=True)
+
+    result, _ = _run_rebuild(app, client, ["--target-index", "datasets-new"])
+
+    assert result.exit_code != 0
+    assert "--allow-legacy-index-removal" in result.output
+    client.client.indices.create.assert_not_called()
+
+
+def test_rebuild_index_converts_legacy_concrete_index_with_flag(app):
+    client = _rebuild_client(alias_indices=None, legacy_concrete=True)
+
+    result, _ = _run_rebuild(
+        app,
+        client,
+        ["--target-index", "datasets-new", "--allow-legacy-index-removal"],
+    )
+
+    assert result.exit_code == 0, result.output
+    actions = client.client.indices.update_aliases.call_args.kwargs["body"]["actions"]
+    assert {"remove_index": {"index": "datasets"}} in actions
+    assert {"add": {"index": "datasets-new", "alias": "datasets"}} in actions
+
+
+def test_rebuild_index_no_switch_alias_leaves_alias_untouched(app):
+    client = _rebuild_client(alias_indices=["datasets-old"])
+
+    result, backfill_mock = _run_rebuild(
+        app, client, ["--target-index", "datasets-new", "--no-switch-alias"]
+    )
+
+    assert result.exit_code == 0, result.output
+    backfill_mock.assert_called_once()
+    client.client.indices.update_aliases.assert_not_called()
+
+
+def test_rebuild_index_deletes_old_index_after_switch(app):
+    client = _rebuild_client(alias_indices=["datasets-old"])
+    # After the switch, delete-old-index re-checks that the old index is no
+    # longer attached to any alias before deleting it.
+    client.client.indices.delete.return_value = {"acknowledged": True}
+
+    result, _ = _run_rebuild(
+        app, client, ["--target-index", "datasets-new", "--delete-old-index"]
+    )
+
+    assert result.exit_code == 0, result.output
+    client.client.indices.delete.assert_called_once_with(index="datasets-old")
+
+
+def test_backfill_from_postgres_overrides_index_and_tallies_failures(app):
+    from app.commands.search import _backfill_from_postgres
+
+    client = Mock()
+    first, second = Mock(), Mock()
+    first.id, second.id = "a", "b"
+
+    # Keyset pagination: first batch returns two datasets, second is empty.
+    chain = Mock()
+    chain.filter.return_value = chain
+    chain.limit.return_value.all.side_effect = [[first, second], []]
+    query_result = Mock()
+    query_result.order_by.return_value = chain
+
+    def fake_streaming_bulk(_client, documents, **_kwargs):
+        # First doc succeeds, second fails; both should target the new index.
+        assert all(doc["_index"] == "datasets-new" for doc in documents)
+        yield True, {"index": {"_id": "a"}}
+        yield False, {"index": {"_id": "b", "error": "boom"}}
+
+    with (
+        patch("app.commands.search.db_interface.db.query", return_value=query_result),
+        patch("app.commands.search.DatasetDocument") as document_cls,
+        patch(
+            "app.commands.search.helpers.streaming_bulk",
+            side_effect=fake_streaming_bulk,
+        ),
+    ):
+        document_cls.side_effect = lambda dataset: Mock(
+            dataset_to_document=lambda: {"_index": "datasets", "_id": dataset.id}
+        )
+        indexed, failed, errors = _backfill_from_postgres(
+            client, "datasets-new", batch_size=1000
+        )
+
+    assert indexed == 1
+    assert failed == 1
+    assert len(errors) == 1
+
+
+def test_delete_index_removes_unused_physical_index(app):
+    client = Mock()
+    client.INDEX_NAME = "datasets"
+    client.client.indices.exists.return_value = True
+    client.client.indices.get_alias.return_value = {"datasets-old": {"aliases": {}}}
+    client.client.indices.delete.return_value = {"acknowledged": True}
+
+    with patch(
+        "app.commands.search.OpenSearchClient.from_environment",
+        return_value=client,
+    ):
+        result = app.test_cli_runner().invoke(
+            args=["search", "delete-index", "--index-name", "datasets-old"]
+        )
+
+    assert result.exit_code == 0, result.output
+    client.client.indices.delete.assert_called_once_with(index="datasets-old")
+
+
+def test_delete_index_refuses_index_still_attached_to_alias(app):
+    client = Mock()
+    client.INDEX_NAME = "datasets"
+    client.client.indices.exists.return_value = True
+    client.client.indices.get_alias.return_value = {
+        "datasets-live": {"aliases": {"datasets": {}}}
+    }
+
+    with patch(
+        "app.commands.search.OpenSearchClient.from_environment",
+        return_value=client,
+    ):
+        result = app.test_cli_runner().invoke(
+            args=["search", "delete-index", "--index-name", "datasets-live"]
+        )
+
+    assert result.exit_code != 0
+    assert "still attached to alias" in result.output
+    client.client.indices.delete.assert_not_called()
+
+
+def test_delete_index_refuses_logical_alias_name(app):
+    client = Mock()
+    client.INDEX_NAME = "datasets"
+
+    with patch(
+        "app.commands.search.OpenSearchClient.from_environment",
+        return_value=client,
+    ):
+        result = app.test_cli_runner().invoke(
+            args=["search", "delete-index", "--index-name", "datasets"]
+        )
+
+    assert result.exit_code != 0
+    assert "physical index starting with" in result.output
+    client.client.indices.delete.assert_not_called()


### PR DESCRIPTION
# Zero-downtime OpenSearch index rebuild

## Summary

Adds a zero-downtime way to rebuild the OpenSearch `datasets` index. Today, a
mapping change requires `reset-mapping` (which deletes and recreates the index,
causing a **search outage** until `compare --force-update` repopulates it). This
PR builds a fresh index alongside the live one, backfills it from PostgreSQL, and
atomically swaps a `datasets` **alias** so catalog and harvester never see a
missing or empty index.

Achieved with **no changes to production runtime code** and **no dependency
changes** — the OpenSearch client lives in the pinned `datagov-data-access`
package, so all new index/alias work goes through the raw `opensearch-py` client
it already exposes.

## How it works

The `Rebuild OpenSearch Index` action orchestrates existing pieces:

1. **Disable harvester** — reuses `toggle_harvester.yml` (now callable via
   `workflow_call`, so the disable/enable logic isn't duplicated).
2. **Drain harvest jobs** — `bin/wait_for_harvest_tasks.sh` polls the CF task API
   until in-flight jobs finish; `force_kill_running_jobs` cancels stragglers after
   15 minutes.
3. **Rebuild** — `flask search rebuild-index` creates `datasets-<timestamp>` with
   the current mapping, backfills every document **from PostgreSQL**, validates the
   doc count against the DB, then atomically switches the `datasets` alias.
4. **Re-enable harvester** — always runs, even if the rebuild failed.
5. **Optional cleanup** — `delete_old_index` removes the previous index after a
   successful switch (or use the standalone `Delete OpenSearch Physical Index`
   action later).

### Why backfill from PostgreSQL instead of OpenSearch `_reindex`?

`_reindex` copies the old `_source`, so it can only reproduce the **old document
shape** — it would silently miss new/changed computed fields, which is often the
whole reason for a rebuild. Regenerating from the DB (via the same
`DatasetDocument` builder used in production) picks up document-shape **and**
mapping changes, and mirrors the existing `compare --force-update` repair path.

## Changes

**Additive only** — existing `reset-mapping` / `compare` commands are untouched:

- `app/commands/search.py` — new `flask search rebuild-index` and
  `flask search delete-index` commands.
- `.github/workflows/rebuild_opensearch_index.yml` — orchestration workflow.
- `.github/workflows/delete_opensearch_index.yml` — manual index-cleanup escape hatch.
- `.github/workflows/toggle_harvester.yml` — added a `workflow_call` trigger
  (existing manual dispatch unchanged).
- `bin/wait_for_harvest_tasks.sh` — CF task drain/force-kill helper (pure `cf curl`).
- Tests: `tests/unit/test_search_commands.py`, `tests/scripts/test_wait_for_harvest_tasks.py`.

## Notes for reviewers / operators

- The alias is named **`datasets`** (not `datasets-alias`) so catalog and harvester
  keep working with zero code changes.
- The **first** production run needs `--allow-legacy-index-removal` to convert the
  current concrete `datasets` index into an alias in one atomic step. The workflow
  always passes this flag.
- Search stays available the entire time: the old index serves reads until the
  atomic cutover.
