### PR TITLE
Verify label-driven reindex in development (docs-only payload)

### DIFF
--- a/docs/ops/opensearch-zero-downtime-deployment.md
+++ b/docs/ops/opensearch-zero-downtime-deployment.md
@@ -8,6 +8,15 @@ The label detector scans from the last successful release rather than inspecting
 only the current push. This preserves the migration request when GitHub replaces a
 pending release with a newer merge.
 
+The watermark must still be an ancestor of the commit being released. A force-push
+orphans the runs it rewrote, so the detector walks the recent successful releases
+newest-first and takes the first one that is still on the branch's lineage,
+skipping any whose comparison against HEAD reports `diverged`. When a branch has
+no release history on its current lineage at all, the detector reports no
+migration instead of failing, because there is no commit range to inspect. A
+labeled pull request that was merged onto a discarded lineage is therefore never
+detected, and needs `flask search rebuild-index` run by hand.
+
 ## Release sequence
 
 For each Cloud Foundry space, the release:


### PR DESCRIPTION
Docs-only payload used to verify the `force re-index recommended` path end to end in the development space.

Documents the watermark lineage handling added in 0b2bdacc: the detector now walks past release watermarks orphaned by a force-push, and treats a lineage with no release history as "no migration" rather than failing.

The previous attempt at this verification (#833) was merged onto a lineage that a later force-push discarded, so its label never triggered a reindex.

Expected on merge:
- `Detect OpenSearch migration` reports `migration_needed=true` and this PR number
- `Release development` provisions `datagov-catalog-opensearch-next`, reindexes, promotes it to `datagov-catalog-opensearch`, and retires the old cluster
- scheduled harvesting is restored to three tasks