### PR TITLE
Let the database cascade harvest source deletes

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -72,6 +72,7 @@ class Organization(Base):
         "HarvestSource",
         backref=backref("org", lazy="joined"),
         cascade="all, delete-orphan",
+        passive_deletes=True,
         lazy=True,
     )
 
@@ -92,7 +93,7 @@ class HarvestSource(Base):
 
     organization_id = Column(
         String(36),
-        ForeignKey("organization.id"),
+        ForeignKey("organization.id", ondelete="CASCADE"),
         nullable=False,
     )
 
@@ -129,6 +130,7 @@ class HarvestSource(Base):
         "HarvestJob",
         backref=backref("source", lazy="joined"),
         cascade="all, delete-orphan",
+        passive_deletes=True,
         lazy=True,
     )
 
@@ -156,9 +158,11 @@ Organization.source_count = column_property(
 class HarvestJob(Base):
     __tablename__ = "harvest_job"
 
+    __table_args__ = (Index("ix_harvest_job_harvest_source_id", "harvest_source_id"),)
+
     harvest_source_id = Column(
         String(36),
-        ForeignKey("harvest_source.id"),
+        ForeignKey("harvest_source.id", ondelete="CASCADE"),
         nullable=False,
     )
 
@@ -188,6 +192,7 @@ class HarvestJob(Base):
         "HarvestJobError",
         backref=backref("job", lazy="joined"),
         cascade="all, delete-orphan",
+        passive_deletes=True,
         lazy=True,
     )
 
@@ -195,6 +200,7 @@ class HarvestJob(Base):
         "HarvestRecord",
         backref="job",
         cascade="all, delete-orphan",
+        passive_deletes=True,
         lazy=True,
     )
 
@@ -202,6 +208,7 @@ class HarvestJob(Base):
         "HarvestRecordError",
         backref="job",
         cascade="all, delete-orphan",
+        passive_deletes=True,
         lazy=True,
     )
 
@@ -213,13 +220,13 @@ class HarvestRecord(Base):
 
     harvest_job_id = Column(
         String(36),
-        ForeignKey("harvest_job.id"),
+        ForeignKey("harvest_job.id", ondelete="CASCADE"),
         nullable=False,
     )
 
     harvest_source_id = Column(
         String(36),
-        ForeignKey("harvest_source.id"),
+        ForeignKey("harvest_source.id", ondelete="CASCADE"),
         nullable=False,
     )
 
@@ -245,6 +252,10 @@ class HarvestRecord(Base):
         index=True,
     )
 
