### PR TITLE
handle no tranformation exception

### DIFF
--- a/app/main/harvest_jobs.py
+++ b/app/main/harvest_jobs.py
@@ -17,15 +17,21 @@ from . import main
 @main.route("/harvest_job/<job_id>", methods=["GET"])
 @valid_id_required
 def view_harvest_job(job_id=None):
-    def _load_json_title(json_string):
+    def _load_json_title(json_string, error_type):
         try:
             if json_string is None:
-                logger.warning("harvest record doesn't have a source_raw")
-                return None
+                logger.warning("harvest record doesn't have a source to load")
+                return
+            if error_type == "TransformationException":
+                logger.warning(
+                    "transformation error produced no source_transform. "
+                    "can't json load an xml doc"
+                )
+                return
             return json.loads(json_string).get("title", None)
         except Exception as e:
             logger.error(f"Error loading json source_raw: {repr(e)}")
-            return None
+            return
 
     record_error_count = deps.db.get_harvest_record_errors_by_job(
         job_id,
@@ -49,7 +55,7 @@ def view_harvest_job(job_id=None):
         {
             "error": make_new_record_error_contract(row),
             "identifier": row[-2],
-            "title": _load_json_title(row[-1]),
+            "title": _load_json_title(row[-1], row[3]),
         }
         for row in record_errors
     ]

--- a/tests/integration/app/test_view_harvest_job.py
+++ b/tests/integration/app/test_view_harvest_job.py
@@ -24,8 +24,24 @@ def job_with_many_errors(interface_with_fixture_json):
     return job
 
 
-class TestViewHarvestJob:
+@pytest.fixture
+def job_with_transformation_error(interface_with_fixture_json):
+    job = interface_with_fixture_json.get_first_harvest_job_by_filter({})
+    record_id = job.records[0].id
+    # add 1 ISO transformation error
+    interface_with_fixture_json.add_harvest_record_error(
+        {
+            "type": "TransformationException",
+            "message": "failed to transform",
+            "harvest_job_id": job.id,
+            "harvest_record_id": record_id,
+        }
+    )
 
+    return job
+
+
+class TestViewHarvestJob:
     def test_harvest_source_name(self, client, job):
         """The harvest source's name appear on the harvest job page."""
         resp = client.get(f"/harvest_job/{job.id}")
@@ -204,3 +220,15 @@ class TestViewHarvestJob:
         )
         assert resp.is_json
         assert "id" in resp.json
+
+    def test_iso_transformation_no_exception(
+        self, client, caplog, job_with_transformation_error
+    ):
+
+        client.get(
+            f"/harvest_job/{job_with_transformation_error.id}?page=2",
+        )
+        assert (
+            caplog.messages[0] == "transformation error produced no source_transform. "
+            "can't json load an xml doc"
+        )


### PR DESCRIPTION
# Pull Request

Related to [6183](https://github.com/GSA/data.gov/issues/6183)

## About
made an initial improvement but noticed JSON parsing exceptions were still occurring after merge. this handles transformation exceptions where source_transform is none so source_raw is used. the json parse error is because `json.loads("<xml>value</xml")`

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
