### PR TITLE
Pause harvesting before the deploy, not inside the reindex

### DIFF
--- a/.github/workflows/release-space.yml
+++ b/.github/workflows/release-space.yml
@@ -2,8 +2,9 @@ name: Release to a space
 
 # The whole release for ONE Cloud Foundry space, in one reusable workflow.
 #
-#   create services -> push -> wait for the rollout -> rebuild the index (if asked)
-#     -> network policies
+#   (pause harvesting, if a rebuild will follow) -> create services -> push
+#     -> wait for the rollout -> rebuild the index (if asked) -> network policies
+#     -> resume harvesting
 #
 # Called once by commit.yml (development) and twice by deploy.yml (staging, then
 # prod), so all three spaces run byte-identical logic. Before this existed the same
@@ -98,8 +99,50 @@ permissions:
   contents: read
 
 jobs:
+  # Harvesting is paused BEFORE the deploy, not inside the rebuild.
+  #
+  # migrate_opensearch_cluster.yml opens with its own `disable-harvester`, which was
+  # first-in-workflow back when it was only ever dispatched *after* a deploy had
+  # already landed. Wrapping a deploy in front of it made that pause third in the
+  # pipeline instead, so new code ran against the old index while harvest jobs were
+  # still writing to it -- `harvester/harvest.py` indexes per dataset, and the drain
+  # in migrate waits up to 2h for in-flight jobs. Additive mapping changes survive
+  # that; a retyped or renamed field does not.
+  #
+  # migrate keeps its inner toggle (the standalone dispatch path still needs it) and
+  # the overlap is harmless: bin/set_harvest_runner_capacity.sh just does `cf set-env`,
+  # so disabling twice is a no-op.
+  disable-harvester:
+    name: Disable harvesting (${{ inputs.space }})
+    # Only when a rebuild will follow. A routine deploy must NOT pause harvesting --
+    # rolling deploys are already safe for harvest jobs, and pausing every deploy
+    # would be a behaviour change nobody asked for.
+    if: ${{ inputs.reindex && !inputs.dry_run }}
+    # Explicit `secrets:` block, unlike the `reindex` job's `inherit` below:
+    # toggle_harvester.yml declares CF_SERVICE_USER and CF_SERVICE_AUTH as *required*
+    # workflow_call secrets, and a `uses:` job that omits a required secret fails as
+    # `startup_failure` with no log and no annotation. actionlint does not model it.
+    uses: ./.github/workflows/toggle_harvester.yml
+    with:
+      state: disable
+      environment: ${{ inputs.space }}
+    secrets:
+      CF_SERVICE_USER: ${{ secrets.CF_SERVICE_USER }}
+      CF_SERVICE_AUTH: ${{ secrets.CF_SERVICE_AUTH }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   create-services:
     name: create services (${{ inputs.space }})
+    needs: disable-harvester
+    # `disable-harvester` is skipped on a plain deploy, and a job whose needs were
+    # skipped is itself skipped BEFORE its own `if:` is evaluated -- so the skipped
+    # case has to be accepted explicitly or no deploy would ever run again. This is
+    # the trap already hit twice here (migrate's teardown-replacement, and both
+    # deploy-prod and release-prod); getting it wrong on this job breaks EVERY
+    # deploy, not just labelled ones.
+    if: >-
+      ${{ !cancelled()
+      && contains(fromJson('["success","skipped"]'), needs.disable-harvester.result) }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.space }}
     # create_cloudgov_services.sh does `cf service <canonical> || cf create-service`,
@@ -264,3 +307,31 @@ jobs:
           cf_space: ${{ inputs.space }}
           cf_username: ${{ secrets.CF_SERVICE_USER }}
           cf_password: ${{ secrets.CF_SERVICE_AUTH }}
