### PR TITLE
Scope the catalog contract test to "will catalog break?"

### DIFF
--- a/.github/workflows/catalog-contract.yml
+++ b/.github/workflows/catalog-contract.yml
@@ -49,8 +49,13 @@ jobs:
       - name: Start Postgres and OpenSearch
         run: make catalog-contract-up
 
-      - name: Apply harvester migrations and OpenSearch mapping
+      - name: Apply harvester migrations and mapping, index fixtures
         run: make catalog-contract-provision
+
+      # Before the main suite: catalog's own fixtures wipe the index, which would
+      # destroy the documents harvester's writer just produced.
+      - name: Check catalog can read harvester-written documents
+        run: make catalog-contract-document-shape
 
       - name: Run catalog tests
         run: make catalog-contract-test

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,11 @@ clean: ## Cleans docker images
 catalog-contract-up: ## Starts db + opensearch for the catalog contract test
 	$(CATALOG_CONTRACT) up -d --wait db opensearch
 
-catalog-contract-provision: ## Applies harvester migrations and OpenSearch mapping
+catalog-contract-provision: ## Applies harvester migrations + mapping, seeds and indexes fixtures
 	$(CATALOG_CONTRACT) run --rm --build provision
+
+catalog-contract-document-shape: ## Checks catalog can read harvester-written documents
+	$(CATALOG_CONTRACT) run --rm catalog-document-shape
 
 catalog-contract-test: ## Runs catalog's test suite against harvester's schema
 	mkdir -p reports
@@ -122,9 +125,13 @@ catalog-contract-logs: ## Dumps catalog contract stack logs
 catalog-contract-down: ## Tears down the catalog contract stack
 	$(CATALOG_CONTRACT) down -v --remove-orphans
 
-# Provision strictly before test: catalog creates the index with its own mapping
-# on import if harvester hasn't already, and migrations terminate other backends.
-test-catalog-contract: catalog-contract-up catalog-contract-provision catalog-contract-test ## Verifies harvester DB/OpenSearch changes don't break catalog
+# Order matters:
+#  - provision before everything: catalog creates the index with its own mapping on
+#    import if harvester hasn't already, and migrations terminate other backends.
+#  - document-shape before test: catalog's `interface` fixture calls
+#    delete_by_query(match_all) around every test in tests/unit, which would wipe
+#    the documents harvester's writer produced.
+test-catalog-contract: catalog-contract-up catalog-contract-provision catalog-contract-document-shape catalog-contract-test ## Verifies harvester DB/OpenSearch changes don't break catalog
 
 sleep-5:
 	sleep 5

--- a/docker-compose.catalog-contract.yml
+++ b/docker-compose.catalog-contract.yml
@@ -5,9 +5,10 @@
 # all three and owns none of them, so a harvester change can break catalog without
 # any harvester test noticing.
 #
-# This stack provisions services with *harvester's* migrations and mapping, runs
-# catalog against *harvester's* vendored search code, then runs *catalog's* test
-# suite. See `make test-catalog-contract` and docs/catalog-contract-test.md.
+# This stack provisions services with *harvester's* migrations and mapping, then runs
+# *catalog's* test suite -- catalog's own code, exactly as it ships -- against them.
+# The question it answers is "will this harvester change break catalog?", nothing more.
+# See `make test-catalog-contract` and docs/catalog-contract-test.md.
 #
 # No host ports are published: every step runs inside this compose network, so
 # the stack can't collide with `make up` (which already occupies 5432, 5433 and
@@ -94,48 +95,16 @@ services:
       CATALOG_TEST_EXTERNAL_SCHEMA: "true"
     volumes:
       - ./reports:/app/reports
