### PR TITLE
closes scoped_session at end of function with idling transaction

### DIFF
--- a/harvester/lib/load_manager.py
+++ b/harvester/lib/load_manager.py
@@ -79,34 +79,40 @@ class LoadManager:
         task before it stops so we adjust the running_tasks calculation and
         only schedule at most one new job.
         """
-        running_tasks = self.handler.num_running_app_tasks()
-        if running_tasks is None:
-            # None here indicates that tasks couldn't be listed with the API
-            # so be safe by not doing anything.
-            logger.warning("Not starting new jobs because tasks could not be listed")
-            return
+        try:
+            running_tasks = self.handler.num_running_app_tasks()
+            if running_tasks is None:
+                # None here indicates that tasks couldn't be listed with the API
+                # so be safe by not doing anything.
+                logger.warning(
+                    "Not starting new jobs because tasks could not be listed"
+                )
+                return
 
-        if check_from_task:
-            running_tasks -= 1
+            if check_from_task:
+                running_tasks -= 1
 
-        if running_tasks >= MAX_TASKS_COUNT:
-            logger.info(
-                f"{running_tasks} running tasks >= max tasks count ({MAX_TASKS_COUNT})."  # noqa E501
-            )
-            return
-        else:
-            slots = MAX_TASKS_COUNT - running_tasks
+            if running_tasks >= MAX_TASKS_COUNT:
+                logger.info(
+                    f"{running_tasks} running tasks >= max tasks count ({MAX_TASKS_COUNT})."  # noqa E501
+                )
+                return
+            else:
+                slots = MAX_TASKS_COUNT - running_tasks
 
-        if check_from_task:
-            # from a task only do 1 at most
-            slots = 1 if slots > 0 else 0
+            if check_from_task:
+                # from a task only do 1 at most
+                slots = 1 if slots > 0 else 0
 
-        # invoke cf_task with next jobs
-        # then mark the job as running in the DB
-        jobs = interface.get_new_harvest_jobs_in_past(limit=slots)
-        for job in jobs:
-            self.start_job(job.id, job.job_type)
-            self.schedule_next_job(job.harvest_source_id)
+            # invoke cf_task with next jobs
+            # then mark the job as running in the DB
+            jobs = interface.get_new_harvest_jobs_in_past(limit=slots)
+            for job in jobs:
+                self.start_job(job.id, job.job_type)
+                self.schedule_next_job(job.harvest_source_id)
+        finally:
+            # closes the scoped_session object
+            interface.close()
 
     def start(self):
         """Runs on Flask Admin start, roughly every 15min"""

--- a/tests/integration/app/test_load_manager.py
+++ b/tests/integration/app/test_load_manager.py
@@ -7,7 +7,7 @@ import pytest
 from cloudfoundry_client.errors import InvalidStatusCode
 from freezegun import freeze_time
 
-from database.models import HarvestJobError
+from database.models import HarvestJob, HarvestJobError
 from harvester.lib.load_manager import LoadManager
 from harvester.utils.general_utils import create_future_date
 
@@ -31,7 +31,6 @@ def all_tasks_json_fixture():
 
 @freeze_time("Jan 14th, 2012")
 class TestLoadManager:
-
     @patch("harvester.lib.cf_handler.CloudFoundryClient")
     @patch("harvester.lib.load_manager.MAX_TASKS_COUNT", 3)
     def test_load_manager_invokes_tasks(
@@ -549,6 +548,7 @@ class TestLoadManager:
             interface_no_jobs.add_harvest_job(job)
 
         jobs = interface_no_jobs.get_new_harvest_jobs_in_past()
+        job_ids = [job.id for job in jobs]
         assert len(jobs) == 2
         for job in jobs:
             assert job.status == "new"
@@ -559,8 +559,11 @@ class TestLoadManager:
         load_manager = LoadManager()
         load_manager._start_new_jobs(check_from_task=True)
 
+        jobs = [interface_no_jobs.db.get(HarvestJob, job_id) for job_id in job_ids]
+
         # one task created
         start_task_mock = CFCMock.return_value.v3.tasks.create
+
         assert start_task_mock.call_count == 1
         # first job is in progress
         assert jobs[0].status == "in_progress"

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from jsonschema.exceptions import ValidationError
 
-from database.models import Dataset, HarvestRecord
+from database.models import Dataset, HarvestJob, HarvestRecord
 from harvester.harvest import HarvestSource, check_for_more_work, harvest_job_starter
 from harvester.utils.general_utils import download_file
 
@@ -760,6 +760,7 @@ class TestCheckMoreWork:
                 "date_created": datetime.now() + timedelta(days=-1),
             }
         )
+        job_id = job.id
 
         # no running tasks
         CFCMock.return_value.v3.apps._pagination.return_value = []
@@ -768,5 +769,8 @@ class TestCheckMoreWork:
         # one task created
         start_task_mock = CFCMock.return_value.v3.tasks.create
         assert start_task_mock.call_count == 1
+
+        job = interface.db.get(HarvestJob, job_id)
+
         # job in progress
         assert job.status == "in_progress"


### PR DESCRIPTION
# Pull Request

Related to [6223](https://github.com/GSA/data.gov/issues/6223). 

## About
- relevant [comment](https://github.com/GSA/data.gov/issues/6223#issuecomment-5270027423). basically, `get_new_harvest_jobs_in_past` produces an `idle in transaction` process in postgres lasting quite a bit (almost 30 minutes in prod). i pushed this update to dev yesterday and so far there's no longer issues with that query. here's the sql command you can use to check pg activity. it'll store the results locally in a csv.
- i'd prefer to update load manager to accept a session and manage it's own db interface instead of relying solely on the harvester session and db interface but that would require more change.

```sql 
\copy (
SELECT
    state,
    now() - xact_start as duration,
    now() - query_start as query_duration,
    wait_event_type,
    wait_event,
    query
FROM pg_stat_activity
WHERE datname = current_database()
ORDER BY xact_start NULLS LAST
) TO 'processes.csv' WITH CSV HEADER;
```

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
