### PR TITLE
Restore dynamic-flag mapping normalization dropped by revert-809

### DIFF
--- a/app/commands/search.py
+++ b/app/commands/search.py
@@ -53,6 +53,11 @@ def _normalize_mapping_for_comparison(value):
             "search_analyzer"
         ) == normalized.get("analyzer"):
             normalized.pop("search_analyzer")
+        # OpenSearch echoes `dynamic` back as a string ("false"), while the
+        # application mapping declares it as a bool. Compare them as strings so
+        # the round trip doesn't look like a mismatch.
+        if "dynamic" in normalized and isinstance(normalized["dynamic"], bool):
+            normalized["dynamic"] = str(normalized["dynamic"]).lower()
         return normalized
 
     if isinstance(value, list):

--- a/tests/unit/test_search_commands.py
+++ b/tests/unit/test_search_commands.py
@@ -38,6 +38,43 @@ def test_reset_mapping_recreates_empty_index(app):
     assert "Mapping reset successfully. The index is empty." in result.output
 
 
+def test_reset_mapping_accepts_stringified_dynamic_flag(app):
+    """OpenSearch echoes `dynamic` back as the string "false", not a bool."""
+    client = Mock()
+    client.INDEX_NAME = "datasets"
+    client.MAPPINGS = {
+        "properties": {
+            "dcat": {
+                "type": "nested",
+                "dynamic": False,
+                "properties": {"modified": {"type": "keyword"}},
+            }
+        }
+    }
+    client.client.indices.get_mapping.return_value = {
+        "datasets": {
+            "mappings": {
+                "properties": {
+                    "dcat": {
+                        "type": "nested",
+                        "dynamic": "false",
+                        "properties": {"modified": {"type": "keyword"}},
+                    }
+                }
+            }
+        }
+    }
+
+    with patch(
+        "app.commands.search.OpenSearchClient.from_environment",
+        return_value=client,
+    ):
+        result = app.test_cli_runner().invoke(args=["search", "reset-mapping"])
+
+    assert result.exit_code == 0
+    assert "Mapping reset successfully. The index is empty." in result.output
+
+
 def test_reset_mapping_rejects_real_mapping_mismatch(app):
     client = Mock()
     client.INDEX_NAME = "datasets"


### PR DESCRIPTION
## Summary
- Restores the `dynamic` bool-vs-string normalization in `_normalize_mapping_for_comparison` (`app/commands/search.py`) that PR #823 accidentally removed along with its revert of the catalog-contract-test feature.
- OpenSearch echoes the mapping's `dynamic` flag back as the string `"false"`, while `search/mappings.py` declares it as a Python bool — without normalization, `reset-mapping` and `rebuild-opensearch-index` both false-positive on "Created index mapping does not match application mapping."
- This was actively breaking the `search-rebuild` GitHub Action in production.

## Test plan
- [x] `pytest tests/unit/test_search_commands.py` — 17/17 passed, including restored `test_reset_mapping_accepts_stringified_dynamic_flag`