### PR TITLE
Deploy on an unlabelled release again

### DIFF
--- a/.github/workflows/release-space.yml
+++ b/.github/workflows/release-space.yml
@@ -167,6 +167,17 @@ jobs:
   deploy:
     name: deploy (${{ inputs.space }})
     needs: create-services
+    # An explicit `if:`, NOT the default. A job with no `if:` defaults to `success()`,
+    # and `success()` evaluates the whole TRANSITIVE ancestor set -- not just this job's
+    # direct `needs`. `disable-harvester` skips on every unlabelled release, so the
+    # default made this job (and everything under it) skip too, even though
+    # `create-services` succeeded. Measured in run 31527120342: `create services`
+    # succeeded, `deploy` skipped, and the run still reported green.
+    #
+    # Guarding `create-services` alone was not enough: that fixed which jobs the skip
+    # stopped at, not the fact that `success()` looks all the way up. Every job
+    # downstream of an optional job needs its own result-based condition.
+    if: ${{ !cancelled() && needs.create-services.result == 'success' }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.space }}
     # `contents: read` only. The pre-refactor jobs carried `actions: write`, but


### PR DESCRIPTION
## The bug

**Unlabelled releases to `development` have not been deploying since #834 merged.**

Run [31527120342](https://github.com/GSA/datagov-harvester/actions/runs/31527120342) — the #834 merge itself — shows it: `create services (development)` **succeeded**, then `deploy`, `await-rollout`, `network-policies` and `dry-run-summary` all **skipped**. Nothing was pushed to Cloud Foundry, and the run still reported green.

## Why

#834 hoisted the harvest pause to the first job of the release and guarded `create-services` against a skipped `disable-harvester`. That guard was necessary but not sufficient.

`deploy` carried **no `if:` at all**, and a job with no `if:` defaults to `success()` — which evaluates the whole **transitive** ancestor set, not just its direct `needs`. On an unlabelled release `disable-harvester` skips, so `success()` was false for `deploy` even though `create-services` succeeded, and the skip cascaded to everything downstream.

Guarding `create-services` alone only changed *where* the skip stopped, not the fact that `success()` looks all the way up the graph.

Three runs isolate it:

| Run | `disable-harvester` | `deploy` |
| --- | --- | --- |
| [31518201599](https://github.com/GSA/datagov-harvester/actions/runs/31518201599) (#832, before #834) | absent | **success** |
| [31527120342](https://github.com/GSA/datagov-harvester/actions/runs/31527120342) (#834, unlabelled) | skipped | **skipped** |
| [31528075293](https://github.com/GSA/datagov-harvester/actions/runs/31528075293) (#833, labelled) | success | **success** |

The labelled path was never affected — `disable-harvester` succeeds there — which is why #833 ran a full migration green and this stayed hidden.

A visible tell in the API: skipped jobs render with their name template unexpanded (`deploy (${{ inputs.space }})`) instead of `deploy (development)`.

## The fix

Give `deploy` an explicit result-based condition:

```yaml
if: ${{ !cancelled() && needs.create-services.result == 'success' }}
```

Every other job in `release-space.yml` already had one. `deploy` was the only job relying on the default, and the only one whose ancestors include an optional job.

Audited the rest: no job in `commit.yml`, `deploy.yml` or `release-space.yml` still relies on default `success()` while having `needs`. `migrate_opensearch_cluster.yml`'s `disable-harvester` and `build` do, but safely — their ancestor `plan` has no `if:` and no `needs`, so it always runs.

## Verification

- `actionlint` clean on `release-space.yml`, `commit.yml`, `deploy.yml`.
- **The check that matters is the merge of this PR itself:** an unlabelled release must show `deploy (development)` **success**, not skipped. That is the same event that exposed the bug, so it is a direct regression test.

Neither `actionlint` nor my earlier reasoning caught this — I had modeled `success()` as depending only on direct `needs`, which is precisely the wrong assumption. The only thing that surfaced it was reading what the jobs actually did in a real run.