### PR TITLE
6208: Missing Identifier does not increase error number  

### DIFF
--- a/example_data/dcatus/dcatus_empty_identifier.json
+++ b/example_data/dcatus/dcatus_empty_identifier.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "http://www.example.gov/data.json",
+  "@type": "dcat:Catalog",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "identifier": "",
+      "contactPoint": {
+        "fn": "John Doe",
+        "hasEmail": "mailto:jdoe@example.gov"
+      },
+      "description": "Dataset with empty string identifier",
+      "title": "Empty Identifier Dataset",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    }
+  ]
+}

--- a/example_data/dcatus/dcatus_mixed_identifiers.json
+++ b/example_data/dcatus/dcatus_mixed_identifiers.json
@@ -1,0 +1,119 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "http://www.example.gov/data.json",
+  "@type": "dcat:Catalog",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "identifier": "valid-id-1",
+      "contactPoint": {
+        "fn": "John Doe",
+        "hasEmail": "mailto:jdoe@example.gov"
+      },
+      "description": "Dataset with valid identifier",
+      "title": "Valid Dataset One",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "contactPoint": {
+        "fn": "Jane Smith",
+        "hasEmail": "mailto:jsmith@example.gov"
+      },
+      "description": "Dataset without identifier",
+      "title": "Missing ID Dataset One",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "identifier": "valid-id-2",
+      "contactPoint": {
+        "fn": "Bob Johnson",
+        "hasEmail": "mailto:bjohnson@example.gov"
+      },
+      "description": "Another dataset with valid identifier",
+      "title": "Valid Dataset Two",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "identifier": "valid-id-3",
+      "contactPoint": {
+        "fn": "Alice Williams",
+        "hasEmail": "mailto:awilliams@example.gov"
+      },
+      "description": "Yet another dataset with valid identifier",
+      "title": "Valid Dataset Three",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "contactPoint": {
+        "fn": "Charlie Brown",
+        "hasEmail": "mailto:cbrown@example.gov"
+      },
+      "description": "Another dataset without identifier",
+      "title": "Missing ID Dataset Two",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "identifier": "valid-id-4",
+      "contactPoint": {
+        "fn": "Diana Prince",
+        "hasEmail": "mailto:dprince@example.gov"
+      },
+      "description": "Final dataset with valid identifier",
+      "title": "Valid Dataset Four",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "identifier": "valid-id-5",
+      "contactPoint": {
+        "fn": "Edward Norton",
+        "hasEmail": "mailto:enorton@example.gov"
+      },
+      "description": "Last dataset with valid identifier",
+      "title": "Valid Dataset Five",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    }
+  ]
+}

--- a/example_data/dcatus/dcatus_multiple_no_identifier.json
+++ b/example_data/dcatus/dcatus_multiple_no_identifier.json
@@ -1,0 +1,54 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "http://www.example.gov/data.json",
+  "@type": "dcat:Catalog",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "contactPoint": {
+        "fn": "John Doe",
+        "hasEmail": "mailto:jdoe@example.gov"
+      },
+      "description": "First dataset without identifier",
+      "title": "Dataset One",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "contactPoint": {
+        "fn": "Jane Smith",
+        "hasEmail": "mailto:jsmith@example.gov"
+      },
+      "description": "Second dataset without identifier",
+      "title": "Dataset Two",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    },
+    {
+      "contactPoint": {
+        "fn": "Bob Johnson",
+        "hasEmail": "mailto:bjohnson@example.gov"
+      },
+      "description": "Third dataset without identifier",
+      "title": "Dataset Three",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    }
+  ]
+}

--- a/example_data/dcatus/dcatus_whitespace_identifier.json
+++ b/example_data/dcatus/dcatus_whitespace_identifier.json
@@ -1,0 +1,25 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "http://www.example.gov/data.json",
+  "@type": "dcat:Catalog",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "identifier": "   ",
+      "contactPoint": {
+        "fn": "John Doe",
+        "hasEmail": "mailto:jdoe@example.gov"
+      },
+      "description": "Dataset with whitespace-only identifier",
+      "title": "Whitespace Identifier Dataset",
+      "accessLevel": "public",
+      "bureauCode": ["339:00"],
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Example Agency"
+      },
+      "keyword": ["test"]
+    }
+  ]
+}

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -397,6 +397,7 @@ class HarvestSource:
                     external_records.append(record)
 
             except NoIdentifierException:
+                self.update_job_record_count_by_action("errored")
                 continue
 
         self.external_records = external_records

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -623,6 +623,50 @@ def job_data_dcatus_no_identifier(source_data_dcatus_no_identifier: dict) -> dic
 
 
 @pytest.fixture
