### PR TITLE
Let catalog's tests index through harvester's writer

### DIFF
--- a/docker-compose.catalog-contract.yml
+++ b/docker-compose.catalog-contract.yml
@@ -133,15 +133,23 @@ services:
       # Tells catalog's dbapp fixture to TRUNCATE rather than drop_all/create_all,
       # preserving the schema harvester's migrations just built.
       CATALOG_TEST_EXTERNAL_SCHEMA: "true"
+      # Index through *harvester's* OpenSearchWriter instead of catalog's vendored
+      # copy, so catalog's full fixture set (DCAT-US 3.0, isPartOf collections,
+      # spatial bboxes, stopword titles) is written by harvester's real production
+      # write path and read back by catalog's real read path. Without this,
+      # catalog writes and reads with its own copy of the writer -- a closed loop
+      # that cannot notice a harvester-side change to DatasetDocument or the
+      # writer. Consumed by catalog's tests/writer_provider.py.
+      HARVESTER_SEARCH_PATH: /harvester/search
     volumes:
       - ./reports:/app/reports
-    # Catalog's own code, unmodified. Harvester's vendored search/ is deliberately
-    # NOT overlaid here: harvester and catalog are allowed to drift, and this job
-    # exists to answer "does catalog still work against harvester's schema and
-    # mapping?", not "are the two vendored trees in sync?". An earlier version
-    # copied harvester's search/ over catalog's and failed when harvester added a
-    # module catalog lacked, which made every additive harvester change a blocking
-    # cross-repo dependency. See docs/catalog-contract-test.md.
+      # Harvester's search package, mounted under its own namespace. This is NOT
+      # the file overlay that was removed from this job: nothing in app/search/ is
+      # clobbered, no filename parity between the repos is required, and harvester
+      # adding a module catalog lacks is a non-event. Only the writer is swapped;
+      # catalog's reader, models, routes and templates stay catalog's.
+      - ./search:/harvester/search:ro
+      - ./shared:/harvester/shared:ro
     command:
       - /bin/sh
       - -c

--- a/search/documents.py
+++ b/search/documents.py
@@ -1,12 +1,21 @@
+from __future__ import annotations
+
 import json
 import os
 from datetime import date, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from database.models import Dataset
 from search.config import DEFAULT_CATALOG_BASE_URL, INDEX_NAME
 from search.spatial import calc_geometry_centroid
 from search.transforms import DcatIndexTransformer
+
+if TYPE_CHECKING:
+    # Annotation only. This module reads a fixed set of attributes off whatever
+    # it is handed (dcat, id, slug, organization, popularity, translated_spatial,
+    # harvest_record_id, last_harvested_date), so it does not need harvester's
+    # ORM at runtime -- which is what lets datagov-catalog's contract test drive
+    # this exact code with its own model rows. See docs/catalog-contract-test.md.
+    from database.models import Dataset
 
 
 class DatasetDocument:

--- a/search/writer.py
+++ b/search/writer.py
@@ -5,7 +5,6 @@ from typing import Callable, TypeVar
 from opensearchpy import helpers
 from opensearchpy.exceptions import ConnectionTimeout
 
-from database.models import Dataset
 from search.client import OpenSearchClient
 from search.config import (
     DEFAULT_DELETE_REQUEST_TIMEOUT_SECONDS,
@@ -199,6 +198,12 @@ class OpenSearchWriter:
                 f"  Batch {batch_number}/{total_batches}: "
                 f"indexing {len(batch_ids)} dataset(s)..."
             )
+            # Imported lazily so this module can be used without harvester's ORM.
+            # index_datasets() below is duck-typed and is the only entry point
+            # datagov-catalog uses (see docs/catalog-contract-test.md); a
+            # module-level import would drag the whole model tree into its image.
+            from database.models import Dataset
+
             datasets = (
                 db_interface.db.query(Dataset).filter(Dataset.id.in_(batch_ids)).all()
             )


### PR DESCRIPTION
Stacked on #820 (base is `contract-testing`, not `main`) and paired with GSA/datagov-catalog#384. Review #820 first.

## Why

#820 removed the file overlay, which was the right call — it compared filenames and blocked additive harvester changes. But it left the document-shape path a closed loop, and the follow-up in that PR only partly closed it.

Catalog owns no part of the OpenSearch write path: harvester defines the mapping and produces every document in production. Yet catalog’s test suite indexes its fixtures with catalog’s *own* vendored `OpenSearchWriter`, then reads them back with its own reader. A harvester-side change to `DatasetDocument`, `MAPPINGS`, or the writer is invisible to that loop.

## What changed

Mount harvester’s `search/` and `shared/` into the catalog image under their own namespace and set `HARVESTER_SEARCH_PATH`, which catalog’s new `tests/writer_provider.py` (GSA/datagov-catalog#384) reads. Catalog’s full fixture set — DCAT-US 3.0 rows, `isPartOf` collections, spatial bboxes, stopword titles — is then written by harvester’s real production code and read back by catalog’s real production code. Neither side is faked.

Two module-level imports blocked this, because they pulled harvester’s whole 420-line ORM into catalog’s image:

- `search/documents.py` used `Dataset` purely as a type annotation → moved under `TYPE_CHECKING`
- `search/writer.py` needs it only in `index_dataset_batches`, which catalog never calls → now a local import

`index_datasets` was already duck-typed (`getattr(dataset_iter, "items", dataset_iter)`, no `isinstance`) and reads only attributes catalog’s slim `app.models.Dataset` also has, so no signature changed.

## Not the overlay again

Worth being explicit, since this reintroduces a mount:

| | old overlay (removed in #820) | this |
| --- | --- | --- |
| harvester files copied over `app/search/` | yes | **no** — imported under its own namespace |
| filename parity required | yes, hard-failed | **no** |
| harvester adds a module catalog lacks | **blocks** | non-event |
| catalog’s reader / models / routes | replaced | **stay catalog’s** |

Only the writer is swapped.

## Verification

Against a catalog image built from GSA/datagov-catalog#384:

| Scenario | Result |
| --- | --- |
| harvester’s writer injected | **265 passed** — confirmed loading `/harvester/search/writer.py` |
| harvester renames `has_spatial` → `spatial_flag` | **5 failed**, all geospatial filter tests |
| harvester adds a new document field | **265 passed** — additive stays non-blocking |
| no env var (catalog’s own CI) | **265 passed** — unchanged |
| full `make test-catalog-contract` vs real GHCR image | **exit 0** (9 + 265 passed) |

The rename case is the important one: that regression is exactly what the old overlay could not detect, and it is why this is worth doing on top of #820’s CLI-seeding stage. DI exercises catalog’s rich fixtures; the CLI stage only reaches harvester’s thin ones (2 datasets, 1 organization, 0 locations).

## Notes for review

- **Ordering.** GSA/datagov-catalog#384 must reach catalog’s `main` before this does anything. Until then the mounted path is simply ignored and the suite runs with catalog’s own writer, so merging this early is harmless but also inert.
- **Pre-existing failures.** `tests/integration/search/test_writer.py` has 2 failures and 2 errors (`test_run_with_timeout_retry`, `test_index_datasets_counts_errors`). I confirmed via `git stash` that they fail identically on an unmodified tree — not caused by the import changes here.
- **Still open from #820.** Harvester’s mapping has no `dynamic: "strict"`, so OpenSearch silently re-adds a field removed from `MAPPINGS`. That softens the mapping check for clean removals. Out of scope here; worth a decision separately.

Refs GSA/data.gov#6210.