### PR TITLE
Support harvesting DCAT-US3 DatasetSeries objects

### DIFF
--- a/example_data/dcatus/dcatus3_0_series_with_members.json
+++ b/example_data/dcatus/dcatus3_0_series_with_members.json
@@ -1,0 +1,80 @@
+{
+  "@type": "Catalog",
+  "@id": "https://example.gov/data-series-with-members.json",
+  "conformsTo": {
+    "@type": "Standard",
+    "title": "DCAT-US 3.0"
+  },
+  "title": "Example DCAT-US 3.0 Catalog With A Dataset Series",
+  "description": "A sample DCAT-US 3.0 catalog where a DatasetSeries's seriesMember/first/last embed full Dataset objects, used for harvest testing.",
+  "datasetSeries": [
+    {
+      "@type": "DatasetSeries",
+      "@id": "https://example.gov/series/annual-report",
+      "title": "Annual Report Series",
+      "description": "A series of annual reports, one dataset per year.",
+      "seriesMember": [
+        {
+          "@type": "Dataset",
+          "title": "Annual Report 2023",
+          "description": "The first dataset in the series.",
+          "identifier": "https://example.gov/datasets/annual-report-2023",
+          "publisher": {
+            "@type": "Organization",
+            "name": "Test Agency"
+          },
+          "contactPoint": {
+            "@type": "Kind",
+            "fn": "Test Contact",
+            "hasEmail": "mailto:series@example.gov"
+          }
+        },
+        {
+          "@type": "Dataset",
+          "title": "Annual Report 2024",
+          "description": "The second dataset in the series.",
+          "identifier": "https://example.gov/datasets/annual-report-2024",
+          "publisher": {
+            "@type": "Organization",
+            "name": "Test Agency"
+          },
+          "contactPoint": {
+            "@type": "Kind",
+            "fn": "Test Contact",
+            "hasEmail": "mailto:series@example.gov"
+          }
+        }
+      ],
+      "first": {
+        "@type": "Dataset",
+        "title": "Annual Report 2023",
+        "description": "The first dataset in the series.",
+        "identifier": "https://example.gov/datasets/annual-report-2023",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Test Agency"
+        },
+        "contactPoint": {
+          "@type": "Kind",
+          "fn": "Test Contact",
+          "hasEmail": "mailto:series@example.gov"
+        }
+      },
+      "last": {
+        "@type": "Dataset",
+        "title": "Annual Report 2024",
+        "description": "The second dataset in the series.",
+        "identifier": "https://example.gov/datasets/annual-report-2024",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Test Agency"
+        },
+        "contactPoint": {
+          "@type": "Kind",
+          "fn": "Test Contact",
+          "hasEmail": "mailto:series@example.gov"
+        }
+      }
+    }
+  ]
+}

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -47,6 +47,7 @@ from harvester.utils.general_utils import (
     dataset_to_hash,
     describe_identifier_error,
     download_file,
+    extract_dcatus3_catalog_dataset_series,
     extract_dcatus3_catalog_datasets,
     extract_dcatus3_catalog_records,
     extract_dcatus3_catalog_services,
@@ -78,15 +79,25 @@ harvest_worker_sync_count = int(os.getenv("HARVEST_WORKER_SYNC_COUNT", 1))
 # complex extraction path shared with WAF/ISO sources). Each entry's
 # "extractor" pulls its objects out of a dcatus3.0 Catalog dict; its
 # "identifier_field" is the dict key that holds the record's identifier --
-# CatalogRecord has no "identifier" field, only a top-level "@id".
+# CatalogRecord and DatasetSeries have no "identifier" field, only a
+# top-level "@id". "schema_ref" is the dcatus3.0 definitions root_ref used
+# to build this type's validator -- built from this registry (not
+# hand-listed) so a new entry can't forget to wire up validation.
 NON_DATASET_RECORD_TYPES = {
     "data_service": {
         "extractor": extract_dcatus3_catalog_services,
         "identifier_field": "identifier",
+        "schema_ref": "dataservice",
     },
     "catalog_record": {
         "extractor": extract_dcatus3_catalog_records,
         "identifier_field": "@id",
+        "schema_ref": "catalogrecord",
+    },
+    "data_series": {
+        "extractor": extract_dcatus3_catalog_dataset_series,
+        "identifier_field": "@id",
+        "schema_ref": "datasetseries",
     },
 }
 
@@ -173,15 +184,15 @@ class HarvestSource:
                     definitions_dir,
                     root_ref="https://resources.data.gov/dcat-us/3.0.0/definitions/dataset",
                 ),