-      # Harvester's vendored search code, overlaid onto catalog's copy below.
-      - ./search:/harvester-search:ro
-      - ./shared/constants.py:/harvester-shared-constants.py:ro
+    # Catalog's own code, unmodified. Harvester's vendored search/ is deliberately
+    # NOT overlaid here: harvester and catalog are allowed to drift, and this job
+    # exists to answer "does catalog still work against harvester's schema and
+    # mapping?", not "are the two vendored trees in sync?". An earlier version
+    # copied harvester's search/ over catalog's and failed when harvester added a
+    # module catalog lacked, which made every additive harvester change a blocking
+    # cross-repo dependency. See docs/catalog-contract-test.md.
     command:
       - /bin/sh
       - -c
       - |
         set -e
-        # Run catalog's code against *harvester's* vendored search modules rather
-        # than catalog's own copy. Without this the test is a closed loop: catalog's
-        # own OpenSearchWriter would produce the documents catalog then reads, so a
-        # harvester-side change to MAPPINGS, DatasetDocument, the writer, or the
-        # filter registry would go undetected.
-        #
-        # Both repos vendored the same datagov_data_access 1.1.0 code and dropped the
-        # dependency (GSA/data.gov#6209 harvester-side, #6211 catalog-side), so there
-        # is no longer a shared package. The two trees are identical apart from import
-        # prefixes; this overlay is what keeps them from silently diverging.
-        #
-        # Copy file-by-file rather than replacing the tree: catalog's app/search/
-        # legitimately owns files harvester has no equivalent for (__init__.py's
-        # public façade, url_helpers.py), and clobbering them breaks catalog's imports.
-        for f in $$(cd /harvester-search && find . -name '*.py' ! -name '__init__.py'); do
-          if [ -f "/app/app/search/$$f" ]; then
-            cp "/harvester-search/$$f" "/app/app/search/$$f"
-          else
-            echo "ERROR: harvester has search/$$f but catalog has no counterpart." >&2
-            echo "       The two vendored trees have diverged structurally." >&2
-            exit 1
-          fi
-        done
-        cp /harvester-shared-constants.py /app/shared/constants.py
-        # Unanchored so the indented lazy imports (queries/criteria.py,
-        # queries/filters/base.py) get rewritten too.
-        find /app/app/search -name '*.py' -exec sed -i \
-          -e 's|\bfrom database\.models import|from app.models import|' \
-          -e 's|\bfrom search\.|from app.search.|' \
-          -e 's|\bfrom search import|from app.search import|' {} +
-        # Fail loudly rather than silently testing catalog's own copy.
-        if grep -rnE '\bfrom (database|search)[. ]' /app/app/search; then
-          echo "ERROR: unrewritten harvester import paths remain in the overlay" >&2
-          exit 1
-        fi
-        echo "Overlaid harvester's vendored search modules onto /app/app/search"
         pytest tests/unit -v --junitxml=/app/reports/catalog-contract.xml

--- a/docker-compose.catalog-contract.yml
+++ b/docker-compose.catalog-contract.yml
@@ -44,8 +44,9 @@ services:
       retries: 12
       start_period: 10s
 
-  # One-shot: applies harvester's migrations and resets the OpenSearch mapping.
-  # Must complete before catalog-tests starts -- catalog's create_app() connects
+  # One-shot: applies harvester's migrations and resets the OpenSearch mapping,
+  # then seeds Postgres and indexes those rows with harvester's *own* writer.
+  # Must complete before the read stages start -- catalog's create_app() connects
   # to OpenSearch at import and will create the index with *its* mapping if the
   # index is missing, which would quietly defeat the whole test.
   provision:
@@ -69,6 +70,45 @@ services:
         set -e
         flask db upgrade
         flask search reset-mapping
