### PR TITLE
Potential fix for code scanning alert no. 39: URL redirection from remote source

### DIFF
--- a/app/main/auth.py
+++ b/app/main/auth.py
@@ -2,9 +2,8 @@ import os
 import secrets
 import time
 import uuid
-from urllib.parse import urlparse
-
 import jwt
+from werkzeug.urls import url_parse
 import requests
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
@@ -63,11 +62,19 @@ def create_client_assertion():
 
 
 def _is_safe_redirect_target(next_url):
-    """Only allow relative, same-origin paths to avoid open redirects."""
-    if not next_url or next_url.startswith("//"):
+    """Only allow relative or same-origin URLs to avoid open redirects."""
+    if not next_url:
         return False
-    parsed = urlparse(next_url)
-    return not parsed.scheme and not parsed.netloc and next_url.startswith("/")
+
+    # Normalize browser-tolerated backslashes before parsing.
+    target = next_url.replace("\\", "/")
+    ref_url = url_parse(request.host_url)
+    test_url = url_parse(url_parse(request.host_url).join(target))
+
+    return (
+        test_url.scheme in {"http", "https"}
+        and ref_url.netloc == test_url.netloc
+    )
 
 
 def _redirect_to_login_gov():


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/datagov-harvester/security/code-scanning/39](https://github.com/GSA/datagov-harvester/security/code-scanning/39)

General fix: do not pass user-derived URLs directly to `redirect()` unless validated by a trusted URL-safety routine that enforces allowed hosts/schemes and handles edge cases correctly.

Best fix here: replace the custom `_is_safe_redirect_target` logic with Flask/Werkzeug’s `url_parse`-based same-origin/relative validation that normalizes backslashes and enforces host matching against `request.host_url`. Keep behavior the same: allow only relative/same-origin targets; otherwise fall back to `main.index`. This keeps existing functionality while hardening validation.

In `app/main/auth.py`:
- Add import: `from werkzeug.urls import url_parse`
- Update `_is_safe_redirect_target(next_url)` implementation to:
  - reject empty
  - normalize backslashes
  - parse both host URL and target
  - allow only `http/https` or empty scheme
  - require target netloc to be empty or same as current host

No other route logic needs changing because callers already use the helper.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