+
+  # Because the disable now lives OUTSIDE migrate, re-enabling is this workflow's
+  # responsibility too: migrate's own enable-harvester only covers the window it
+  # disabled itself, and it never runs at all if the deploy failed before the reindex.
+  enable-harvester:
+    name: Re-enable harvesting (${{ inputs.space }})
+    needs: [disable-harvester, deploy, await-rollout, reindex]
+    # `always()`, not `!cancelled()`: harvesting must resume even when the deploy
+    # failed or the run was cancelled -- leaving HARVEST_RUNNER_MAX_TASKS at 0 stops
+    # all scheduled harvesting indefinitely, with nothing to notice it.
+    #
+    # `!= 'skipped'` rather than `== 'success'`, deliberately. The intent is only to
+    # leave max_tasks alone when the disable never ran (a plain deploy), so that an
+    # operator who paused harvesting by hand is not overridden -- and that case is
+    # `skipped`. A FAILED disable must still re-enable: set_harvest_runner_capacity.sh
+    # does `cf set-env` and *then* `cf restart --strategy rolling`, so a restart that
+    # times out reports failure having already written 0. `== 'success'` would strand
+    # harvesting off in exactly that case.
+    if: always() && needs.disable-harvester.result != 'skipped'
+    uses: ./.github/workflows/toggle_harvester.yml
+    with:
+      state: enable
+      max_tasks: ${{ inputs.max_tasks }}
+      environment: ${{ inputs.space }}
+    secrets:
+      CF_SERVICE_USER: ${{ secrets.CF_SERVICE_USER }}
+      CF_SERVICE_AUTH: ${{ secrets.CF_SERVICE_AUTH }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/docs/ops/migrate-opensearch-cluster.md
+++ b/docs/ops/migrate-opensearch-cluster.md
@@ -194,13 +194,42 @@ quietly serves the old shape.
 
 ### One pipeline, three spaces
 
-`release-space.yml` is the per-space release — create services → push → wait for the
-rollout → rebuild the index → network policies. It is called once by `commit.yml` for
-`development` and twice by `deploy.yml` for `staging` then `prod`, so all three spaces
-run identical logic. The only per-space differences are `on_build_failure` (`keep` in
-prod, where re-provisioning an `es-large` costs hours; `delete` elsewhere, so a failure
+`release-space.yml` is the per-space release — pause harvesting → create services →
+push → wait for the rollout → rebuild the index → network policies → resume
+harvesting. It is called once by `commit.yml` for `development` and twice by
+`deploy.yml` for `staging` then `prod`, so all three spaces run identical logic. The
+only per-space differences are `on_build_failure` (`keep` in prod, where
+re-provisioning an `es-large` costs hours; `delete` elsewhere, so a failure
 self-heals) and `force_kill_running_jobs` (`false` in prod — long harvest jobs are not
 cancelled unattended).
+
+### A labelled release pauses harvesting for its whole duration
+
+The pause is the **first** job of the release, before the new code is pushed, and
+harvesting resumes only when the release finishes — as its own `always()` job, so it
+resumes even if the deploy failed or the run was cancelled. Only labelled releases
+pause; a plain deploy leaves harvesting running, since a rolling deploy is already
+safe for harvest jobs.
+
+That ordering exists because the writes are the hazard. The rebuild's own drain waits
+up to 2h for in-flight jobs, and every one of them indexes per dataset — so pausing
+inside the rebuild, three jobs after the push, would let new code write into the old
+index for that entire window. Additive mapping changes tolerate it; a retyped or
+renamed field does not.
+
+**This stops the writes, not the reads.** From the moment the deploy lands until the
+promote, the new code — and catalog — still query the *old* index. On a
+schema-breaking change that means wrong results for the full provision + rebuild
+duration: ~20 min on `es-medium`, hours on a prod `es-large`. Closing that needs
+[two-phase mode](#two-phase-mode-schema-breaking-changes), which the automated label
+path cannot yet reach — `release-space.yml` hardcodes `stop_after: decommission` and
+exposes no `stop_after` input. For a change that breaks reads, deploy with
+`reindex: skip` and drive the migration by hand in two phases.
+
+`migrate_opensearch_cluster.yml` keeps its own inner disable/enable for the
+hand-dispatched path, so a labelled release toggles twice. That is harmless:
+`bin/set_harvest_runner_capacity.sh` just does `cf set-env`, and both calls restore the
+same `max_tasks`.
 
 ### Each release path is a queue
 


### PR DESCRIPTION
## What

`release-space.yml` deployed new code **three jobs before** harvesting was paused. This hoists the pause to the first job of the release and resumes it in an `always()` job at the end.

`commit.yml` and `deploy.yml` need no changes — they already call `release-space.yml`, so both the `develop` → development and `main` → staging + prod paths inherit the fix.

## Why

`migrate_opensearch_cluster.yml` opens with its own `disable-harvester`, which was correct when that workflow was only ever dispatched *after* a deploy had already landed. Wrapping a deploy in front of it moved that pause from "first in its own workflow" to "third in the pipeline" without anyone changing it.

The exposure is not a brief gap: the drain waits up to **2h** for in-flight jobs (`wait_for_harvest_tasks.sh datagov-harvest 7200`), and every one of them indexes per dataset. So every write in that window went into an index whose mapping no longer matched the document being written — rejected, or silently coerced. Additive mapping changes tolerate that; a retyped or renamed field does not.

## New order

```
disable-harvester → create-services → deploy → await-rollout → reindex → network-policies
enable-harvester   ← always()
```

Only labelled releases pause. A plain deploy is unaffected — rolling deploys are already safe for harvest jobs, and pausing every deploy would be a behaviour change nobody asked for.

## One deviation from the plan

The plan specified gating the re-enable on `disable-harvester.result == 'success'`. I used `!= 'skipped'` instead.

`bin/set_harvest_runner_capacity.sh` does `cf set-env` and **then** `cf restart --strategy rolling`, so a disable whose rolling restart times out reports `failure` **having already written 0**. Gating on `== 'success'` would skip the re-enable in exactly that case and leave `HARVEST_RUNNER_MAX_TASKS` pinned at 0 indefinitely, with nothing to notice — the failure mode the `always()` exists to prevent. `skipped` is still precisely the plain-deploy case, so a hand-paused harvester is left alone either way.

## What this does NOT fix

Disabling harvesting stops the **writes**, not the **reads**. From the moment the deploy lands until the promote, the new code — and catalog — still query the *old* index. On a schema-breaking change that means wrong results for the full provision + rebuild duration (~20 min on `es-medium`, hours on a prod `es-large`).

Closing that needs the parked two-phase path, which the automated label path can't reach: `release-space.yml` hardcodes `stop_after: decommission` and exposes no `stop_after` input. Follow-up work, not in this PR. For a change that breaks reads, deploy with `reindex: skip` and drive the migration by hand.

## Verification

- `actionlint` clean on `release-space.yml`, `commit.yml`, `deploy.yml`, `toggle_harvester.yml`, `migrate_opensearch_cluster.yml`. (The 7 findings from linting *all* workflows are pre-existing, in files this PR doesn't touch.)
- **The secret wiring actionlint can't model:** `CF_SERVICE_USER`/`CF_SERVICE_AUTH` are *environment* secrets and a `uses:` job cannot declare `environment:`, so a missing one fails as `startup_failure` with no log and no annotation. Confirmed against run `31432510233` (staging migrate, success) that both toggle jobs authenticated through this identical explicit-`secrets:` pattern.
- Simulated all six branches by evaluating the actual `if:` expressions:

  | scenario | disable | create | deploy | reindex | enable |
  | --- | --- | --- | --- | --- | --- |
  | plain deploy (no label) | skipped | success | success | skipped | skipped |
  | labelled deploy | success | success | success | success | success |
  | dry run | skipped | success | success | skipped | skipped |
  | labelled, deploy fails | success | success | **failure** | skipped | success |
  | labelled, disable fails | **failure** | skipped | skipped | skipped | success |
  | labelled, cancelled | success | skipped | skipped | skipped | success |

  Note the disable-fails row: `create-services` skips, so new code never lands while writes are unpaused, and capacity is still restored.

### Still needs a real run — the regression to watch

**A plain, unlabelled deploy must still work.** `create-services` now depends on a job that skips on the common path, and a job whose `needs` were skipped is itself skipped *before* its own `if:` is evaluated — hence the explicit `contains(fromJson('["success","skipped"]'), ...)`. If that condition is wrong it breaks **every** deploy in the repo, not just labelled ones. This is the trap already hit twice here (migrate's `teardown-replacement`, and both `deploy-prod` and `release-prod`).

Then: confirm on a labelled merge that `Disable harvesting (development)` completes **before** `create services (development)` starts — by timestamp, not UI order.

## Also

`5885-zero-downtime-opensearch-timeouts` had **none** of the release pipeline (no `release-space.yml`, no `detect-reindex.yml`) and was 23 commits behind, so the workflows were about to fork into two divergent copies. `origin/develop` is now merged into it and this commit cherry-picked on top (`7c594013`). The merge was textually clean; all 86 `tests/scripts` tests pass there. 12 `test_auth_logging.py` unit failures on that branch are pre-existing — they fail identically on unmerged `develop`.