+    # No delete cascade here on purpose: record errors outlive their record so
+    # error history survives record cleanup (see test_harvest_record_error_remains).
+    # harvest_record_id is nullable and stays SET NULL; the errors are still
+    # cleaned up when the owning job or source goes away, via harvest_job_id.
     errors = relationship("HarvestRecordError", backref="record", lazy=True)
 
     __table_args__ = (
@@ -306,21 +317,27 @@ class Dataset(Base):
     popularity = Column(Integer, server_default="0")
     last_harvested_date = Column(DateTime, index=True)
 
+    # The `datasets` / `dataset` backrefs below are the one-to-many side, so
+    # passive_deletes belongs on the backref. Without it SQLAlchemy tries to NULL
+    # these non-nullable FKs when a parent is deleted, raising IntegrityError.
+    # "all" rather than True so a warm collection is handled by the database too,
+    # and without delete-orphan, which would delete a row merely reassigned to a
+    # different parent.
     organization = relationship(
         "Organization",
-        backref=backref("datasets", lazy=True),
+        backref=backref("datasets", lazy=True, passive_deletes="all"),
         lazy="joined",
     )
 
     harvest_source = relationship(
         "HarvestSource",
-        backref=backref("datasets", lazy=True),
+        backref=backref("datasets", lazy=True, passive_deletes="all"),
         lazy="joined",
     )
 
     harvest_record = relationship(
         "HarvestRecord",
-        backref=backref("dataset", uselist=False, lazy=True),
+        backref=backref("dataset", uselist=False, lazy=True, passive_deletes="all"),
         lazy="joined",
         uselist=False,
     )
@@ -346,7 +363,7 @@ class HarvestJobError(Error):
 
     harvest_job_id = Column(
         String(36),
-        ForeignKey("harvest_job.id"),
+        ForeignKey("harvest_job.id", ondelete="CASCADE"),
         nullable=False,
     )
 
@@ -356,15 +373,17 @@ class HarvestJobError(Error):
 class HarvestRecordError(Error):
     __tablename__ = "harvest_record_error"
 
+    # SET NULL, not CASCADE: a record error outlives the record it describes.
+    # Deleting a job or source still removes it via harvest_job_id's CASCADE.
     harvest_record_id = Column(
         String,
-        ForeignKey("harvest_record.id"),
+        ForeignKey("harvest_record.id", ondelete="SET NULL"),
         nullable=True,
     )
 
     harvest_job_id = Column(
         String(36),
-        ForeignKey("harvest_job.id"),
+        ForeignKey("harvest_job.id", ondelete="CASCADE"),
         nullable=False,
     )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,13 @@ services:
         POSTGRES_USER: ${DATABASE_USER}
         POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
         POSTGRES_DB: ${DATABASE_NAME}
+      # PGPORT above makes postgres listen on DATABASE_PORT, so the container
+      # side of this mapping has to be DATABASE_PORT too -- not 5432. With
+      # `make up` (DATABASE_PORT=5433) the old "5433:5432" pointed the host at
+      # a port nothing was listening on, leaving this db unreachable from
+      # outside the compose network.
       ports:
-        - "${DATABASE_PORT}:5432"
+        - "${DATABASE_PORT}:${DATABASE_PORT}"
       volumes:
         - postgres_data:/var/lib/postgresql/data
       healthcheck:

--- a/migrations/versions/b3f7a91c24de_add_fk_delete_cascades.py
+++ b/migrations/versions/b3f7a91c24de_add_fk_delete_cascades.py
@@ -1,0 +1,132 @@
+"""Push harvest source/job/record delete cascades into the database.
+
+Deleting a harvest source used to be done row-by-row by SQLAlchemy, which loaded
+every child harvest_record (including source_raw) into the web worker and OOM-killed
+it on large sources. With ON DELETE CASCADE in place the ORM can set
+passive_deletes=True and let Postgres do the whole cascade in one statement.
+
+harvest_record_error.harvest_record_id becomes SET NULL rather than CASCADE on
+purpose: record errors outlive the record they describe. They are still cleaned up
+when the owning job or source goes away, via harvest_job_id's CASCADE.
+
+Each constraint is re-added as NOT VALID and validated separately. Adding a normal
+FK takes ACCESS EXCLUSIVE while it scans the whole child table; NOT VALID skips that
+scan, and the later VALIDATE CONSTRAINT only needs SHARE UPDATE EXCLUSIVE. That
+matters because harvest_record is large in prod.
+
+Revision ID: b3f7a91c24de
+Revises: b3f4a9c1d7e2
+Create Date: 2026-07-29 16:05:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3f7a91c24de"
+down_revision = "b3f4a9c1d7e2"
+branch_labels = None
+depends_on = None
+
+
+# (constraint, table, column, referenced table, referenced column)
+FOREIGN_KEYS = [
+    (
+        "harvest_source_organization_id_fkey",
+        "harvest_source",
+        "organization_id",
+        "organization",
+        "id",
+    ),
+    (
+        "harvest_job_harvest_source_id_fkey",
+        "harvest_job",
+        "harvest_source_id",
+        "harvest_source",
+        "id",
+    ),
+    (
+        "harvest_record_harvest_job_id_fkey",
+        "harvest_record",
+        "harvest_job_id",
+        "harvest_job",
+        "id",
+    ),
+    (
+        "harvest_record_harvest_source_id_fkey",
+        "harvest_record",
+        "harvest_source_id",
+        "harvest_source",
+        "id",
+    ),
+    (
+        "harvest_job_error_harvest_job_id_fkey",
+        "harvest_job_error",
+        "harvest_job_id",
+        "harvest_job",
+        "id",
+    ),
+    (
+        "harvest_record_error_harvest_job_id_fkey",
+        "harvest_record_error",
+        "harvest_job_id",
+        "harvest_job",
+        "id",
+    ),
+]
+
+# Deleting a harvest_record must not delete its errors, only orphan them.
+SET_NULL_KEYS = [
+    (
+        "harvest_record_error_harvest_record_id_fkey",
+        "harvest_record_error",
+        "harvest_record_id",
+        "harvest_record",
+        "id",
+    ),
+]
+
+
+def _replace_fk(constraint, table, column, ref_table, ref_column, on_delete):
+    op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint}")
+    op.execute(
+        f"ALTER TABLE {table} ADD CONSTRAINT {constraint} "
+        f"FOREIGN KEY ({column}) REFERENCES {ref_table} ({ref_column}) "
+        f"ON DELETE {on_delete} NOT VALID"
+    )
+    op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")
+
+
+def upgrade():
+    # The cascade from harvest_source -> harvest_job traverses this FK, and it was
+    # the one lookup path without an index (see 1f6d2c9a8b3e for the others).
+    with op.get_context().autocommit_block():
+        op.execute("""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS
+            ix_harvest_job_harvest_source_id
+            ON harvest_job (harvest_source_id)
+            """)
+
+    for constraint, table, column, ref_table, ref_column in FOREIGN_KEYS:
+        _replace_fk(constraint, table, column, ref_table, ref_column, "CASCADE")
+
+    for constraint, table, column, ref_table, ref_column in SET_NULL_KEYS:
+        _replace_fk(constraint, table, column, ref_table, ref_column, "SET NULL")
+
+
+def downgrade():
+    for constraint, table, column, ref_table, ref_column in (
+        FOREIGN_KEYS + SET_NULL_KEYS
+    ):
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint}")
+        op.execute(
+            f"ALTER TABLE {table} ADD CONSTRAINT {constraint} "
+            f"FOREIGN KEY ({column}) REFERENCES {ref_table} ({ref_column}) NOT VALID"
+        )
+        op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")
+
+    with op.get_context().autocommit_block():
+        op.execute("""
+            DROP INDEX CONCURRENTLY IF EXISTS
+            ix_harvest_job_harvest_source_id
+            """)

--- a/tests/integration/database/test_harvest_source.py
+++ b/tests/integration/database/test_harvest_source.py
@@ -1,3 +1,9 @@
+from sqlalchemy import event, text
+
+from database.models import Dataset, HarvestRecord
+from tests.conftest import create_record_for_dataset, dataset_payload
+
+
 def test_add_harvest_source(interface, organization_data, source_data_dcatus):
     interface.add_organization(organization_data)
     source = interface.add_harvest_source(source_data_dcatus)
@@ -132,6 +138,145 @@ def test_delete_harvest_source(
 
     deleted_source = interface.get_harvest_source(source.id)
     assert deleted_source is None
+
+
+def test_delete_harvest_source_does_not_load_children(
+    interface,
+    organization_data,
+    source_data_dcatus,
+    job_data_dcatus,
+):
+    """Deleting a source must not load or delete child rows one at a time.
+
+    Regression test for an OOM: with passive_deletes=False SQLAlchemy pulled every
+    harvest_record (including source_raw) into memory and emitted one DELETE per
+    row, killing the web worker on large sources. Postgres now does the cascade.
+    """
+    interface.add_organization(organization_data)
+    source = interface.add_harvest_source(source_data_dcatus)
+    job_data_dcatus["harvest_source_id"] = source.id
+    interface.add_harvest_job(job_data_dcatus)
+
+    for i in range(50):
+        interface.add_harvest_record(
+            {
+                "identifier": f"bulk-delete-{i}",
+                "harvest_job_id": job_data_dcatus["id"],
+                "harvest_source_id": source.id,
+                "action": "delete",  # so the 409 guard allows the delete
+                "status": "success",
+                "source_raw": "x" * 1000,
+            }
+        )
+
+    assert (
+        interface.db.query(HarvestRecord).filter_by(harvest_source_id=source.id).count()
+        == 50
+    )
+
+    statements = []
+
+    def record_statement(conn, cursor, statement, params, context, executemany):
+        statements.append(" ".join(statement.split()))
+
+    engine = interface.db.get_bind()
+    event.listen(engine, "before_cursor_execute", record_statement)
+    try:
+        message, status = interface.delete_harvest_source(source.id)
+    finally:
+        event.remove(engine, "before_cursor_execute", record_statement)
+
+    assert status == 200
+
+    # Match on the statement text, not the statement count. SQLAlchemy batches
+    # its per-row deletes into a single executemany, so counting would pass even
+    # in the broken configuration this test exists to catch.
+    child_deletes = [
+        s
+        for s in statements
+        if s.upper().startswith("DELETE FROM HARVEST_RECORD")
+        or s.upper().startswith("DELETE FROM HARVEST_JOB")
+    ]
+    assert child_deletes == [], f"expected DB-side cascade, got: {child_deletes}"
+
+    interface.db.expire_all()
+    assert interface.get_harvest_source(source.id) is None
+    assert (
+        interface.db.query(HarvestRecord).filter_by(harvest_source_id=source.id).count()
+        == 0
+    )
+
+
+def test_delete_harvest_source_with_datasets(
+    interface,
+    organization_data,
+    source_data_dcatus,
+    job_data_dcatus,
+):
+    """A source that has dataset rows must delete cleanly.
+
+    The dataset FKs are non-nullable with ON DELETE CASCADE, but without
+    passive_deletes on the `datasets` backref SQLAlchemy tried to NULL them and
+    raised IntegrityError instead of letting Postgres cascade.
+    """
+    record = create_record_for_dataset(
+        interface,
+        organization_data,
+        source_data_dcatus,
+        job_data_dcatus,
+        identifier="delete-source-with-dataset",
+    )
+    slug = "delete-source-with-dataset"
+    interface.insert_dataset(
+        dataset_payload(slug, record, organization_data, source_data_dcatus)
+    )
+
+    source_id = source_data_dcatus["id"]
+    assert (
+        interface.db.query(Dataset).filter_by(harvest_source_id=source_id).count() == 1
+    )
+
+    # latest record action is "create", so clear it first to pass the 409 guard
+    interface.update_harvest_record(record.id, {"action": "delete"})
+
+    message, status = interface.delete_harvest_source(source_id)
+    assert status == 200
+
+    interface.db.expire_all()
+    assert interface.get_harvest_source(source_id) is None
+    assert (
+        interface.db.query(Dataset).filter_by(harvest_source_id=source_id).count() == 0
+    )
+
+
+def test_harvest_fk_delete_actions(interface):
+    """The schema, not the ORM, is what has to carry the cascade.
+
+    Integration tests build their schema from the models via create_all, so this
+    pins the ondelete rules the OOM fix depends on. harvest_record_error's link to
+    its record is deliberately SET NULL ("n") -- record errors outlive the record
+    they describe -- while everything else cascades ("c").
+    """
+    expected = {
+        "harvest_source_organization_id_fkey": "c",
+        "harvest_job_harvest_source_id_fkey": "c",
+        "harvest_record_harvest_job_id_fkey": "c",
+        "harvest_record_harvest_source_id_fkey": "c",
+        "harvest_job_error_harvest_job_id_fkey": "c",
+        "harvest_record_error_harvest_job_id_fkey": "c",
+        "harvest_record_error_harvest_record_id_fkey": "n",
+    }
+
+    rows = interface.db.execute(
+        text("""
+            SELECT conname, confdeltype
+            FROM pg_constraint
+            WHERE contype = 'f' AND conname = ANY(:names)
+        """),
+        {"names": list(expected)},
+    ).all()
+
+    assert dict(rows) == expected
 
 
 def test_harvest_source_by_jobid(

--- a/tests/playwright/test_harvest_source_delete_cascade.py
+++ b/tests/playwright/test_harvest_source_delete_cascade.py
@@ -1,0 +1,278 @@
+"""Deleting a "cleared" harvest source must cascade its child rows.
+
+The other delete tests cover a source with no records at all, or the 409
+refusal when a source still has live records. Neither reaches the cascade:
+`delete_harvest_source` counts only the *latest* synced record per identifier
+whose action is not "delete", so a source that has been cleared reports zero
+records while its harvest_record / harvest_record_error rows are all still in
+the table. That is the path that OOM-killed the web worker in production, and
+the path ON DELETE CASCADE plus passive_deletes is meant to fix.
+
+The fixture seeds a dataset as well as records. Datasets are what make this a
+regression test rather than a smoke test: `dataset.harvest_source_id` is NOT
+NULL, so without passive_deletes on the backref SQLAlchemy tries to NULL it
+and the delete fails with IntegrityError instead of cascading.
+
+Rows are committed on their own connection because the app under test is a
+separate process; the shared `session` fixture rolls back, so anything seeded
+through it would be invisible to the browser.
+
+They also have to land in the *app's* database, which is not the one
+`DATABASE_URI` names. `make up` runs two stacks: the app under test with its db
+on APP_DATABASE_PORT, and a second db on DATABASE_PORT that host-side pytest
+owns and that the autouse `dbapp` fixture drops and recreates per test. Seeding
+through DATABASE_URI would write to that second db, so the browser would 404 on
+the source and never render a Delete button.
+"""
+
+import os
+import uuid
+
+import pytest
+from playwright.sync_api import expect
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+
+RECORD_COUNT = 25
+
+# Host port of the db belonging to the app under test. Kept in step with the
+# `DATABASE_PORT=5433` override in the Makefile's `up` target.
+APP_DATABASE_PORT = int(os.getenv("APP_DATABASE_PORT", "5433"))
+
+
+@pytest.fixture()
+def engine():
+    """Engine on the app-under-test's db, not the host pytest db.
+
+    Credentials, host and database name are reused from DATABASE_URI; only the
+    port differs between the two stacks.
+    """
+    database_uri = os.getenv("DATABASE_URI")
+    if not database_uri:
+        pytest.skip("DATABASE_URI is required to seed cascade fixtures")
+
+    engine = create_engine(make_url(database_uri).set(port=APP_DATABASE_PORT))
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def cleared_source(engine):
+    """A source whose records were all cleared, with errors and a dataset.
+
+    Every record's latest action is "delete", so the UI's record count reports
+    zero and the Delete button is allowed through to the cascade.
+    """
+    org_id = str(uuid.uuid4())
+    source_id = str(uuid.uuid4())
+    job_id = str(uuid.uuid4())
+    suffix = source_id[:8]
+    source_name = f"Cascade Source {suffix}"
+    record_ids: list[str] = []
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO organization (id, name, slug) VALUES (:id, :name, :slug)"
+            ),
+            {
+                "id": org_id,
+                "name": f"Cascade Org {suffix}",
+                "slug": f"cascade-{suffix}",
+            },
+        )
+        conn.execute(
+            text("""
+                INSERT INTO harvest_source (
+                    id, name, notification_emails, organization_id, frequency,
+                    notification_frequency, url, schema_type, source_type
+                ) VALUES (
+                    :id, :name, '{email@example.com}', :org_id, 'daily',
+                    'always', :url, 'dcatus1.1: federal', 'document'
+                )
+            """),
+            {
+                "id": source_id,
+                "name": source_name,
+                "org_id": org_id,
+                "url": f"http://localhost:80/dcatus/cascade-{suffix}.json",
+            },
+        )
+        conn.execute(
+            text(
+                "INSERT INTO harvest_job (id, harvest_source_id, status) "
+                "VALUES (:id, :source_id, 'complete')"
+            ),
+            {"id": job_id, "source_id": source_id},
+        )
+
+        for index in range(RECORD_COUNT):
+            record_id = str(uuid.uuid4())
+            record_ids.append(record_id)
+            conn.execute(
+                text("""
+                    INSERT INTO harvest_record (
+                        id, harvest_job_id, harvest_source_id, identifier,
+                        source_raw, status, action, date_created
+                    ) VALUES (
+                        :id, :job_id, :source_id, :identifier,
+                        :source_raw, 'success', 'delete', now()
+                    )
+                """),
+                {
+                    "id": record_id,
+                    "job_id": job_id,
+                    "source_id": source_id,
+                    "identifier": f"cascade-identifier-{index}",
+                    "source_raw": '{"title": "cleared"}',
+                },
+            )
+            conn.execute(
+                text("""
+                    INSERT INTO harvest_record_error (
+                        id, harvest_record_id, harvest_job_id, message, type
+                    ) VALUES (
+                        :id, :record_id, :job_id, 'record is invalid',
+                        'ValidationException'
+                    )
+                """),
+                {
+                    "id": str(uuid.uuid4()),
+                    "record_id": record_id,
+                    "job_id": job_id,
+                },
+            )
+
+        # dataset.harvest_source_id / .harvest_record_id are NOT NULL, so this
+        # row is what catches a missing passive_deletes on the backref.
+        conn.execute(
+            text("""
+                INSERT INTO dataset (
+                    id, slug, dcat, organization_id, harvest_source_id,
+                    harvest_record_id, popularity
+                ) VALUES (
+                    :id, :slug, '{}', :org_id, :source_id, :record_id, 0
+                )
+            """),
+            {
+                "id": str(uuid.uuid4()),
+                "slug": f"cascade-dataset-{suffix}",
+                "org_id": org_id,
+                "source_id": source_id,
+                "record_id": record_ids[0],
+            },
+        )
+
+    yield {"source_id": source_id, "org_id": org_id, "name": source_name}
+
+    # The test deletes the source itself, so normally there is nothing left to
+    # do. Tear down child-first anyway rather than leaning on ON DELETE CASCADE:
+    # this fixture has to clean up even when the cascade under test is missing.
+    with engine.begin() as conn:
+        conn.execute(
+            text("DELETE FROM dataset WHERE harvest_source_id = :id"),
+            {"id": source_id},
+        )
+        conn.execute(
+            text("""
+                DELETE FROM harvest_record_error
+                WHERE harvest_record_id IN (
+                    SELECT id FROM harvest_record WHERE harvest_source_id = :id
+                )
+            """),
+            {"id": source_id},
+        )
+        conn.execute(
+            text("DELETE FROM harvest_record_error WHERE harvest_job_id = :id"),
+            {"id": job_id},
+        )
+        conn.execute(
+            text("DELETE FROM harvest_record WHERE harvest_source_id = :id"),
+            {"id": source_id},
+        )
+        conn.execute(
+            text("DELETE FROM harvest_job_error WHERE harvest_job_id = :id"),
+            {"id": job_id},
+        )
+        conn.execute(
+            text("DELETE FROM harvest_job WHERE harvest_source_id = :id"),
+            {"id": source_id},
+        )
+        conn.execute(
+            text("DELETE FROM harvest_source WHERE id = :id"), {"id": source_id}
+        )
+        conn.execute(text("DELETE FROM organization WHERE id = :id"), {"id": org_id})
+
+
+def _child_row_counts(engine, source_id):
+    with engine.connect() as conn:
+        return {
+            "sources": conn.execute(
+                text("SELECT count(*) FROM harvest_source WHERE id = :id"),
+                {"id": source_id},
+            ).scalar(),
+            "jobs": conn.execute(
+                text("SELECT count(*) FROM harvest_job WHERE harvest_source_id = :id"),
+                {"id": source_id},
+            ).scalar(),
+            "records": conn.execute(
+                text(
+                    "SELECT count(*) FROM harvest_record "
+                    "WHERE harvest_source_id = :id"
+                ),
+                {"id": source_id},
+            ).scalar(),
+            "record_errors": conn.execute(
+                text("""
+                    SELECT count(*)
+                    FROM harvest_record_error error
+                    JOIN harvest_record record
+                        ON error.harvest_record_id = record.id
+                    WHERE record.harvest_source_id = :id
+                """),
+                {"id": source_id},
+            ).scalar(),
+            "datasets": conn.execute(
+                text("SELECT count(*) FROM dataset WHERE harvest_source_id = :id"),
+                {"id": source_id},
+            ).scalar(),
+        }
+
+
+class TestHarvestSourceDeleteCascade:
+    def test_delete_cleared_source_cascades_children(
+        self, authed_page, engine, cleared_source
+    ):
+        source_id = cleared_source["source_id"]
+
+        before = _child_row_counts(engine, source_id)
+        assert before == {
+            "sources": 1,
+            "jobs": 1,
+            "records": RECORD_COUNT,
+            "record_errors": RECORD_COUNT,
+            "datasets": 1,
+        }
+
+        authed_page.goto(f"/harvest_source/{source_id}")
+
+        # Assert positively that the page found the seeded source before reaching
+        # for the Delete button. If the fixture ever seeds a db the app isn't
+        # reading, the button is simply absent and a bare click would fail as an
+        # opaque locator timeout rather than naming the real problem.
+        expect(authed_page.locator("h1")).to_have_text(cleared_source["name"])
+
+        authed_page.once("dialog", lambda dialog: dialog.accept())
+        authed_page.get_by_role("button", name="Delete", exact=True).click()
+
+        expect(authed_page.locator(".usa-alert--warning")).to_contain_text(
+            [f"Deleted harvest source with ID:{source_id} successfully"]
+        )
+
+        assert _child_row_counts(engine, source_id) == {
+            "sources": 0,
+            "jobs": 0,
+            "records": 0,
+            "record_errors": 0,
+            "datasets": 0,
+        }


### PR DESCRIPTION
## About

Deleting a harvest source on staging returned 502 and the source was never removed.

Every child relationship had the default `passive_deletes=False`, which stops SQLAlchemy from letting Postgres do the cascade: it loads every child row into Python and emits one `DELETE` per row. On staging source `99c4e78b` that is **44,694 `harvest_record` rows / 582 MB of `source_raw`** plus 44,697 `harvest_record_error` rows, into a 1 GB instance running 3 workers. The kernel OOM-killed the worker — confirmed in staging logs as `Worker (pid:175) was sent SIGKILL!` with **no preceding `WORKER TIMEOUT`**, which rules out gunicorn's 120s timeout path. The transaction never committed, so the source stayed and the dropped connection became a 502.

This adds `ON DELETE CASCADE` to the schema and `passive_deletes=True` to the ORM, so the whole delete is one statement with bounded memory at any source size.

### Second bug fixed on the same path

The `Dataset` backrefs (`datasets`, `dataset`) had no delete handling while their FK columns are `nullable=False`, so SQLAlchemy tried to NULL them:

```
UPDATE dataset SET harvest_source_id=NULL ... -> NotNullViolation
```

So deleting a source that **had** datasets failed with `IntegrityError` rather than OOMing. `99c4e78b` had `datasets = 0`, which is why it OOM'd instead.

## This combines two upstream PRs

The fix was originally split across two repos because the models lived in `datagov_data_access`. They are now back in this repo and that dependency is gone, so both halves land here:

- GSA/datagov_data_access#9 (merged) — the ORM half, now `database/models.py`
- GSA/datagov-harvester#793 — the migration, ported unchanged

**Both halves are required.** `flask db check` fails on either one alone — Alembic compares FK `ondelete` on Postgres, so models-only reports 15 diffs and migration-only reports the inverse. The migration alone is safe to deploy but does not fix the OOM.

Not ported: #793's `pyproject.toml` pin bump, since `datagov-data-access` is no longer a dependency.

### One deviation from upstream, worth a look

The three `Dataset` backrefs use `passive_deletes="all"` rather than upstream's `cascade="all, delete-orphan", passive_deletes=True`. Both fix the `IntegrityError`; `delete-orphan` additionally means removing a `Dataset` from a collection, or reassigning its parent, deletes the row — a rule nothing here needs. Nothing mutates these collections today (`.datasets` appears only as reads in `view_source_data.html`).

### Two deliberate non-changes

`harvest_record_error.harvest_record_id` uses `ON DELETE SET NULL`, not `CASCADE`. Record errors intentionally outlive the record they describe — `test_harvest_record_error_remains` and `test_delete_outdated_records` both assert this. They are still cleaned up when the owning job or source goes away, via `harvest_job_id`'s cascade.

The 409 guard is left as-is. It counts only latest-non-deleted records, so a cleared source reports 0 while still holding 44k rows — which is what let this delete through. Harmless now that the DB does the cascade quickly.

### Lock safety

Each constraint is dropped and re-added `NOT VALID`, then validated separately. A plain FK add holds `ACCESS EXCLUSIVE` while it scans the entire child table; `VALIDATE CONSTRAINT` only needs `SHARE UPDATE EXCLUSIVE`. That matters because `harvest_record` is large in prod. The new index uses `CONCURRENTLY` in an `autocommit_block`, per `1f6d2c9a8b3e`.

Also adds `ix_harvest_job_harvest_source_id`, the one cascade lookup path without an index. This was **not** a cause of the 502 — that seq scan measures 3.4 ms — but an unindexed cascade would bite at prod scale.

### Compose port fix

`PGPORT` makes postgres listen on `DATABASE_PORT`, but the mapping hardcoded 5432 on the container side, so under `make up` (`DATABASE_PORT=5433`) that db was unreachable from the host — which blocks the e2e test from seeding. A no-op wherever `DATABASE_PORT=5432`, including both CI workflows. This does not revisit `dbf8fba`; the two compose projects stay separate.

## Testing

**Cascade works.** Deleting a source with 1 job + 500 records + 500 record errors + 1 job error + 1 dataset, in a rolled-back transaction — one statement:

```
before | jobs 1 | recs 500 | rerr 500 | jerr 1 | ds 1
DELETE 1
after  | jobs 0 | recs 0   | rerr 0   | jerr 0 | ds 0
```

`SET NULL` verified both ways: deleting only the record keeps its error (orphaned, `harvest_record_id IS NULL`); deleting the source then removes it.

**Migration round-trips.** Full 21-revision chain → head `b3f7a91c24de` → downgrade → re-upgrade, clean. Resulting state: six FKs `c`, `harvest_record_error_harvest_record_id_fkey` `n`, all validated, index present. `flask db check` reports no operations in-container.

**Negative control** — the check that makes these tests mean anything. With `database/models.py` reverted, all four new tests fail, and for the right reasons:

```
does_not_load_children: DELETE FROM harvest_record WHERE id = %(id)s   <- per-row
with_datasets:          NotNullViolation on dataset.harvest_source_id
```

The e2e failure reproduces the production symptom exactly: `Failed to delete harvest source :: IntegrityError ... NotNullViolation`.

**No regressions**, failure lists diffed against reverted baselines rather than compared by count:

| suite | baseline | with change |
|---|---|---|
| `tests/integration` | 64 failed | identical set |
| `tests/playwright` | 9 failed | identical set |
| `tests/unit` | 345 passed | 345 passed |
| `tests/scripts` | 24 passed | 24 passed |

Pre-existing failures are environmental (transformer/OpenSearch `ConnectionError`) and unrelated glossary/mobile-drawer tests. Ruff clean on all changed files.

## Follow-ups not in scope

- **Background worker.** Even a correct cascade blocks an HTTP worker for the duration. A CF task, like the existing harvest jobs, is the right long-term shape.
- **Staging source `99c4e78b-34e1-4c4b-a8fe-920489f4e2d1`** is still stuck and does not need to wait for this — it can be cleared now with explicit child-first deletes in a transaction, then `VACUUM (ANALYZE) harvest_record;`.
- `synced=True` at `database/interface.py:239` is silently ignored; nothing reads that kwarg.
- `docs/developer.md:20-27,49-57` still documents the single-stack world from the reverted `23f1879`. Pre-existing.

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted
