### PR TITLE
Make catalog contract test one-directional, drop search/ tree parity

### DIFF
--- a/.github/workflows/catalog-contract.yml
+++ b/.github/workflows/catalog-contract.yml
@@ -1,8 +1,10 @@
 name: Catalog Contract
 
 # Verifies that harvester changes to the Postgres schema or the OpenSearch mapping
-# don't break catalog, which reads both and owns neither. Provisions services with
-# harvester's migrations and mapping, then runs catalog's test suite against them.
+# don't break catalog's own, unmodified code, which reads both and owns neither.
+# Provisions services with harvester's migrations and mapping, then runs catalog's
+# real test suite against them -- catalog's search/ code is not touched, and the
+# two repos' vendored search/ trees are not required to match file-for-file.
 # See GSA/data.gov#6210 and docs/catalog-contract-test.md.
 #
 # No branch filter: harvester PRs target both main and develop, and DB changes tend

--- a/docker-compose.catalog-contract.yml
+++ b/docker-compose.catalog-contract.yml
@@ -1,13 +1,15 @@
 # Catalog contract test (GSA/data.gov#6210).
 #
-# Harvester owns the Postgres schema (migrations/), the OpenSearch index mapping
-# (search/mappings.py), and the document shape (search/documents.py). Catalog reads
-# all three and owns none of them, so a harvester change can break catalog without
-# any harvester test noticing.
+# Harvester owns the Postgres schema (migrations/) and the OpenSearch index mapping
+# (search/mappings.py). Catalog reads both and owns neither, so a harvester change to
+# either can break catalog without any harvester test noticing.
 #
-# This stack provisions services with *harvester's* migrations and mapping, runs
-# catalog against *harvester's* vendored search code, then runs *catalog's* test
-# suite. See `make test-catalog-contract` and docs/catalog-contract-test.md.
+# This stack provisions services with *harvester's* migrations and mapping, then runs
+# *catalog's own, unmodified* test suite against them -- catalog's search/ code is not
+# touched or overlaid. The two vendored search/ trees are allowed to diverge; this is a
+# one-directional check that harvester's schema/mapping changes don't break the catalog
+# code running in production today. See `make test-catalog-contract` and
+# docs/catalog-contract-test.md.
 #
 # No host ports are published: every step runs inside this compose network, so
 # the stack can't collide with `make up` (which already occupies 5432, 5433 and
@@ -94,48 +96,16 @@ services:
       CATALOG_TEST_EXTERNAL_SCHEMA: "true"
     volumes:
       - ./reports:/app/reports
-      # Harvester's vendored search code, overlaid onto catalog's copy below.
-      - ./search:/harvester-search:ro
-      - ./shared/constants.py:/harvester-shared-constants.py:ro
     command:
       - /bin/sh
       - -c
       - |
         set -e
-        # Run catalog's code against *harvester's* vendored search modules rather
-        # than catalog's own copy. Without this the test is a closed loop: catalog's
-        # own OpenSearchWriter would produce the documents catalog then reads, so a
-        # harvester-side change to MAPPINGS, DatasetDocument, the writer, or the
-        # filter registry would go undetected.
-        #
-        # Both repos vendored the same datagov_data_access 1.1.0 code and dropped the
-        # dependency (GSA/data.gov#6209 harvester-side, #6211 catalog-side), so there
-        # is no longer a shared package. The two trees are identical apart from import
-        # prefixes; this overlay is what keeps them from silently diverging.
-        #
-        # Copy file-by-file rather than replacing the tree: catalog's app/search/
-        # legitimately owns files harvester has no equivalent for (__init__.py's
-        # public façade, url_helpers.py), and clobbering them breaks catalog's imports.
-        for f in $$(cd /harvester-search && find . -name '*.py' ! -name '__init__.py'); do
-          if [ -f "/app/app/search/$$f" ]; then
-            cp "/harvester-search/$$f" "/app/app/search/$$f"
-          else
-            echo "ERROR: harvester has search/$$f but catalog has no counterpart." >&2
-            echo "       The two vendored trees have diverged structurally." >&2
-            exit 1
-          fi
-        done
-        cp /harvester-shared-constants.py /app/shared/constants.py
-        # Unanchored so the indented lazy imports (queries/criteria.py,
-        # queries/filters/base.py) get rewritten too.
-        find /app/app/search -name '*.py' -exec sed -i \
-          -e 's|\bfrom database\.models import|from app.models import|' \
-          -e 's|\bfrom search\.|from app.search.|' \
-          -e 's|\bfrom search import|from app.search import|' {} +
-        # Fail loudly rather than silently testing catalog's own copy.
-        if grep -rnE '\bfrom (database|search)[. ]' /app/app/search; then
-          echo "ERROR: unrewritten harvester import paths remain in the overlay" >&2
-          exit 1
-        fi
-        echo "Overlaid harvester's vendored search modules onto /app/app/search"
+        # Run catalog's own, unmodified code and tests -- no overlay of harvester's
+        # search/ modules. Harvester and catalog are allowed to vendor their own
+        # copies of the search/document code and let them diverge over time; this
+        # job only checks that catalog's code, as it exists today, still works
+        # against the Postgres schema and OpenSearch mapping harvester is proposing.
+        # A harvester-side search/ change that catalog can't read yet is not, by
+        # itself, a reason to fail this job -- see docs/catalog-contract-test.md.
         pytest tests/unit -v --junitxml=/app/reports/catalog-contract.xml

--- a/docs/catalog-contract-test.md
+++ b/docs/catalog-contract-test.md
@@ -1,56 +1,60 @@
 # Catalog contract test
 
-Harvester owns the Postgres schema (`migrations/`), the OpenSearch index mapping
-(`search/mappings.py`), and the indexed document shape (`search/documents.py`).
-[datagov-catalog](https://github.com/GSA/datagov-catalog) reads all three and owns none of
-them — it has no migrations of its own. So a harvester change can break catalog, and until
-this test existed nothing caught it before deploy.
+Harvester owns the Postgres schema (`migrations/`) and the OpenSearch index mapping
+(`search/mappings.py`). [datagov-catalog](https://github.com/GSA/datagov-catalog) reads both
+and owns neither — it has no migrations of its own. So a harvester change to the schema or
+mapping can break catalog, and until this test existed nothing caught it before deploy.
 
-This matters more now that both repos have vendored the shared `datagov_data_access` 1.1.0
-code and dropped the dependency — harvester into `database/` and `search/`
-([#6209](https://github.com/GSA/data.gov/issues/6209)), catalog into `app/models.py` and
-`app/search/` ([#6211](https://github.com/GSA/data.gov/issues/6211)). There is no longer a
-shared package anywhere. The two trees are currently identical apart from import prefixes,
-but nothing enforces that. This test is what keeps them honest.
+This is deliberately **one-directional**: it checks that catalog's code, as it exists today
+in its published `:main` image, still works against the Postgres schema and OpenSearch
+mapping a harvester PR is proposing. It does not require harvester's and catalog's vendored
+`search/` trees (each repo's copy of the former `datagov_data_access` code —
+[#6209](https://github.com/GSA/data.gov/issues/6209) harvester-side,
+[#6211](https://github.com/GSA/data.gov/issues/6211) catalog-side) to match file-for-file.
+The two applications are allowed to diverge there over time; see "Why not tree parity?"
+below.
 
 The `Catalog Contract` GitHub Action runs on every harvester pull request. It provisions
-Postgres and OpenSearch using *harvester's* migrations and mapping, then runs *catalog's*
-test suite against them. Implements [GSA/data.gov#6210](https://github.com/GSA/data.gov/issues/6210).
+Postgres and OpenSearch using *harvester's* migrations and mapping, then runs *catalog's own,
+unmodified* test suite against them. Implements
+[GSA/data.gov#6210](https://github.com/GSA/data.gov/issues/6210).
 
 ## What it actually proves
 
-Three things, in one run:
+Two things, in one run:
 
 1. **Schema contract** — catalog's queries work against the schema `flask db upgrade`
-   produces. Catalog's test fixtures insert rows through the shared SQLAlchemy models, so a
+   produces. Catalog's test fixtures insert rows through its own SQLAlchemy models, so a
    dropped/renamed column, a changed enum, or a missing constraint fails loudly.
 2. **Mapping contract** — catalog's searches, aggregations, and filters work against the
    index `flask search reset-mapping` creates.
-3. **Document-shape contract** — catalog's tests index their fixtures through the
-   `OpenSearchWriter`, so `DatasetDocument` output is exercised end to end:
-   writer → index → reader → template.
 
-Point 3 only holds because the job **overlays harvester's vendored `search/` modules (and
-`shared/constants.py`) onto catalog's `app/search/`** before running pytest. Without that the
-test is a closed loop — catalog's own copy of the writer would produce the documents catalog
-then reads, so a harvester-side change to `MAPPINGS`, `DatasetDocument`, the writer, or the
-filter registry would go completely undetected.
+Catalog's own `OpenSearchWriter`, `DatasetDocument`, and filter registry index the test
+fixtures and read them back — none of that is touched or replaced by harvester's copies.
+That is intentional: this job answers "does catalog's current code still work," not "are the
+two vendored trees identical." A harvester-side change to `MAPPINGS`, `DatasetDocument`, the
+writer, or the filter registry that catalog's copy doesn't know about yet will not, by
+itself, fail this job — see below for why.
 
-The overlay copies module-for-module and rewrites import prefixes (`search.*` →
-`app.search.*`, `database.models` → `app.models`), which is sufficient because the two
-vendored trees are otherwise identical. It then greps for any unrewritten path and fails
-hard if one remains, so a silent fallback to catalog's own copy is not possible.
+## Why not tree parity?
 
-Two deliberate limits:
+An earlier version of this job overlaid harvester's vendored `search/` modules onto
+catalog's tree before running catalog's tests, and hard-failed if harvester had a module
+catalog lacked. That check answered a different question — "are the two trees identical" —
+which has two problems:
 
-- **It copies files, it does not replace the tree.** Catalog's `app/search/` legitimately
-  owns modules harvester has no counterpart for (`__init__.py`'s public façade,
-  `url_helpers.py`); clobbering them breaks catalog's imports. If harvester ever gains a
-  `search/` module catalog lacks, the overlay fails loudly rather than silently skipping it.
-- **`database/models.py` is not overlaid.** Catalog's fixtures must exercise the schema
-  harvester's migrations actually built; substituting harvester's model definitions would
-  make that check tautological. Catalog's own slim models in `app/models.py` are the client
-  under test.
+- It penalizes pure additions (e.g. a new filter module) exactly as hard as a breaking
+  change, because it can't tell the two apart.
+- It forces the two repos' releases into lockstep: harvester couldn't ship a `search/`
+  addition until catalog had already merged and released a matching file to `main`, even
+  when nothing about catalog's current behavior was at risk. Timing that across two
+  independently deployed apps is itself an outage risk if the timing slips.
+
+What actually matters operationally is whether harvester's *schema and mapping* changes
+break catalog's *current, deployed* code — that's what a bad migration or mapping change
+does in production, independent of whether the two `search/` trees match. This job checks
+that directly by running catalog's real test suite against harvester's proposed services,
+and leaves `search/` drift between the repos as an accepted, unenforced condition.
 
 ## Running it locally
 
@@ -106,8 +110,8 @@ broken migration.
 
 ## When this job fails
 
-Read it as "this harvester change breaks catalog." Three failure modes are worth calling out
-because none of them is a flaky test:
+Read it as "this harvester change breaks catalog's current, deployed code." Two failure
+modes are worth calling out because neither is a flaky test:
 
 - **A migration removed or changed something catalog reads.** Either keep it, or land the
   catalog change first.
@@ -118,9 +122,11 @@ because none of them is a flaky test:
   `flask db check` in the `Pytests` job catches most of this class; anything that slips
   through surfaces here as a catalog failure. Either way it's a real bug, not a false
   positive — write the migration.
-- **`search/` changed in a way catalog can't read.** Harvester's `search/` and catalog's
-  `app/search/` are two copies of the same vendored code and are meant to stay equivalent,
-  so a mapping, document, or filter-registry change that breaks catalog needs a matching
-  catalog change. Catalog's `commit.yml` has a non-blocking text-diff of harvester's
-  `search/mappings.py` that makes drift visible; this job is the blocking version, and
-  covers the whole module set rather than just the mapping.
+
+A harvester-side `search/` change (mapping, document shape, filter registry) that catalog's
+own copy doesn't know about yet will **not** fail this job by itself, since catalog's copy
+isn't touched — see "Why not tree parity?" above. If such a change also alters the
+OpenSearch mapping in a way catalog's current queries can't handle, that still surfaces here
+as a mapping-contract failure; only the module-for-module identity check was removed.
+Catalog's `commit.yml` has a non-blocking text-diff of harvester's `search/mappings.py` that
+makes `search/` drift between the repos visible without blocking either side.


### PR DESCRIPTION
## Summary
Per discussion with Cody Seibert and James Brown on harvester #813: the "Catalog Contract" job was checking that harvester's and catalog's vendored `search/` trees match file-for-file, which is the wrong invariant. That overlay+parity check:

- Penalized pure additions (a new filter module) exactly like a breaking/removed one, since it can't tell the two apart.
- Forced the two repos' releases into lockstep — harvester couldn't ship a `search/` addition until catalog had already merged and shipped a matching file to `main`, even when catalog's current behavior wasn't at risk.

This PR removes the overlay and file-parity check entirely. The job now runs **catalog's own, unmodified code and test suite** against the Postgres schema and OpenSearch mapping a harvester PR is proposing — i.e. "does catalog's code, as deployed today, still work against this harvester change," not "do the two repos' internal `search/` copies match."

## What's unchanged
- Schema contract (catalog's queries work against `flask db upgrade`'s output) and mapping contract (catalog's searches/filters work against `flask search reset-mapping`'s index) are still checked, and still catch a bad migration or breaking mapping change.

## What's removed
- The `search/` → `app/search/` file overlay, import-prefix rewrite, and the hard failure when harvester has a `search/` module catalog lacks. The two vendored trees may now diverge; `search/` drift between the repos is visible via catalog's existing non-blocking text-diff in `commit.yml`, not blocking here.

## Verification
Ran `make test-catalog-contract` locally against harvester's `has_download.py` filter addition (the change that originally triggered the false failure on #813) — catalog's `:main` image doesn't have a matching file, and all 265 of catalog's `tests/unit` pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