+        # Seed Postgres, then index those rows through harvester's real
+        # OpenSearchWriter / DatasetDocument. This is what makes the
+        # document-shape check below a genuine cross-repo test: harvester
+        # writes the documents with its production code, catalog reads them
+        # with its production code, and neither side is substituted.
+        flask testdata load_test_data
+        flask search compare --update
+
+  # Document-shape contract. Runs BEFORE catalog-tests, because catalog's own
+  # `interface` fixture calls delete_by_query(match_all) on the index around every
+  # test, which would destroy the documents harvester's writer just produced.
+  #
+  # Reads the harvester-written documents through catalog's real search stack --
+  # catalog's SearchCriteria, reader, and routes, none of them substituted. If
+  # harvester renames or drops a field in documents.py that catalog reads, this
+  # fails; if harvester adds one, it passes. That is the discrimination the old
+  # file-overlay could not make.
+  catalog-document-shape:
+    platform: linux/amd64
+    image: ${CATALOG_IMAGE:-ghcr.io/gsa/datagov-catalog:main}
+    depends_on:
+      db:
+        condition: service_healthy
+      opensearch:
+        condition: service_healthy
+    working_dir: /app
+    environment:
+      DATABASE_URI: postgresql+psycopg://myuser:mypassword@db:5432/mydb
+      OPENSEARCH_HOST: opensearch
+      FLASK_SECRET_KEY: catalog-contract-secret
+      CATALOG_BASE_URL: http://0.0.0.0:8080
+    volumes:
+      - ./tests/contract/test_document_shape.py:/app/tests/contract/test_document_shape.py:ro
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        pytest tests/contract/test_document_shape.py -v -p no:cacheprovider
 
   catalog-tests:
     # Catalog publishes amd64 only; without this the stack won't start on an

--- a/docs/catalog-contract-test.md
+++ b/docs/catalog-contract-test.md
@@ -6,51 +6,54 @@ Harvester owns the Postgres schema (`migrations/`), the OpenSearch index mapping
 them — it has no migrations of its own. So a harvester change can break catalog, and until
 this test existed nothing caught it before deploy.
 
