### PR TITLE
terminate connections for upgrade or downgrade

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -125,21 +125,6 @@ def run_migrations_offline():
     with context.begin_transaction():
         context.run_migrations()
 
-
-def migrations_are_pending(connectable) -> bool:
-    script_directory = ScriptDirectory.from_config(config)
-    migration_heads = set(script_directory.get_heads())
-
-    with connectable.connect() as connection:
-        migration_context = MigrationContext.configure(connection)
-        database_heads = set(migration_context.get_current_heads())
-
-    if database_heads == migration_heads:
-        return False
-
-    return True
-
-
 def terminate_database_connections(connectable) -> None:
     autocommit_engine = connectable.execution_options(isolation_level="AUTOCOMMIT")
 
@@ -176,9 +161,7 @@ def run_migrations_online():
 
     connectable = get_engine()
 
-    # Terminate connections only if migrations are necessary
-    if migrations_are_pending(connectable):
-        terminate_database_connections(connectable)
+    terminate_database_connections(connectable)
 
     with connectable.connect() as connection:
         context.configure(

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -125,6 +125,7 @@ def run_migrations_offline():
     with context.begin_transaction():
         context.run_migrations()
 
+
 def terminate_database_connections(connectable) -> None:
     autocommit_engine = connectable.execution_options(isolation_level="AUTOCOMMIT")
 


### PR DESCRIPTION
# Pull Request

Related to [6223](https://github.com/GSA/data.gov/issues/6223)

## About
terminates db connections on db upgrade or downgrade. previously, connections were terminated only when there's migrations needing to be applied. i had tested manually dropping connections then performing the downgrade but it was still getting hung up so i thought it wasn't working but doing it in the `env.py` script worked. here's proof. previously the downgrade never finished.

```terminal
vcap@e815830c-0c54-48f7-6cb1-7d9e:~$ flask db downgrade
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running downgrade f8d4c5ec0e5b -> b3f7a91c24de, Add dcatus_catalog to harvest_job
vcap@e815830c-0c54-48f7-6cb1-7d9e:~$ flask db upgrade
[2026-08-12 14:38:15,029] WARNING [harvest_admin.create_app:278] Load manager startup failed with exception: ProgrammingError('(psycopg.errors.UndefinedColumn) column harvest_job.dcatus_catalog does not exist\nLINE 1: ...cords_validated AS harvest_job_records_validated, harvest_jo...\n                                                             ^')
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade b3f7a91c24de -> f8d4c5ec0e5b, Add dcatus_catalog to harvest_job
vcap@e815830c-0c54-48f7-6cb1-7d9e:~$ \q
bash: q: command not found
vcap@e815830c-0c54-48f7-6cb1-7d9e:~$ exit
exit
reidhewitt@Reids-MacBook-Pro datagov-harvesting-logic % 
```

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
