### PR TITLE
use body-file instead. template expects string.

### DIFF
--- a/.github/workflows/update-data-access.yml
+++ b/.github/workflows/update-data-access.yml
@@ -111,4 +111,4 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "Update datagov-data-access to ${VERSION}" \
-            --template "$TEMPLATE"
+            --body-file "$TEMPLATE"


### PR DESCRIPTION
# Pull Request

Related to [6191](https://github.com/GSA/data.gov/issues/6191)

## About
`--template` expects a string not a file object. swapping to use `--body-file`. here's my local [test](https://github.com/GSA/datagov-catalog/pull/361)

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