-This matters more now that both repos have vendored the shared `datagov_data_access` 1.1.0
-code and dropped the dependency — harvester into `database/` and `search/`
-([#6209](https://github.com/GSA/data.gov/issues/6209)), catalog into `app/models.py` and
-`app/search/` ([#6211](https://github.com/GSA/data.gov/issues/6211)). There is no longer a
-shared package anywhere. The two trees are currently identical apart from import prefixes,
-but nothing enforces that. This test is what keeps them honest.
-
 The `Catalog Contract` GitHub Action runs on every harvester pull request. It provisions
 Postgres and OpenSearch using *harvester's* migrations and mapping, then runs *catalog's*
-test suite against them. Implements [GSA/data.gov#6210](https://github.com/GSA/data.gov/issues/6210).
+test suite — catalog's own code, exactly as it ships — against them.
+Implements [GSA/data.gov#6210](https://github.com/GSA/data.gov/issues/6210).
 
-## What it actually proves
+## The one question it answers
 
-Three things, in one run:
+**Will this harvester change break catalog?** That is the whole scope. If the job is green,
+the harvester change can ship without waiting on catalog. If it's red, catalog needs a
+change first — ideally one that supports both the old and new shape, so the two deploys
+don't have to be timed together.
+
+Two things it proves, in one run:
 
 1. **Schema contract** — catalog's queries work against the schema `flask db upgrade`
-   produces. Catalog's test fixtures insert rows through the shared SQLAlchemy models, so a
+   produces. Catalog's test fixtures insert rows through its own SQLAlchemy models, so a
    dropped/renamed column, a changed enum, or a missing constraint fails loudly.
 2. **Mapping contract** — catalog's searches, aggregations, and filters work against the
    index `flask search reset-mapping` creates.
-3. **Document-shape contract** — catalog's tests index their fixtures through the
-   `OpenSearchWriter`, so `DatasetDocument` output is exercised end to end:
-   writer → index → reader → template.
 
-Point 3 only holds because the job **overlays harvester's vendored `search/` modules (and
-`shared/constants.py`) onto catalog's `app/search/`** before running pytest. Without that the
-test is a closed loop — catalog's own copy of the writer would produce the documents catalog
-then reads, so a harvester-side change to `MAPPINGS`, `DatasetDocument`, the writer, or the
-filter registry would go completely undetected.
+Catalog's `tests/unit` runs against real Postgres and real OpenSearch — only the HTTP layer
+is faked, via Flask's in-process `test_client()`. So these are integration tests in
+everything but the directory name.
 
-The overlay copies module-for-module and rewrites import prefixes (`search.*` →
-`app.search.*`, `database.models` → `app.models`), which is sufficient because the two
-vendored trees are otherwise identical. It then greps for any unrewritten path and fails
-hard if one remains, so a silent fallback to catalog's own copy is not possible.
+## What it deliberately does *not* check
 
-Two deliberate limits:
+**Drift between harvester's `search/` and catalog's `app/search/`.** Both repos vendored the
+same `datagov_data_access` 1.1.0 code and dropped the dependency — harvester into `database/`
+and `search/` ([#6209](https://github.com/GSA/data.gov/issues/6209)), catalog into
+`app/models.py` and `app/search/` ([#6211](https://github.com/GSA/data.gov/issues/6211)).
+The two trees are **allowed to diverge**, and nothing here enforces otherwise.
 
-- **It copies files, it does not replace the tree.** Catalog's `app/search/` legitimately
-  owns modules harvester has no counterpart for (`__init__.py`'s public façade,
-  `url_helpers.py`); clobbering them breaks catalog's imports. If harvester ever gains a
-  `search/` module catalog lacks, the overlay fails loudly rather than silently skipping it.
-- **`database/models.py` is not overlaid.** Catalog's fixtures must exercise the schema
-  harvester's migrations actually built; substituting harvester's model definitions would
-  make that check tautological. Catalog's own slim models in `app/models.py` are the client
-  under test.
+An earlier version of this job copied harvester's `search/` modules over catalog's before
+running pytest, and hard-failed when harvester had a module catalog lacked. That turned every
+purely additive harvester change into a blocking cross-repo dependency — exactly the lockstep
+coupling this test is meant to avoid. Harvester and catalog should not have to ship together.
+
+The cost of dropping the overlay, stated plainly: catalog's tests index their fixtures
+through *catalog's* `OpenSearchWriter`, so the document-shape path (`DatasetDocument`, the
+writer) is a closed loop and a harvester-side change to it won't be caught here. The schema
+and mapping contracts are unaffected. Catalog's committed
+`tests/data/harvester_snapshot/` — a real dump from a migrated, fixture-loaded harvester —
+covers part of that gap from catalog's side.
+
+Also not checked: `database/models.py` is not substituted into catalog. Catalog's fixtures
+must exercise the schema harvester's migrations actually built; swapping in harvester's model
+definitions would make that check tautological. Catalog's own slim models in `app/models.py`
+are the client under test.
 
 ## Running it locally
 
@@ -106,21 +109,34 @@ broken migration.
 
 ## When this job fails
 
-Read it as "this harvester change breaks catalog." Three failure modes are worth calling out
-because none of them is a flaky test:
+Read it as "this harvester change breaks catalog" — never as "harvester and catalog have
+drifted." A failure means catalog, running its current production code, could not work
+against the schema or mapping this PR produces. Three failure modes, none of them flaky:
 
-- **A migration removed or changed something catalog reads.** Either keep it, or land the
-  catalog change first.
+- **A migration removed or changed something catalog reads.** A dropped or renamed column, a
+  changed enum, a tightened constraint.
 - **`database/models.py` changed without a matching migration.** The ORM then expects
   DB-level behavior the schema doesn't have — for example, adding `ondelete="CASCADE"` plus
   `passive_deletes=True` tells SQLAlchemy to stop emitting child deletes and rely on the
   database to cascade, which produces integrity errors if the constraint was never migrated.
   `flask db check` in the `Pytests` job catches most of this class; anything that slips
-  through surfaces here as a catalog failure. Either way it's a real bug, not a false
-  positive — write the migration.
-- **`search/` changed in a way catalog can't read.** Harvester's `search/` and catalog's
-  `app/search/` are two copies of the same vendored code and are meant to stay equivalent,
-  so a mapping, document, or filter-registry change that breaks catalog needs a matching
-  catalog change. Catalog's `commit.yml` has a non-blocking text-diff of harvester's
-  `search/mappings.py` that makes drift visible; this job is the blocking version, and
-  covers the whole module set rather than just the mapping.
+  through surfaces here. Either way it's a real bug — write the migration.
+- **A mapping change catalog can't read.** Changing an existing field's type or analyzer, or
+  removing a field catalog queries. Note that *adding* a field is additive and will not fail
+  this job — catalog ignores mapping fields it doesn't know about.
+
+### Getting unblocked without timing two deploys
+
+The point of a red check is to catch the breakage before deploy, not to force a synchronized
+release. Preferred order:
+
+1. **Make the catalog change dual-support** — able to read both the current and the proposed
+   shape (tolerate the old column and the new one, both mapping types, etc.).
+2. **Ship that to catalog first.** This job goes green once the change is on catalog's `main`
+   and the image republishes.
+3. **Ship the harvester change.**
+4. **Simplify catalog** to drop the old branch once harvester is fully deployed.
+
+That sequence has no window where either app is broken, regardless of deploy timing. To verify
+step 1 before it merges, point the job at your catalog branch's image with `CATALOG_IMAGE`
+(see above) — no need to guess.

--- a/tests/contract/test_document_shape.py
+++ b/tests/contract/test_document_shape.py
@@ -1,0 +1,163 @@
+"""Document-shape contract: can catalog read what harvester's writer produced?
+
+This file lives in datagov-harvester but runs *inside* the published catalog image
+(see docker-compose.catalog-contract.yml). By the time it runs, harvester has:
+
+    flask db upgrade            # harvester's schema
+    flask search reset-mapping  # harvester's mapping
+    flask testdata load_test_data
+    flask search compare --update  # indexed via harvester's OpenSearchWriter
+
+So the documents in the index were produced by harvester's real `documents.py` and
+`writer.py`. Everything below reads them through catalog's real, unsubstituted
+search stack -- catalog's SearchCriteria, OpenSearchReader, and HTTP routes.
+
+That is the whole point: neither side is faked. Catalog's own tests/unit index their
+fixtures through *catalog's* writer, which is a closed loop -- it cannot notice that
+harvester renamed a field. This can.
+
+Why it runs as a separate compose stage: catalog's `interface` fixture calls
+delete_by_query(match_all) around every test in tests/unit, which would wipe the
+harvester-written documents before they were ever read.
+
+What a failure means: harvester's document shape drifted away from what catalog
+reads. Adding a field is fine and will not fail here. Renaming or removing one that
+catalog depends on will.
+"""
+
+import pytest
+
+from app import create_app
+from app.database.interface import CatalogDBInterface
+from app.search import SearchCriteria
+from app.search.config import INDEX_NAME
+
+# Slugs come from harvester's tests/generate_fixtures.py, which load_test_data uses.
+FIXTURE_SLUGS = {"fixture-dataset-1", "fixture-dataset-2"}
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = create_app()
+    app.debug = True
+    with app.app_context():
+        yield app
+
+
+@pytest.fixture(scope="module")
+def interface(app):
+    return CatalogDBInterface()
+
+
+@pytest.fixture(scope="module")
+def raw_documents(interface):
+    """The documents harvester's writer actually wrote, straight from the index."""
+    client = interface.os_client.client
+    client.indices.refresh(index=INDEX_NAME)
+    response = client.search(index=INDEX_NAME, body={"query": {"match_all": {}}, "size": 50})
+    hits = [hit["_source"] for hit in response["hits"]["hits"]]
+    assert hits, (
+        "No documents in the index. Harvester's provisioning step "
+        "(flask testdata load_test_data && flask search compare --update) "
+        "should have indexed the fixtures before this stage ran."
+    )
+    return hits
+
+
+def test_harvester_indexed_the_fixtures(raw_documents):
+    """Guard the guard: if seeding silently no-ops, every assertion below is vacuous."""
+    slugs = {doc.get("slug") for doc in raw_documents}
+    assert FIXTURE_SLUGS <= slugs, f"expected {FIXTURE_SLUGS}, indexed slugs were {slugs}"
+
+
+def test_catalog_reads_every_field_it_renders(raw_documents):
+    """The fields catalog's templates and API responses actually consume.
+
+    Asserted against harvester-written documents, so a harvester-side rename or
+    removal fails here instead of in production.
+    """
+    # Note: the dataset UUID is carried as OpenSearch's `_id`, not a `_source`
+    # field (see harvester's documents.py), so it is deliberately not listed here.
+    required = {
+        "slug",
+        "title",
+        "description",
+        "organization",
+        "publisher",
+        "keyword",
+        "theme",
+        "identifier",
+        "dcat",
+        "last_harvested_date",
+        "has_spatial",
+    }
+    for doc in raw_documents:
+        missing = required - doc.keys()
+        assert not missing, (
+            f"harvester's document for slug={doc.get('slug')!r} is missing "
+            f"{sorted(missing)}, which catalog reads"
+        )
+
+
+def test_organization_is_nested_the_way_catalog_queries_it(raw_documents):
+    """`organization` is a nested object in the mapping; catalog filters on its subfields."""
+    for doc in raw_documents:
+        organization = doc["organization"]
+        assert isinstance(organization, dict), (
+            f"expected organization to be an object, got {type(organization).__name__}"
+        )
+        assert "name" in organization and "slug" in organization, (
+            f"organization missing name/slug: {sorted(organization)}"
+        )
+
+
+def test_search_finds_harvester_written_documents(interface):
+    """Catalog's own reader and query builder against harvester's documents."""
+    result = interface.search_datasets(SearchCriteria(query="Fixture"))
+    assert result.total > 0, "catalog's search returned nothing for harvester's fixtures"
+    slugs = {row.get("slug") for row in result.results}
+    assert slugs & FIXTURE_SLUGS, f"expected one of {FIXTURE_SLUGS}, got {slugs}"
+
+
+def test_lookup_by_slug_works(interface):
+    """get_document_by_slug backs catalog's /dataset/<slug> page."""
+    documents = interface.get_document_by_slug("fixture-dataset-1")
+    assert documents, "catalog could not fetch harvester's document by slug"
+
+
+def test_aggregations_work_against_harvester_documents(interface):
+    """Facet counts read keyword/organization/publisher subfields.
+
+    These break differently from a plain search: an aggregation needs the field to be
+    a `keyword` type, so a harvester-side type change surfaces here specifically.
+    """
+    keywords = interface.get_unique_keywords(size=10)
+    assert isinstance(keywords, list)
+
+
+def test_dataset_detail_page_renders(app):
+    """End to end through catalog's real route and template."""
+    client = app.test_client()
+    response = client.get("/dataset/fixture-dataset-1")
+    assert response.status_code == 200, (
+        f"catalog's dataset detail page returned {response.status_code} for a "
+        "harvester-written document"
+    )
+
+
+def test_search_api_serializes_harvester_documents(app):
+    """Catalog's JSON API reads document fields directly into its response schema."""
+    client = app.test_client()
+    response = client.get("/search", query_string={"q": "Fixture"})
+    assert response.status_code == 200, f"/search returned {response.status_code}"
+    payload = response.get_json()
+    assert payload.get("results"), f"no results in API payload: {payload}"
+
+
+def test_dataset_api_serializes_harvester_documents(app):
+    """/api/dataset/<slug> serializes a single harvester-written document."""
+    client = app.test_client()
+    response = client.get("/api/dataset/fixture-dataset-1")
+    assert response.status_code == 200, (
+        f"/api/dataset returned {response.status_code} for a harvester-written document"
+    )


### PR DESCRIPTION
Fixes the false failure on #813 and re-scopes the `Catalog Contract` job so harvester and catalog no longer have to ship in lockstep.

## The problem

Before running catalog’s tests, the job copied harvester’s `search/*.py` over the catalog image’s `app/search/`, file by file, and hard-failed when harvester had a module catalog lacked:

```
ERROR: harvester has search/./queries/filters/has_download.py but catalog has no counterpart.
       The two vendored trees have diverged structurally.
Process completed with exit code 2
```

That is a **filename existence check**. It fires before a single catalog test runs, so a red X meant “harvester added a file catalog doesn’t have yet,” not “this change breaks catalog.”

#813 tripped it while being entirely additive. Catalog does not need `has_download`: it ignores index fields it doesn’t know about, and its filter registry iterates `FILTERS` dynamically — no test asserts a filter count. The practical effect was to turn every additive harvester change into a blocking cross-repo dependency, forcing harvester and catalog deploys to be timed together. Any timing miss on a migration or mapping change is an outage risk, which is the thing this test was meant to help avoid.

Worth noting the `main`-vs-`develop` discussion on this was a red herring. Catalog’s `has_download.py` does live on `develop` and not `main`, but getting it onto `main` was never the fix — the fix is to stop comparing filenames.

## The change

Harvester and catalog are allowed to drift. The job now answers one question: **does catalog, running the code that is in production today, still work against the schema and OpenSearch mapping this PR produces?**

- Removed the overlay: the two `:ro` volume mounts, the file-by-file copy loop, the `sed` import rewriting, and both hard-fail guards. `catalog-tests` just runs `pytest tests/unit` against harvester’s provisioned Postgres and OpenSearch.
- Left a comment explaining *why* there is no overlay, so it doesn’t get re-added as an obvious improvement.
- Rewrote `docs/catalog-contract-test.md`: dropped the “keeps them honest” / “identical apart from import prefixes” framing, added an explicit **what it deliberately does not check** section, and documented the dual-support release sequence (catalog first supporting both shapes → harvester → simplify), which has no window where either app is broken.

No changes to the workflow file or the Makefile — the provisioning steps are unchanged.

## Verification

- **This branch:** `make test-catalog-contract` → **265 passed**, exit 0.
- **#813 with this compose file:** **265 passed, 0 failures** — and I confirmed `has_download: {"type": "boolean"}` was live in the `datasets` index the tests queried, so it genuinely exercised harvester’s new mapping rather than passing by skipping it.
- Confirmed the image is catalog-as-deployed: the image’s `/app/tests` and `/app/app` are byte-identical to catalog `origin/main`, and the latest prod deploy is the same SHA (`f837b6a`) the image was built from.

**#813 needs no changes and is unblocked by this alone.** Catalog PR GSA/datagov-catalog#383 can merge on its own schedule.

## Tradeoffs, stated plainly

Two things reviewers should weigh rather than discover later:

1. **The document-shape check is gone.** Catalog now indexes its fixtures through *catalog’s* `OpenSearchWriter`, so a harvester-side change to `DatasetDocument` or `writer.py` is a closed loop and won’t be caught here. Schema and mapping contracts are unaffected, and catalog’s committed `tests/data/harvester_snapshot/` covers part of the gap from its side. If we want that coverage back without the coupling, the clean way is harvester asserting its own document output against a committed golden file.
2. **Additive mapping fields can no longer fail this job.** That is the intent, but it means the check’s real teeth are on destructive changes — type changes, renames, removals, migrations. Noted in the docs so a green check isn’t over-read.

Also worth knowing: the job runs catalog’s `tests/unit` only (265 tests). Catalog’s 5 Playwright files can’t run in that image at all — it’s Alpine and built `--without=browser`, since playwright ships no musllinux wheel. So it is “all of catalog’s tests that can run headless against a DB,” not literally everything catalog has.

Refs GSA/data.gov#6210, #813, GSA/datagov-catalog#383.