+def job_data_dcatus_multiple_no_identifier(
+    source_data_dcatus_multiple_no_identifier: dict,
+) -> dict:
+    return {
+        "id": "c9457afe-d5a3-48e3-ab97-2e9f728013a2",
+        "status": "new",
+        "harvest_source_id": source_data_dcatus_multiple_no_identifier["id"],
+    }
+
+
+@pytest.fixture
+def job_data_dcatus_mixed_identifiers(
+    source_data_dcatus_mixed_identifiers: dict,
+) -> dict:
+    return {
+        "id": "d9457afe-d5a3-48e3-ab97-2e9f728013a3",
+        "status": "new",
+        "harvest_source_id": source_data_dcatus_mixed_identifiers["id"],
+    }
+
+
+@pytest.fixture
+def job_data_dcatus_empty_identifier(
+    source_data_dcatus_empty_identifier: dict,
+) -> dict:
+    return {
+        "id": "e9457afe-d5a3-48e3-ab97-2e9f728013a4",
+        "status": "new",
+        "harvest_source_id": source_data_dcatus_empty_identifier["id"],
+    }
+
+
+@pytest.fixture
+def job_data_dcatus_whitespace_identifier(
+    source_data_dcatus_whitespace_identifier: dict,
+) -> dict:
+    return {
+        "id": "f9457afe-d5a3-48e3-ab97-2e9f728013a5",
+        "status": "new",
+        "harvest_source_id": source_data_dcatus_whitespace_identifier["id"],
+    }
+
+
+@pytest.fixture
 def job_data_waf_iso19115_2(source_data_waf_iso19115_2: dict) -> dict:
     return {
         "id": "83c431e6-0f53-4471-8003-b6afc0541101",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,6 +286,66 @@ def source_data_dcatus_no_identifier(organization_data: dict) -> dict:
 
 
 @pytest.fixture
+def source_data_dcatus_multiple_no_identifier(organization_data: dict) -> dict:
+    return {
+        "id": "e8f1b0d6-ecd7-4b5f-9e5d-9e2146e21f88",
+        "name": "Test Source (multiple missing identifiers)",
+        "notification_emails": ["email@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_multiple_no_identifier.json",
+        "schema_type": "dcatus1.1: federal",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
+def source_data_dcatus_mixed_identifiers(organization_data: dict) -> dict:
+    return {
+        "id": "f9f1b0d6-ecd7-4b5f-9e5d-9e2146e21f99",
+        "name": "Test Source (mixed valid and missing identifiers)",
+        "notification_emails": ["email@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_mixed_identifiers.json",
+        "schema_type": "dcatus1.1: federal",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
+def source_data_dcatus_empty_identifier(organization_data: dict) -> dict:
+    return {
+        "id": "a1f1b0d6-ecd7-4b5f-9e5d-9e2146e21faa",
+        "name": "Test Source (empty identifier)",
+        "notification_emails": ["email@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_empty_identifier.json",
+        "schema_type": "dcatus1.1: federal",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
+def source_data_dcatus_whitespace_identifier(organization_data: dict) -> dict:
+    return {
+        "id": "b2f1b0d6-ecd7-4b5f-9e5d-9e2146e21fbb",
+        "name": "Test Source (whitespace identifier)",
+        "notification_emails": ["email@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus_whitespace_identifier.json",
+        "schema_type": "dcatus1.1: federal",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
 def source_data_dcatus_cant_translate_spatial(organization_data: dict) -> dict:
     return {
         "id": "b3360061-bdf6-4fb5-885f-805d90726f92",

--- a/tests/integration/harvest/test_missing_identifier_error_count.py
+++ b/tests/integration/harvest/test_missing_identifier_error_count.py
@@ -1,0 +1,160 @@
+from harvester.harvest import HarvestSource
+
+
+class TestMissingIdentifierErrorCount:
+    def test_missing_identifier_increments_error_count(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_no_identifier,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        assert harvest_source.reporter.errored == 1
+
+    def test_missing_identifier_persists_error_count_to_job(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_no_identifier,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        stored_job = interface.get_harvest_job(harvest_job.id)
+        assert stored_job.records_errored == 1
+
+    def test_dcatus3_object_identifier_without_atid_increments_error_count(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus3_0_no_identifier,
+        job_data_dcatus3_0_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus3_0_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus3_0_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        assert harvest_source.reporter.errored == 1
+
+    def test_dcatus3_object_identifier_without_atid_persists_error_count(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus3_0_no_identifier,
+        job_data_dcatus3_0_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus3_0_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus3_0_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        stored_job = interface.get_harvest_job(harvest_job.id)
+        assert stored_job.records_errored == 1
+
+    def test_multiple_missing_identifiers_count_all_errors(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_multiple_no_identifier,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_multiple_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        assert harvest_source.reporter.errored == 3
+
+    def test_multiple_missing_identifiers_persist_total_error_count(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_multiple_no_identifier,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_multiple_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        stored_job = interface.get_harvest_job(harvest_job.id)
+        assert stored_job.records_errored == 3
+
+    def test_mixed_valid_and_missing_identifiers_counts_only_errors(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_mixed_identifiers,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_mixed_identifiers)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        assert harvest_source.reporter.errored == 2
+        assert len(harvest_source.external_records) == 5
+
+    def test_empty_string_identifier_increments_error_count(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_empty_identifier,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_empty_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        assert harvest_source.reporter.errored == 1
+
+    def test_whitespace_only_identifier_increments_error_count(
+        self,
+        interface,
+        organization_data,
+        source_data_dcatus_whitespace_identifier,
+        job_data_dcatus_no_identifier,
+    ):
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus_whitespace_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+
+        harvest_source = HarvestSource(harvest_job.id)
+        harvest_source.acquire_data_sources()
+        harvest_source.filter_datasets_with_no_identifier()
+
+        assert harvest_source.reporter.errored == 1

--- a/tests/integration/harvest/test_missing_identifier_error_count.py
+++ b/tests/integration/harvest/test_missing_identifier_error_count.py
@@ -77,11 +77,11 @@ class TestMissingIdentifierErrorCount:
         interface,
         organization_data,
         source_data_dcatus_multiple_no_identifier,
-        job_data_dcatus_no_identifier,
+        job_data_dcatus_multiple_no_identifier,
     ):
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_multiple_no_identifier)
-        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_multiple_no_identifier)
 
         harvest_source = HarvestSource(harvest_job.id)
         harvest_source.acquire_data_sources()
@@ -94,11 +94,11 @@ class TestMissingIdentifierErrorCount:
         interface,
         organization_data,
         source_data_dcatus_multiple_no_identifier,
-        job_data_dcatus_no_identifier,
+        job_data_dcatus_multiple_no_identifier,
     ):
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_multiple_no_identifier)
-        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_multiple_no_identifier)
 
         harvest_source = HarvestSource(harvest_job.id)
         harvest_source.acquire_data_sources()
@@ -112,11 +112,11 @@ class TestMissingIdentifierErrorCount:
         interface,
         organization_data,
         source_data_dcatus_mixed_identifiers,
-        job_data_dcatus_no_identifier,
+        job_data_dcatus_mixed_identifiers,
     ):
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_mixed_identifiers)
-        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_mixed_identifiers)
 
         harvest_source = HarvestSource(harvest_job.id)
         harvest_source.acquire_data_sources()
@@ -130,11 +130,11 @@ class TestMissingIdentifierErrorCount:
         interface,
         organization_data,
         source_data_dcatus_empty_identifier,
-        job_data_dcatus_no_identifier,
+        job_data_dcatus_empty_identifier,
     ):
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_empty_identifier)
-        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_empty_identifier)
 
         harvest_source = HarvestSource(harvest_job.id)
         harvest_source.acquire_data_sources()
@@ -147,11 +147,11 @@ class TestMissingIdentifierErrorCount:
         interface,
         organization_data,
         source_data_dcatus_whitespace_identifier,
-        job_data_dcatus_no_identifier,
+        job_data_dcatus_whitespace_identifier,
     ):
         interface.add_organization(organization_data)
         interface.add_harvest_source(source_data_dcatus_whitespace_identifier)
-        harvest_job = interface.add_harvest_job(job_data_dcatus_no_identifier)
+        harvest_job = interface.add_harvest_job(job_data_dcatus_whitespace_identifier)
 
         harvest_source = HarvestSource(harvest_job.id)
         harvest_source.acquire_data_sources()

--- a/tests/unit/test_harvest_identifier.py
+++ b/tests/unit/test_harvest_identifier.py
@@ -17,6 +17,7 @@ def harvest_source_for_identifier_filter():
         id="error-record-id",
         identifier="Dataset With Invalid Object Identifier",
     )
+    source._reporter = MagicMock()
     return source
 
 
@@ -36,6 +37,9 @@ class TestFilterDatasetsWithNoIdentifier:
 
         assert harvest_source_for_identifier_filter.external_records == []
         harvest_source_for_identifier_filter._db_interface.add_harvest_record.assert_called_once()
+        harvest_source_for_identifier_filter._reporter.update.assert_called_once_with(
+            "errored"
+        )
 
     def test_keeps_object_identifier_with_atid(
         self, harvest_source_for_identifier_filter


### PR DESCRIPTION
PR for fixing the bug in [Issue #6208](https://github.com/GSA/data.gov/issues/6208). When a dataset is missing it's identifier field, this rightfully causes an error. But that error isn't reported in the `error count` section of the dataset page. This code change is to fix that to display the error count accurately. 

