### PR TITLE
add missing index to models

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -289,6 +289,7 @@ class HarvestRecord(Base):
             postgresql_where=text("status = 'success'"),
             postgresql_include=["action"],
         ),
+        Index("ix_harvest_record_status", "status"),
     )
 
     @property


### PR DESCRIPTION
# Pull Request

Related to recent db issues. [slack discussion](https://gsa-tts.slack.com/archives/C2N85536E/p1786735187963519)

## About
found out that [this index](https://github.com/GSA/datagov-harvester/blob/aba49641d4cd0def2d046d0cf800539a37ea8fee/migrations/versions/cf577d46fccd_new_initial_base_migration.py#L210) was missing in our models after running `flask db check`. the link is an old migration. those indexes have been created in staging and prod. will add it to development.

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