-                "data_service": build_dcatus3_validator(
-                    definitions_dir,
-                    root_ref="https://resources.data.gov/dcat-us/3.0.0/definitions/dataservice",
-                ),
-                "catalog_record": build_dcatus3_validator(
-                    definitions_dir,
-                    root_ref="https://resources.data.gov/dcat-us/3.0.0/definitions/catalogrecord",
-                ),
             }
+            for record_type, config in NON_DATASET_RECORD_TYPES.items():
+                self._validators[record_type] = build_dcatus3_validator(
+                    definitions_dir,
+                    root_ref=(
+                        "https://resources.data.gov/dcat-us/3.0.0/definitions/"
+                        f"{config['schema_ref']}"
+                    ),
+                )
         else:
             self._validators = {
                 "dataset": Draft202012Validator(
@@ -206,9 +217,16 @@ class HarvestSource:
         """Return the schema validator for [record_type].
 
         Non-dcatus3.0 sources only have a "dataset" validator, since they
-        have no concept of other DCAT-US 3.0 record types.
+        have no concept of other DCAT-US 3.0 record types. Raises rather
+        than silently falling back to the dataset validator for an unknown
+        record_type -- that fallback previously masked a missing
+        data_series validator entry by validating DatasetSeries objects
+        against the Dataset schema instead.
         """
-        return self._validators.get(record_type, self._validators["dataset"])
+        try:
+            return self._validators[record_type]
+        except KeyError:
+            raise ValueError(f"no validator registered for record_type '{record_type}'")
 
     @property
     def records(self):
@@ -655,11 +673,24 @@ class HarvestSource:
                             record_type: config["extractor"](catalog)
                             for record_type, config in NON_DATASET_RECORD_TYPES.items()
                         }
-                        self.external_records = extract_dcatus3_catalog_datasets(
-                            catalog
-                        ) + extract_dcatus3_nested_datasets(
-                            self.external_records_by_type.get("data_service", []),
-                            "servesDataset",
+                        self.external_records = (
+                            extract_dcatus3_catalog_datasets(catalog)
+                            + extract_dcatus3_nested_datasets(
+                                self.external_records_by_type.get("data_service", []),
+                                "servesDataset",
+                                parent_identifier_field=NON_DATASET_RECORD_TYPES[
+                                    "data_service"
+                                ]["identifier_field"],
+                            )
+                            + extract_dcatus3_nested_datasets(
+                                self.external_records_by_type.get("data_series", []),
+                                "seriesMember",
+                                "first",
+                                "last",
+                                parent_identifier_field=NON_DATASET_RECORD_TYPES[
+                                    "data_series"
+                                ]["identifier_field"],
+                            )
                         )
                         self.db_interface.update_harvest_job(
                             self.job_id,

--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -511,7 +511,18 @@ def extract_dcatus3_catalog_records(catalog: dict) -> list:
     return _extract_dcatus3_catalog_objects(catalog, "record")
 
 
-def extract_dcatus3_nested_datasets(parents: list, *fields: str) -> list:
+def extract_dcatus3_catalog_dataset_series(catalog: dict) -> list:
+    """
+    recursively collect every DatasetSeries from a DCAT-US3 Catalog dict,
+    including series nested arbitrarily deep within its "catalog"
+    (sub-catalog) field.
+    """
+    return _extract_dcatus3_catalog_objects(catalog, "datasetSeries")
+
+
+def extract_dcatus3_nested_datasets(
+    parents: list, *fields: str, parent_identifier_field: str = "identifier"
+) -> list:
     """
     pull full inline Dataset objects out of [fields] on each dict in
     [parents], tagging each with "parent_identifier" set to the parent's own
@@ -522,18 +533,37 @@ def extract_dcatus3_nested_datasets(parents: list, *fields: str) -> list:
     than reference them by id: DataService.servesDataset, and
     DatasetSeries.seriesMember/first/last. This is the shared extraction
     step for all of them -- callers pass the parent objects and which
-    field(s) on them hold nested datasets.
+    field(s) on them hold nested datasets. parent_identifier_field selects
+    which key on the parent holds its own identifier: DatasetSeries (like
+    CatalogRecord) has no "identifier" field, only a top-level "@id".
+
+    the same dataset can legitimately appear in more than one of [fields] on
+    the same parent (e.g. a DatasetSeries's "first" is typically also present
+    in "seriesMember") -- that's redundancy in the source data, not a
+    harvest-time duplicate-identifier error, so each parent only contributes
+    one copy per distinct identifier.
     """
     nested_datasets = []
 
     for parent in parents:
-        parent_identifier = normalize_dataset_identifier(parent.get("identifier"))
+        parent_identifier = normalize_dataset_identifier(
+            parent.get(parent_identifier_field)
+        )
+        seen_identifiers = set()
         for field in fields:
             value = parent.get(field)
             if value is None:
                 continue
             candidates = value if isinstance(value, list) else [value]
             for dataset in candidates:
+                dataset_identifier = normalize_dataset_identifier(
+                    dataset.get("identifier")
+                )
+                if dataset_identifier is not None:
+                    if dataset_identifier in seen_identifiers:
+                        continue
+                    seen_identifiers.add(dataset_identifier)
+
                 dataset = dict(dataset)
                 dataset["parent_identifier"] = parent_identifier
                 nested_datasets.append(dataset)

--- a/migrations/versions/c3e5a7b9d1f3_add_data_series_to_record_type.py
+++ b/migrations/versions/c3e5a7b9d1f3_add_data_series_to_record_type.py
@@ -1,0 +1,60 @@
+"""add 'data_series' to record_type
+
+Revision ID: c3e5a7b9d1f3
+Revises: b2d4f6a8c0e2
+Create Date: 2026-08-12 00:00:00.000001
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3e5a7b9d1f3"
+down_revision = "b2d4f6a8c0e2"
+branch_labels = None
+depends_on = None
+
+old_options = ("dataset", "data_service", "catalog_record")
+new_options = ("dataset", "data_service", "catalog_record", "data_series")
+
+old_enum = sa.Enum(*old_options, name="record_type")
+new_enum = sa.Enum(*new_options, name="record_type_new")
+
+
+def upgrade():
+    new_enum.create(op.get_bind(), checkfirst=False)
+
+    op.execute("ALTER TABLE harvest_record ALTER COLUMN record_type DROP DEFAULT")
+    op.execute(
+        "ALTER TABLE harvest_record ALTER COLUMN record_type TYPE record_type_new "
+        "USING record_type::text::record_type_new"
+    )
+    op.execute(
+        "ALTER TABLE harvest_record ALTER COLUMN record_type "
+        "SET DEFAULT 'dataset'::record_type_new"
+    )
+
+    old_enum.drop(op.get_bind(), checkfirst=False)
+    op.execute("ALTER TYPE record_type_new RENAME TO record_type")
+
+
+def downgrade():
+    old_enum.name = "record_type_old"
+    old_enum.create(op.get_bind(), checkfirst=False)
+
+    op.execute("ALTER TABLE harvest_record ALTER COLUMN record_type DROP DEFAULT")
+    # will fail if any rows use the data_series record_type
+    op.execute(
+        "ALTER TABLE harvest_record ALTER COLUMN record_type TYPE record_type_old "
+        "USING record_type::text::record_type_old"
+    )
+    op.execute(
+        "ALTER TABLE harvest_record ALTER COLUMN record_type "
+        "SET DEFAULT 'dataset'::record_type_old"
+    )
+
+    new_enum.name = "record_type"
+    new_enum.drop(op.get_bind(), checkfirst=False)
+
+    op.execute("ALTER TYPE record_type_old RENAME TO record_type")

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -39,7 +39,7 @@ ORGANIZATION_TYPE_SELECT_CHOICES = [
 
 RECORD_STATUS_VALUES = ["error", "success", "dataset_pending"]
 
-RECORD_TYPE_VALUES = ["dataset", "data_service", "catalog_record"]
+RECORD_TYPE_VALUES = ["dataset", "data_service", "catalog_record", "data_series"]
 
 SEVERITY_VALUES = ["error", "warning"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,6 +346,21 @@ def source_data_dcatus3_0_service_serves_dataset(organization_data: dict) -> dic
 
 
 @pytest.fixture
+def source_data_dcatus3_0_series_with_members(organization_data: dict) -> dict:
+    return {
+        "id": "f0b1c3d5-7890-4bcd-ef01-234567890124",
+        "name": "Test Source DCAT-US 3.0 (series with members)",
+        "notification_emails": ["email@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus3_0_series_with_members.json",
+        "schema_type": "dcatus3.0",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
 def source_data_dcatus_same_title(organization_data: dict) -> dict:
     return {
         "id": "50301cdb-5766-46ed-8f46-ca63844315a2",
@@ -706,6 +721,17 @@ def job_data_dcatus3_0_service_serves_dataset(
         "id": "f9b1d3e5-789a-4bcd-ef01-234567890123",
         "status": "new",
         "harvest_source_id": source_data_dcatus3_0_service_serves_dataset["id"],
+    }
+
+
+@pytest.fixture
+def job_data_dcatus3_0_series_with_members(
+    source_data_dcatus3_0_series_with_members: dict,
+) -> dict:
+    return {
+        "id": "a1c2e4f6-8901-4cde-f012-345678901235",
+        "status": "new",
+        "harvest_source_id": source_data_dcatus3_0_series_with_members["id"],
     }
 
 

--- a/tests/integration/harvest/test_extract.py
+++ b/tests/integration/harvest/test_extract.py
@@ -201,6 +201,35 @@ class TestExtract:
             "https://example.gov/services/one"
         )
 
+    def test_extract_dcatus3_0_series_with_members(
+        self,
+        make_harvest_source,
+        source_data_dcatus3_0_series_with_members,
+        job_data_dcatus3_0_series_with_members,
+    ):
+        """A DatasetSeries's seriesMember/first/last embed full Dataset
+        objects; first/last duplicate entries already in seriesMember must
+        not be double-harvested, and each surviving dataset is tagged with
+        the series' identifier as its parent."""
+        harvest_source = make_harvest_source(
+            source_data_dcatus3_0_series_with_members,
+            job_data_dcatus3_0_series_with_members,
+        )
+        harvest_source.acquire_minimum_external_data()
+
+        assert len(harvest_source.external_records_by_type["data_series"]) == 1
+        assert len(harvest_source.external_records) == 2
+
+        identifiers = {r["identifier"] for r in harvest_source.external_records}
+        assert identifiers == {
+            "https://example.gov/datasets/annual-report-2023",
+            "https://example.gov/datasets/annual-report-2024",
+        }
+        assert all(
+            r["parent_identifier"] == "https://example.gov/series/annual-report"
+            for r in harvest_source.external_records
+        )
+
     def test_check_iso_dcatus_schema(
         self,
         make_harvest_source,

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -274,6 +274,66 @@ class TestHarvestJobFullFlow:
         assert dataset_record.status == "success"
 
     @patch("harvester.harvest.HarvestSource.send_notification_emails")
+    def test_harvest_dcatus3_0_series_members_persist_with_parent(
+        self,
+        send_notification_emails_mock: MagicMock,
+        interface,
+        organization_data,
+        source_data_dcatus3_0_series_with_members,
+    ):
+        """AC: Datasets embedded in a DatasetSeries's seriesMember/first/last
+        are harvested as real Datasets, tagged with the series' identifier
+        as their parent, with first/last redundancy against seriesMember
+        deduped rather than double-harvested. The DatasetSeries itself
+        persists as a data_series HarvestRecord only, no Dataset row."""
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus3_0_series_with_members)
+        harvest_job = interface.add_harvest_job(
+            {
+                "status": "new",
+                "harvest_source_id": (source_data_dcatus3_0_series_with_members["id"]),
+            }
+        )
+
+        job_id = harvest_job.id
+        harvest_job_starter(job_id, "harvest")
+
+        harvest_job = interface.get_harvest_job(job_id)
+        assert harvest_job.status == "complete"
+        assert harvest_job.records_added == 3
+
+        datasets = interface.db.query(Dataset).all()
+        assert len(datasets) == 2
+        assert {d.dcat["identifier"] for d in datasets} == {
+            "https://example.gov/datasets/annual-report-2023",
+            "https://example.gov/datasets/annual-report-2024",
+        }
+
+        records = (
+            interface.db.query(HarvestRecord)
+            .filter(
+                HarvestRecord.harvest_source_id
+                == source_data_dcatus3_0_series_with_members["id"]
+            )
+            .all()
+        )
+        assert len(records) == 3
+
+        dataset_records = [r for r in records if r.record_type == "dataset"]
+        series_records = [r for r in records if r.record_type == "data_series"]
+        assert len(dataset_records) == 2
+        assert len(series_records) == 1
+        assert all(r.status == "success" for r in dataset_records)
+        assert all(r.status == "success" for r in series_records)
+        assert all(
+            r.parent_identifier == "https://example.gov/series/annual-report"
+            for r in dataset_records
+        )
+        assert series_records[0].identifier == (
+            "https://example.gov/series/annual-report"
+        )
+
+    @patch("harvester.harvest.HarvestSource.send_notification_emails")
     def test_multiple_harvest_jobs(
         self,
         send_notification_emails_mock: MagicMock,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -828,6 +828,22 @@ class TestDcatus3Catalog:
 
 
 class TestExtractDcatus3NestedDatasets:
+    def test_uses_custom_parent_identifier_field(self):
+        """DatasetSeries (like CatalogRecord) has no "identifier" field,
+        only a top-level "@id"."""
+        parents = [
+            {
+                "@id": "series-1",
+                "seriesMember": [{"identifier": "ds-1"}],
+            }
+        ]
+
+        result = extract_dcatus3_nested_datasets(
+            parents, "seriesMember", parent_identifier_field="@id"
+        )
+
+        assert result == [{"identifier": "ds-1", "parent_identifier": "series-1"}]
+
     def test_extracts_single_field(self):
         parents = [
             {
@@ -890,6 +906,62 @@ class TestExtractDcatus3NestedDatasets:
         extract_dcatus3_nested_datasets(parents, "servesDataset")
 
         assert "parent_identifier" not in original_dataset
+
+    def test_dedupes_same_identifier_across_fields_on_one_parent(self):
+        """A DatasetSeries's "first"/"last" are typically also present in
+        "seriesMember" -- that's redundant source data, not a
+        duplicate-identifier error, so only one copy should survive per
+        parent."""
+        parents = [
+            {
+                "identifier": "series-1",
+                "seriesMember": [
+                    {"identifier": "ds-1", "title": "First title seen"},
+                    {"identifier": "ds-2"},
+                ],
+                "first": {
+                    "identifier": "ds-1",
+                    "title": "Redundant, should be dropped",
+                },
+            }
+        ]
+
+        result = extract_dcatus3_nested_datasets(
+            parents, "seriesMember", "first", "last"
+        )
+
+        assert [d["identifier"] for d in result] == ["ds-1", "ds-2"]
+        assert result[0]["title"] == "First title seen"
+
+    def test_does_not_dedupe_missing_identifiers_across_datasets(self):
+        """Datasets with no usable identifier must each be kept (and later
+        flagged individually as missing an identifier), not collapsed into
+        one just because they all normalize to None."""
+        parents = [
+            {
+                "identifier": "series-1",
+                "seriesMember": [{"title": "No id one"}, {"title": "No id two"}],
+            }
+        ]
+
+        result = extract_dcatus3_nested_datasets(parents, "seriesMember")
+
+        assert len(result) == 2
+
+    def test_same_identifier_across_different_parents_not_deduped(self):
+        """Overlapping identifiers across different parents are a real
+        cross-source ambiguity, not the same kind of intra-parent
+        redundancy, so both copies should be kept for the normal
+        duplicate-identifier filter to catch."""
+        parents = [
+            {"identifier": "svc-1", "servesDataset": [{"identifier": "ds-1"}]},
+            {"identifier": "svc-2", "servesDataset": [{"identifier": "ds-1"}]},
+        ]
+
+        result = extract_dcatus3_nested_datasets(parents, "servesDataset")
+
+        assert len(result) == 2
+        assert {d["parent_identifier"] for d in result} == {"svc-1", "svc-2"}
 
 
 class TestRetrySession:


### PR DESCRIPTION
## Summary

Stacked on #835 (#6181, CatalogRecord), which is itself stacked on #831 (#6178, DataService).

- Adds `extract_dcatus3_catalog_dataset_series` and wires `data_series` into the `NON_DATASET_RECORD_TYPES` registry established in #835 — same "extract from a catalog field, validate, persist as HarvestRecord only" shape as CatalogRecord.
- The interesting part: a DatasetSeries's `seriesMember`/`first`/`last` fields embed full inline `Dataset` objects (same shape as `DataService.servesDataset` from #831), not references. These are pulled out via `extract_dcatus3_nested_datasets` (already built generically for exactly this in #831) and merged into the normal dataset pipeline — so series members get real `Dataset` rows, appear in the catalog/OpenSearch, and are tagged with `parent_identifier` = the series' own `@id` (reusing the existing `HarvestRecord.parent_identifier` column, same mechanism as WAF-collection parents).
- `extract_dcatus3_nested_datasets` gained two things to make this work correctly:
  - `parent_identifier_field`, since DatasetSeries (like CatalogRecord) has no `identifier` field, only `@id`.
  - intra-parent dedup by dataset identifier, since a series' `first`/`last` are typically also present in `seriesMember` — that's redundancy in the source data, not a harvest-time duplicate-identifier error, and would otherwise get flagged as one.
- Found and fixed a real bug along the way: `HarvestSource._validators` had no `data_series` entry, and `validator_for()` silently fell back to the Dataset validator for any unrecognized `record_type` — so a DatasetSeries record would have validated (and failed) against the Dataset schema instead of its own DatasetSeries schema. Validators are now built generically off `NON_DATASET_RECORD_TYPES` (which gained a `schema_ref` field) so the two registries can't drift apart again, and `validator_for()` now raises on an unknown `record_type` instead of silently mis-validating.

New migration (`c3e5a7b9d1f3`) adds `data_series` to the `record_type` enum, chained on top of #835's `catalog_record` migration — tested both upgrade and downgrade against the live dev DB.

Addresses [GSA/data.gov#6179](https://github.com/GSA/data.gov/issues/6179).

## Commits
1. `record_type` enum migration for `data_series`
2. DatasetSeries extraction/validation (+ the validator-fallback bug fix)
3. New DatasetSeries fixture (with the seriesMember/first/last redundancy case)
4. Tests for extraction/validation/persistence

## Test plan
- [x] `make lint-check` passes
- [x] Full `pytest tests/unit tests/integration` — 692 passed; the 12 failures present are pre-existing and unrelated (same failures as on the base #6181 branch)
- [x] Manually tested the new migration's upgrade and downgrade paths against the live dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)