### PR TITLE
6175: add has_download filter for datasets without distribution links

### DIFF
--- a/search/documents.py
+++ b/search/documents.py
@@ -92,6 +92,11 @@ class DatasetDocument:
             or dataset.translated_spatial is not None
             or has_spatial_theme
         )
+        has_download = any(
+            isinstance(distribution, dict)
+            and str(distribution.get("downloadURL") or "").strip()
+            for distribution in (dataset.dcat.get("distribution") or [])
+        )
         nested_dcat = self._normalize_dcat_dates(dataset.dcat)
         spatial_centroid = calc_geometry_centroid(dataset.translated_spatial)
         last_harvested = (
@@ -116,6 +121,7 @@ class DatasetDocument:
             "theme": index_fields["theme"],
             "identifier": index_fields["identifier"],
             "has_spatial": has_spatial,
+            "has_download": has_download,
             "organization": organization,
             "distribution_titles": index_fields["distribution_titles"],
             "popularity": popularity,

--- a/search/mappings.py
+++ b/search/mappings.py
@@ -58,6 +58,7 @@ MAPPINGS = {
             "search_analyzer": TEXT_ANALYZER,
         },
         "has_spatial": {"type": "boolean"},
+        "has_download": {"type": "boolean"},
         "popularity": {"type": "integer"},
         "organization": {
             "type": "nested",

--- a/search/queries/filters/__init__.py
+++ b/search/queries/filters/__init__.py
@@ -7,6 +7,7 @@ from search.queries.filters.base import (
 )
 from search.queries.filters.collection import COLLECTION_FILTER
 from search.queries.filters.geography import GEOGRAPHY_FILTER
+from search.queries.filters.has_download import HAS_DOWNLOAD_FILTER
 from search.queries.filters.keyword import KEYWORD_FILTER
 from search.queries.filters.organization import ORGANIZATION_FILTER
 from search.queries.filters.organization_type import (
@@ -32,4 +33,5 @@ FILTERS = (
     PUBLISHER_FILTER,
     SPATIAL_DATA_FILTER,
     COLLECTION_FILTER,
+    HAS_DOWNLOAD_FILTER,
 )

--- a/search/queries/filters/has_download.py
+++ b/search/queries/filters/has_download.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from search.queries.filters.base import (
+    API_CONTEXT,
+    MAIN_CONTEXT,
+    ORGANIZATION_CONTEXT,
+    ApiQueryParam,
+    FilterDefinition,
+    FilterOption,
+    get_value,
+    parse_bool_param,
+)
+
+HAS_DOWNLOAD_OPTIONS = (
+    FilterOption(
+        value="true",
+        label="Only show datasets with a downloadable file",
+        input_id="filter-has-download",
+    ),
+)
+
+
+def _clause(criteria, value: bool) -> dict | None:
+    if value:
+        return {"term": {"has_download": True}}
+    return None
+
+
+def _section(criteria, context) -> dict:
+    value = criteria.get_filter("has_download") or False
+    return {
+        "field_name": "has_download",
+        "values": ["true"] if value else [],
+        "subtitle": "Limit results to datasets with a direct data download",
+        "section_id": "filter-has-download",
+        "button_id": "has-download-label",
+        "active_summary": HAS_DOWNLOAD_OPTIONS[0].label if value else None,
+    }
+
+
+HAS_DOWNLOAD_FILTER = FilterDefinition(
+    name="has_download",
+    query_params=("has_download",),
+    parse_contexts=(MAIN_CONTEXT, API_CONTEXT, ORGANIZATION_CONTEXT),
+    ui_contexts=(MAIN_CONTEXT, ORGANIZATION_CONTEXT),
+    label="Data Access",
+    renderer="checkbox_group",
+    options=HAS_DOWNLOAD_OPTIONS,
+    api_query_params=(ApiQueryParam("has_download", field_type="boolean"),),
+    parse=lambda args: parse_bool_param(get_value(args, "has_download"), False),
+    to_query_pairs=lambda value: [("has_download", "true")] if value else [],
+    is_active=lambda value: value is True,
+    clause_builder=_clause,
+    section_builder=_section,
+)

--- a/tests/integration/search/test_documents.py
+++ b/tests/integration/search/test_documents.py
@@ -100,6 +100,7 @@ def test_dataset_to_document(sample_dataset, monkeypatch):
     assert document["dcat"]["isPartOf"] == "collection-1"
     assert document["distribution_titles"] == ["CSV download", "API endpoint"]
     assert document["has_spatial"] is True
+    assert document["has_download"] is False
     assert document["harvest_record"] == "https://catalog.data.gov/harvest_record/hr-1"
     assert (
         document["harvest_record_raw"]
@@ -203,6 +204,51 @@ def test_dataset_to_document_without_spatial_data_or_theme(sample_dataset, theme
     document = dataset_doc.dataset_to_document()
 
     assert document["has_spatial"] is False
+
+
+def test_dataset_to_document_has_download_when_download_url_present(sample_dataset):
+    sample_dataset.dcat["distribution"].append(
+        {"title": "Data file", "downloadURL": "https://example.gov/data.csv"}
+    )
+
+    dataset_doc = DatasetDocument(sample_dataset)
+    document = dataset_doc.dataset_to_document()
+
+    assert document["has_download"] is True
+
+
+def test_dataset_to_document_has_download_false_for_access_url_only(sample_dataset):
+    sample_dataset.dcat["distribution"] = [
+        {"title": "API endpoint", "accessURL": "https://example.gov/api"}
+    ]
+
+    dataset_doc = DatasetDocument(sample_dataset)
+    document = dataset_doc.dataset_to_document()
+
+    assert document["has_download"] is False
+
+
+@pytest.mark.parametrize("distribution", [None, [], "not-a-list"])
+def test_dataset_to_document_has_download_false_when_distribution_missing(
+    sample_dataset, distribution
+):
+    sample_dataset.dcat["distribution"] = distribution
+
+    dataset_doc = DatasetDocument(sample_dataset)
+    document = dataset_doc.dataset_to_document()
+
+    assert document["has_download"] is False
+
+
+def test_dataset_to_document_has_download_false_for_blank_download_url(
+    sample_dataset,
+):
+    sample_dataset.dcat["distribution"] = [{"title": "Blank", "downloadURL": "   "}]
+
+    dataset_doc = DatasetDocument(sample_dataset)
+    document = dataset_doc.dataset_to_document()
+
+    assert document["has_download"] is False
 
 
 def test_dataset_to_document_omits_transformed_url_without_payload(sample_dataset):

--- a/tests/unit/search/test_mappings.py
+++ b/tests/unit/search/test_mappings.py
@@ -1,0 +1,5 @@
+from search.mappings import MAPPINGS
+
+
+def test_has_download_field_mapping():
+    assert MAPPINGS["properties"]["has_download"]["type"] == "boolean"

--- a/tests/unit/search/test_search_filter_registry.py
+++ b/tests/unit/search/test_search_filter_registry.py
@@ -27,6 +27,7 @@ def test_search_criteria_parses_registered_filters():
             "org_slug": "city-example",
             "spatial_filter": "geospatial",
             "collection": "collection-id",
+            "has_download": "true",
             "sort": "popularity",
         },
         route_context=MAIN_CONTEXT,
@@ -39,6 +40,7 @@ def test_search_criteria_parses_registered_filters():
     assert criteria.get_filter("organization") == "city-example"
     assert criteria.get_filter("spatial_data") == "geospatial"
     assert criteria.get_filter("collection") == "collection-id"
+    assert criteria.get_filter("has_download") is True
     assert criteria.sort_by == "popularity"
 
 
@@ -51,6 +53,13 @@ def test_search_criteria_rejects_malformed_spatial_geometry():
 
     assert excinfo.value.parameter == "spatial_geometry"
     assert excinfo.value.message == "spatial_geometry parameter is malformed"
+
+
+def test_has_download_filter_defaults_to_inactive():
+    criteria = SearchCriteria.from_request_args({}, route_context=MAIN_CONTEXT)
+
+    assert criteria.get_filter("has_download") is None
+    assert build_filter_clauses(criteria) == []
 
 
 def test_query_params_are_generated_from_registered_filters():
@@ -85,6 +94,7 @@ def test_filter_clauses_are_built_from_registered_filters():
             "publisher": "City Publisher",
             "spatial_filter": "non-geospatial",
             "collection": "collection-id",
+            "has_download": "true",
         },
         route_context=MAIN_CONTEXT,
     )
@@ -96,6 +106,7 @@ def test_filter_clauses_are_built_from_registered_filters():
     assert {"term": {"keyword.normalized": "health"}} in clauses
     assert {"term": {"publisher.normalized": "city publisher"}} in clauses
     assert {"term": {"has_spatial": False}} in clauses
+    assert {"term": {"has_download": True}} in clauses
     assert {
         "nested": {
             "path": "organization",
@@ -147,6 +158,7 @@ def test_fixed_option_sections_are_built_by_filter_definitions():
         filters={
             "org_type": ["City Government"],
             "spatial_data": "geospatial",
+            "has_download": True,
         }
     )
 
@@ -159,6 +171,9 @@ def test_fixed_option_sections_are_built_by_filter_definitions():
     assert by_name["spatial_data"]["field_name"] == "spatial_filter"
     assert by_name["spatial_data"]["value"] == "geospatial"
     assert by_name["spatial_data"]["active_summary"] == "Geospatial only"
+    assert by_name["has_download"]["field_name"] == "has_download"
+    assert by_name["has_download"]["values"] == ["true"]
+    assert by_name["has_download"]["active_summary"] is not None
 
 
 def test_geography_section_exposes_template_fields_only():
@@ -202,6 +217,7 @@ def test_visible_filter_query_params_come_from_registered_sections():
         "spatial_geometry",
         "spatial_within",
         "geography_label",
+        "has_download",
     }
     assert "collection" not in visible_filter_query_params(MAIN_CONTEXT)
 


### PR DESCRIPTION
## Summary
- Ports [GSA/datagov_data_access#13](https://github.com/GSA/datagov_data_access/pull/13) into harvester's vendored `search/` package now that `datagov_data_access` was deprecated (never made it into the vendor snapshot before deprecation)
- Adds a `has_download` boolean field to the OpenSearch dataset document/mapping, computed from `dcat.distribution[].downloadURL` (DCAT-US 1.1/3.0 compatible; `accessURL`-only distributions do not count, per DCAT-US 3.0 semantics where `accessURL` is explicitly indirect access)
- Registers a new opt-in `has_download` search filter (single checkbox, off by default) rendered via the existing generic `checkbox_group` sidebar renderer

Addresses GSA/data.gov#6175. Companion PR in datagov-catalog: (link once opened).

## Test plan
- [x] `poetry run pytest tests/unit/search/test_search_filter_registry.py tests/unit/search/test_mappings.py tests/integration/search/test_documents.py` (74 passed)
- [x] `poetry run ruff check` / `poetry run black --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)