### PR TITLE
Avoid SMTP binding for the OpenSearch task app

### DIFF
--- a/.github/workflows/release-space.yml
+++ b/.github/workflows/release-space.yml
@@ -85,7 +85,6 @@ jobs:
           cf_space: ${{ env.CF_SPACE }}
           command: cf push datagov-harvest-next --task
           manifest_vars: >-
-            --var app_name=datagov-harvest-next
             --var opensearch_service_name=datagov-catalog-opensearch-next
           deploy_proxy: "false"
           cf_username: ${{ secrets.CF_SERVICE_USER }}

--- a/manifest.yml
+++ b/manifest.yml
@@ -16,7 +16,8 @@ applications:
       INTERNAL_ROUTE: ((route_internal))
       BASIC_AUTH_ENABLED: ((basic_auth_enabled))
 
-  - name: ((app_name))
+  - &harvest_app
+    name: ((app_name))
     buildpacks:
       - python_buildpack
     routes:
@@ -48,3 +49,12 @@ applications:
       NEW_RELIC_CONFIG_FILE: /home/vcap/app/config/newrelic.ini
       ASSET_VERSION: ((asset_version))
     command: ./app-start.sh
+
+  - <<: *harvest_app
+    name: ((app_name))-next
+    routes: []
+    services:
+      - ((harvest_service_name))-db
+      - ((harvest_service_name))-secrets
+      - ((opensearch_service_name))
+      - logstack-space-drain

--- a/manifest.yml
+++ b/manifest.yml
@@ -53,6 +53,7 @@ applications:
   - <<: *harvest_app
     name: ((app_name))-next
     routes: []
+    instances: 0
     services:
       - ((harvest_service_name))-db
       - ((harvest_service_name))-secrets


### PR DESCRIPTION
## Summary
- add a dedicated manifest entry for `datagov-harvest-next`
- omit the unused SMTP binding while retaining DB, secrets, replacement OpenSearch, and log drain bindings
- keep the canonical harvester SMTP binding unchanged

Addresses #851.

## Validation
- `pre-commit run check-yaml --files manifest.yml .github/workflows/release-space.yml`
- parsed the merged manifest and verified SMTP is present only on the canonical app