### PR TITLE
add new relic db monitor script

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,7 @@ from app.local_dev_auth import is_running_on_cloud_foundry
 from app.startup_validation import validate_required_env_vars
 from config.logger_config import LOGGING_CONFIG
 from database.models import db
+from scripts.new_relic_db_monitor import emit_idle_transaction_event
 from scripts.sync_datasets import register_cli
 
 logger = logging.getLogger("harvest_admin")
@@ -326,6 +327,13 @@ def create_app():
             # we need to get to app start up, so ignore all errors
             # from the load manager but log them
             logger.warning("Load manager startup failed with exception: %s", repr(e))
+
+    # emit new relic custom event for db idle-in-transaction monitoring
+    new_relic_monitor_db_activity = (
+        os.getenv("NEW_RELIC_MONITOR_DB_ACTIVITY", "false").lower() == "true"
+    )
+    if new_relic_monitor_db_activity:
+        emit_idle_transaction_event()
 
     # Content-Security-Policy headers
     # single quotes need to appear in some of the strings

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -68,6 +68,7 @@ from harvester.utils.general_utils import (
     translate_spatial_to_geojson,
     traverse_waf,
 )
+from scripts.new_relic_db_monitor import emit_idle_transaction_event
 
 # logging data
 logger = logging.getLogger("harvest_runner")
@@ -1617,6 +1618,13 @@ def check_for_more_work():
         # The application should pick up jobs every 15 minutes,
         # this is only for speed.
         return
+
+    # emit new relic custom event for db idle-in-transaction monitoring
+    new_relic_monitor_db_activity = (
+        os.getenv("NEW_RELIC_MONITOR_DB_ACTIVITY", "false").lower() == "true"
+    )
+    if new_relic_monitor_db_activity:
+        emit_idle_transaction_event()
 
 
 if __name__ == "__main__":

--- a/manifest.yml
+++ b/manifest.yml
@@ -47,6 +47,7 @@ applications:
       NEW_RELIC_HOST: gov-collector.newrelic.com
       NEW_RELIC_MONITOR_MODE: ((new_relic_monitor_mode))
       NEW_RELIC_CONFIG_FILE: /home/vcap/app/config/newrelic.ini
+      NEW_RELIC_MONITOR_DB_ACTIVITY: ((new_relic_monitor_db_activity))
       ASSET_VERSION: ((asset_version))
     command: ./app-start.sh
 

--- a/scripts/new_relic_db_monitor.py
+++ b/scripts/new_relic_db_monitor.py
@@ -1,0 +1,93 @@
+import logging
+import os
+
+import newrelic.agent
+from sqlalchemy import create_engine, text
+
+logger = logging.getLogger(__name__)
+
+newrelic.agent.initialize()
+
+PG_ACTIVITY_SUMMARY = text("""
+    WITH idle_transactions AS (
+        SELECT
+            pid,
+            application_name,
+            query,
+            xact_start,
+            state_change
+        FROM pg_stat_activity
+        WHERE state = 'idle in transaction'
+          AND xact_start IS NOT NULL
+    )
+    SELECT
+        COUNT(*)::int AS idle_transaction_count,
+
+        COALESCE(
+            MAX(EXTRACT(EPOCH FROM (now() - xact_start))),
+            0
+        )::float AS max_transaction_age_seconds,
+
+        COALESCE(
+            MAX(EXTRACT(EPOCH FROM (now() - state_change))),
+            0
+        )::float AS max_idle_age_seconds,
+
+        COUNT(*) FILTER (
+            WHERE now() - xact_start > INTERVAL '60 seconds'
+        )::int AS over_60_seconds,
+
+        COUNT(*) FILTER (
+            WHERE now() - xact_start > INTERVAL '5 minutes'
+        )::int AS over_5_minutes,
+
+        (
+            ARRAY_AGG(query ORDER BY xact_start ASC)
+        )[1] AS oldest_transaction_query
+
+    FROM idle_transactions
+""")
+
+
+def emit_idle_transaction_event():
+    try:
+        application = newrelic.agent.register_application(timeout=10)
+
+        if not application.active:
+            logger.error("new relic monitoring session isn't active. exiting.")
+            return
+
+        db_url = os.getenv("DATABASE_URI")
+        if not db_url:
+            logger.error(
+                "database url isn't set in env. can't proceed further. exiting."
+            )
+            return
+
+        engine = create_engine(db_url)
+
+        with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+            activity = conn.execute(PG_ACTIVITY_SUMMARY).mappings().one()
+
+        if not activity:
+            logger.error("no activity from the database to emit to new relic. exiting.")
+            return
+
+        newrelic.agent.record_custom_event(
+            "PostgresActivitySample",
+            {
+                "idleTransactionCount": activity["idle_transaction_count"],
+                "maxTransactionAgeSeconds": activity["max_transaction_age_seconds"],
+                "maxIdleAgeSeconds": activity["max_idle_age_seconds"],
+                "over60Seconds": activity["over_60_seconds"],
+                "over5Minutes": activity["over_5_minutes"],
+                "oldestTransactionQuery": activity["oldest_transaction_query"] or "",
+                # new relic app name is available via cf manifest.yml
+                "appName": os.getenv("NEW_RELIC_APP_NAME"),
+            },
+            application=application,
+        )
+
+        newrelic.agent.shutdown_agent(timeout=5)
+    except Exception as e:
+        logger.error(f"exception thrown during new relic db monitoring. {str(e)}")

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -28,3 +28,4 @@ REDIRECT_URI: https://harvest-dev.data.gov/callback
 
 # New Relic
 new_relic_monitor_mode: false
+new_relic_monitor_db_activity: false

--- a/vars.prod.yml
+++ b/vars.prod.yml
@@ -28,3 +28,4 @@ REDIRECT_URI: https://harvest.data.gov/callback
 
 # New Relic
 new_relic_monitor_mode: true
+new_relic_monitor_db_activity: true

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -28,3 +28,4 @@ REDIRECT_URI: https://harvest-stage.data.gov/callback
 
 # New Relic
 new_relic_monitor_mode: true
+new_relic_monitor_db_activity: true


### PR DESCRIPTION

# Pull Request

Related to [6252](https://github.com/GSA/data.gov/issues/6252)

## About
adds a script for sending db "idle_in_transaction" data to new relic. this occurs on flask app startup after the last db operation. flask-sqlalchemy shapes session management around the request lifecycle so sessions are closed following a response. it also occurs at the end of a harvest. 

another thing we could look into is setting this for our scheduled scripts (e.g. "update_dataset_view_count") but for now let's try to see what's happening during harvesting and the load manager (called on flask app startup) 

[image of event on prod](https://github.com/GSA/data.gov/issues/6252#issuecomment-5331516391)
## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
