### PR TITLE
#6243: count a dataset quality issue once, as either an error or a warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ test-e2e-ci: re-up test-playwright test-functional ## All e2e/expensive tests. R
 
 test-ci: up test-unit test-integration test-scripts ## All simulated tests using only db and required test resources. Run on commit.
 
-re-up: clean up sleep-5 load-test-data ## resets system to clean fixture status
+re-up: clean up wait-for-app load-test-data ## resets system to clean fixture status
 
 re-up-debug: clean up-debug load-test-data ## resets system to clean fixture status for flask debugging
 
@@ -103,6 +103,21 @@ clean: ## Cleans docker images
 	
 sleep-5:
 	sleep 5
+
+wait-for-app: ## Wait until flask has finished db upgrade and is serving
+	@echo "Waiting for the app to finish migrations and start..."
+	@i=0; \
+	while [ $$i -lt 60 ]; do \
+		code=$$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/ 2>/dev/null || true); \
+		case $$code in \
+			2*|3*) echo "App is up (HTTP $$code)."; exit 0 ;; \
+		esac; \
+		i=$$((i + 1)); \
+		sleep 1; \
+	done; \
+	echo "App did not become ready in 60s"; \
+	docker compose logs --tail=80 app; \
+	exit 1
 
 lint-check:  ## Lints wtih ruff, isort, black
 	poetry run ruff check .

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,7 +17,6 @@ from app.local_dev_auth import is_running_on_cloud_foundry
 from app.startup_validation import validate_required_env_vars
 from config.logger_config import LOGGING_CONFIG
 from database.models import db
-from scripts.new_relic_db_monitor import emit_idle_transaction_event
 from scripts.sync_datasets import register_cli
 
 logger = logging.getLogger("harvest_admin")
@@ -333,6 +332,8 @@ def create_app():
         os.getenv("NEW_RELIC_MONITOR_DB_ACTIVITY", "false").lower() == "true"
     )
     if new_relic_monitor_db_activity:
+        from scripts.new_relic_db_monitor import emit_idle_transaction_event
+
         emit_idle_transaction_event()
 
     # Content-Security-Policy headers

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -68,7 +68,6 @@ from harvester.utils.general_utils import (
     translate_spatial_to_geojson,
     traverse_waf,
 )
-from scripts.new_relic_db_monitor import emit_idle_transaction_event
 
 # logging data
 logger = logging.getLogger("harvest_runner")
@@ -1625,6 +1624,8 @@ def check_for_more_work():
         os.getenv("NEW_RELIC_MONITOR_DB_ACTIVITY", "false").lower() == "true"
     )
     if new_relic_monitor_db_activity:
+        from scripts.new_relic_db_monitor import emit_idle_transaction_event
+
         emit_idle_transaction_event()
 
 

--- a/harvester/utils/dcat_warnings.py
+++ b/harvester/utils/dcat_warnings.py
@@ -13,6 +13,27 @@ message so the storage-wiring story can populate `harvest_record_error.type`
 without parsing message text (mirroring how harvest errors are typed by
 exception class name in `harvester/harvest.py`).
 
+Boundary with the schema (GSA/data.gov#6243): a warning rule must never fire on
+a value the DCAT-US 3.0 JSON Schema already rejects. The schema owns JSON type,
+format, length, and enum checks; this module owns content-and-semantics checks
+on values the schema accepts. When a rule below guards on `isinstance(...)` (or
+similarly narrows its input) purely to defer to the schema, the guard's comment
+names the schema constraint it is deferring to. Restating a schema constraint
+here would report the same defect twice: once as a validator error, once as a
+warning. If you add a rule, check the field's definition under
+`schemas/dcatus3.0/definitions/` first and only warn on values the schema's
+type/format/length/enum already lets through.
+
+Known, accepted limitation: dropping the universal `@id` IRI walk (see below)
+means an `@id` on an object nested under a property the schema does not
+define (e.g. an ad hoc `extension` object) now produces no signal at all --
+not a schema error, not a warning -- because the schema never validates that
+object in the first place. We do not restore the universal walk: doing so
+would reinstate the exact double-report this issue is about for every
+schema-defined object (each definition declares `@id` as `{"type": "string",
+"format": "iri"}`), and a position-aware version would need to track which
+paths the schema actually covers, which this module does not do.
+
 Rules that validate against controlled vocabularies (ISO 639-1 languages, IANA
 character sets and media types, NARA restriction authority lists) read bundled
 static JSON snapshots from `reference_data/` instead of calling those registries
@@ -75,8 +96,6 @@ _NARA_SPECIFIC_USE_RESTRICTION = _load_reference_values(
 )
 
 
-_IRI_FORMAT_CHECKER = FormatChecker()
-
 # xsd:duration / ISO 8601 duration. Requires something after P (and after T
 # when a time part is present); accepts an optional leading sign and weeks.
 _XSD_DURATION_RE = re.compile(
@@ -111,26 +130,67 @@ _US_COUNTRY_NAMES = {
     "united states of america",
 }
 
-
-def _is_valid_iri(value) -> bool:
-    """True when value is a string that conforms to the IRI format."""
-    return isinstance(value, str) and _IRI_FORMAT_CHECKER.conforms(value, "iri")
+# Used by `_parse_dcat_date` to defer to the validator's own definition of a
+# valid "date"/"date-time" (the validator itself is built with
+# `format_checker=FormatChecker()`, see `build_dcatus3_validator`). This is
+# not restating a schema constraint -- it is asking the schema's own checker
+# whether a value is in-bounds before treating it as a parsed date, so a
+# value the schema rejects (e.g. a date-time with no UTC offset) can't also
+# be double-reported as a `date_out_of_order` warning (GSA/data.gov#6243).
+_DATE_FORMAT_CHECKER = FormatChecker()
 
 
 def _parse_dcat_date(value):
-    """Parse a DCAT date/date-time/YYYY/YYYY-MM string to a date, else None."""
+    """Parse a DCAT date/date-time/YYYY/YYYY-MM string to a date, else None.
+
+    A `created`/`modified`/`issued`/etc. value is `anyOf[null, {format:
+    date-time}, {format: date}, {pattern: "^[0-9]{4}$"}, {pattern:
+    "^[0-9]{4}-[0-9]{2}$"}]` (see e.g. Dataset.json `created`). Only that
+    exact set parses here; anything else is already a schema error, not a
+    content-quality one. `format: date-time` is RFC 3339 and requires a UTC
+    offset, which `datetime.fromisoformat` alone does not enforce, so the
+    date-time branch below checks `FormatChecker` first rather than relying
+    on `fromisoformat` succeeding.
+
+    Every one of those alternatives is checked by the schema against the
+    value exactly as given -- the `^[0-9]{4}$`/`^[0-9]{4}-[0-9]{2}$` patterns
+    are anchored with no allowance for surrounding whitespace, and both
+    `FormatChecker` formats reject it too. So this parses `value` itself, not
+    a stripped copy: a padded string like `" 2025-06-01 "` is already a
+    schema `format`/`pattern` error (GSA/data.gov#6243), and stripping it
+    here would let it parse anyway and be double-reported as
+    `date_out_of_order`.
+    """
     if not isinstance(value, str):
         return None
-    v = value.strip()
     try:
-        if re.fullmatch(r"\d{4}", v):
-            return date(int(v), 1, 1)
-        if re.fullmatch(r"\d{4}-\d{2}", v):
-            year, month = v.split("-")
+        if re.fullmatch(r"\d{4}", value):
+            return date(int(value), 1, 1)
+        if re.fullmatch(r"\d{4}-\d{2}", value):
+            year, month = value.split("-")
             return date(int(year), int(month), 1)
-        return datetime.fromisoformat(v.replace("Z", "+00:00")).date()
+        if _DATE_FORMAT_CHECKER.conforms(value, "date"):
+            return date.fromisoformat(value)
+        if _DATE_FORMAT_CHECKER.conforms(value, "date-time"):
+            # RFC 3339 (what `format: date-time` requires) treats the "T"
+            # separator and the "Z" UTC designator as case-insensitive, and
+            # `FormatChecker` -- and therefore the schema -- accepts a
+            # lowercase "z" for the same reason it accepts a lowercase "t"
+            # (which `fromisoformat` already tolerates on its own). Only a
+            # trailing, case-insensitive "z" needs normalizing to the offset
+            # `fromisoformat` requires; anywhere else in a valid date-time
+            # string, "Z"/"z" can't appear. Leaving this schema-valid form
+            # unparseable would mean no `date_out_of_order` warning could
+            # ever fire for it (GSA/data.gov#6243).
+            normalized = re.sub(r"[Zz]$", "+00:00", value)
+            return datetime.fromisoformat(normalized).date()
     except ValueError:
+        # `conforms()` accepts some values (e.g. a pattern-only "0000" year)
+        # that the stricter parse below still rejects; treat those as
+        # unparseable rather than raising out of warning detection, matching
+        # this function's pre-6243 behavior.
         return None
+    return None
 
 
 def _date_later_than(value, other) -> bool:
@@ -142,37 +202,16 @@ def _date_later_than(value, other) -> bool:
     return parsed_value > parsed_other
 
 
-def _warn_iri(field: str, value) -> Optional[DcatWarning]:
-    """Warn if a single field value is not a valid IRI."""
-    if value is None or _is_valid_iri(value):
-        return None
-    return DcatWarning("invalid_iri", f'`{field}` value "{value}" is not a valid IRI.')
-
-
-def _warn_iris(field: str, values) -> list:
-    """Warn for each string entry in an array-valued field that is not an IRI.
-
-    Non-string entries (e.g. Standard objects on `conformsTo`) are skipped here;
-    their `@id` is covered by the universal object walk.
-    """
-    if not isinstance(values, list):
-        return []
-    warnings = []
-    for value in values:
-        if isinstance(value, str) and not _is_valid_iri(value):
-            warnings.append(
-                DcatWarning(
-                    "invalid_iri", f'`{field}` value "{value}" is not a valid IRI.'
-                )
-            )
-    return warnings
-
-
 def _warn_duplicate_keywords(keywords) -> list:
-    """Warn once per keyword that appears more than once."""
+    """Warn once per keyword that appears more than once.
+
+    Empty entries are skipped: `keyword` items carry `minLength: 1`, so ""
+    is already a schema violation, not a content-quality one. Whitespace-only
+    entries pass that constraint, so they are still counted here.
+    """
     if not isinstance(keywords, list):
         return []
-    counts = Counter(k for k in keywords if isinstance(k, str))
+    counts = Counter(k for k in keywords if isinstance(k, str) and k != "")
     return [
         DcatWarning(
             "duplicate_keyword",
@@ -187,7 +226,11 @@ def _warn_spatial_resolution(value) -> Optional[DcatWarning]:
     """Warn if spatialResolutionInMeters is non-numeric or not greater than zero."""
     if value is None:
         return None
-    if not _DECIMAL_RE.match(str(value)):
+    # spatialResolutionInMeters is `type: ["null", "string"]`; a non-string
+    # value is already a schema type error, not a content-quality one.
+    if not isinstance(value, str):
+        return None
+    if not _DECIMAL_RE.match(value):
         return DcatWarning(
             "invalid_spatial_resolution",
             f'`spatialResolutionInMeters` value "{value}" '
@@ -207,7 +250,13 @@ def _warn_temporal_resolution(value, invalid_msg: str) -> Optional[DcatWarning]:
     `invalid_msg` supplies the class-specific message tail (ISO 8601 for Dataset,
     xsd:duration for Distribution/DataService); the grammar checked is identical.
     """
-    if value is None or (isinstance(value, str) and _XSD_DURATION_RE.match(value)):
+    if value is None:
+        return None
+    # temporalResolution is `type: ["null", "string"]`; a non-string value is
+    # already a schema type error, not a content-quality one.
+    if not isinstance(value, str):
+        return None
+    if _XSD_DURATION_RE.match(value):
         return None
     return DcatWarning(
         "invalid_temporal_resolution",
@@ -217,7 +266,14 @@ def _warn_temporal_resolution(value, invalid_msg: str) -> Optional[DcatWarning]:
 
 def _warn_byte_size(value) -> Optional[DcatWarning]:
     """Warn if byteSize does not parse to a number."""
-    if value is None or is_number(value):
+    if value is None:
+        return None
+    # byteSize is `type: ["null", "string"]`; a non-string value (e.g. a list)
+    # is already a schema type error. is_number() would otherwise raise
+    # TypeError on non-string/non-numeric values such as a list.
+    if not isinstance(value, str):
+        return None
+    if is_number(value):
         return None
     return DcatWarning(
         "invalid_byte_size",
@@ -286,27 +342,49 @@ def _warn_tel_has_letters(value) -> Optional[DcatWarning]:
     return None
 
 
-def _warn_expected_data_type(value) -> list:
-    """Warn for each expectedDataType value that does not begin with `xsd:`."""
-    values = value if isinstance(value, list) else [value]
-    warnings = []
-    for entry in values:
-        if isinstance(entry, str) and not entry.startswith("xsd:"):
-            warnings.append(
-                DcatWarning(
-                    "invalid_expected_data_type",
-                    f'`expectedDataType` value "{entry}" does not appear to be a '
-                    'valid XSD type. Expected format begins with "xsd:" (e.g., '
-                    '"xsd:string", "xsd:decimal").',
-                )
-            )
-    return warnings
+def _warn_expected_data_type(value) -> Optional[DcatWarning]:
+    """Warn if expectedDataType does not begin with `xsd:`."""
+    # Metric.expectedDataType is `"type": "string"`, a scalar; a non-string
+    # value (e.g. a list) is already a schema type error.
+    if not isinstance(value, str):
+        return None
+    if not value.startswith("xsd:"):
+        return DcatWarning(
+            "invalid_expected_data_type",
+            f'`expectedDataType` value "{value}" does not appear to be a '
+            'valid XSD type. Expected format begins with "xsd:" (e.g., '
+            '"xsd:string", "xsd:decimal").',
+        )
+    return None
 
 
 def _warn_spatial_unresolved(field: str, value) -> Optional[DcatWarning]:
-    """Warn if a spatial value cannot be resolved to a geographic area."""
+    """Warn if a spatial value cannot be resolved to a geographic area.
+
+    `bbox` and `geometry` are each `anyOf[null, string, object]`
+    (Location.json), and the object variant requires "type" and
+    "coordinates" for both. A value that is neither a string nor a dict
+    carrying those required keys is already a schema type/required-property
+    error for either field, not a content-quality one, so it is skipped here
+    rather than re-warned on.
+
+    `bbox`'s object variant additionally pins "type" to the constant
+    "Polygon"; an object whose "type" isn't exactly "Polygon" is already a
+    schema `const` error there, so it is skipped too (GSA/data.gov#6243) --
+    `translate_spatial` never gets the chance to judge it. `geometry`'s
+    object variant has no such constant (any "type" value passes the
+    schema), so a `geometry` dict `translate_spatial` can't resolve is still
+    a legitimate, schema-clean content-quality warning and must still fire.
+    """
     if value is None:
         return None
+    if not isinstance(value, (str, dict)):
+        return None
+    if isinstance(value, dict):
+        if not {"type", "coordinates"} <= value.keys():
+            return None
+        if field == "bbox" and value.get("type") != "Polygon":
+            return None
     if translate_spatial(value):
         return None
     return DcatWarning(
@@ -332,7 +410,14 @@ def _warn_us_postal_code(postal_code, country_name) -> Optional[DcatWarning]:
 
 
 def _warn_empty_address(address: dict) -> Optional[DcatWarning]:
-    """Warn if an Address object has no populated fields."""
+    """Warn if an Address object has no populated fields.
+
+    Each Address field is `type: ["null", "string"]` (Address.json), so
+    `None` and "" are the only schema-valid "unpopulated" states. Any other
+    falsy value (e.g. `0`, `[]`) is already a schema type error, not an
+    empty-address content issue -- there is a populated, if wrongly-typed,
+    value, so it must not also count toward "no populated fields".
+    """
     fields = (
         "street-address",
         "locality",
@@ -340,7 +425,7 @@ def _warn_empty_address(address: dict) -> Optional[DcatWarning]:
         "postal-code",
         "country-name",
     )
-    if all(not (address.get(field) or "") for field in fields):
+    if all(address.get(field) in (None, "") for field in fields):
         return DcatWarning("empty_address", "Address object has no populated fields.")
     return None
 
@@ -366,11 +451,15 @@ def _as_list(value) -> list:
 def _warn_language(value) -> list:
     """Warn on language codes that are too short or not recognized ISO 639-1.
 
-    `language` may be a single string or an array of strings.
+    `language` is `anyOf[null, {string, maxLength 2}, {array of {string,
+    maxLength 2}}]`, so `language` may be a single string or an array of
+    strings; either way each entry is expected to already be at most 2
+    characters. An entry longer than 2 characters is already a schema
+    `maxLength` error, so it is skipped here rather than re-warned on.
     """
     warnings = []
     for entry in _as_list(value):
-        if not isinstance(entry, str):
+        if not isinstance(entry, str) or len(entry) > 2:
             continue
         if len(entry) < 2:
             warnings.append(
@@ -393,8 +482,13 @@ def _warn_language(value) -> list:
 
 def _warn_character_encoding(value) -> list:
     """Warn on character encodings not recognized as IANA character set names."""
+    # Distribution.characterEncoding is `anyOf[null, {array of string}]`; a
+    # bare string (not wrapped in a list) is already a schema type error, so
+    # only a list is evaluated here (unlike `_warn_language`, no `_as_list`).
+    if not isinstance(value, list):
+        return []
     warnings = []
-    for entry in _as_list(value):
+    for entry in value:
         if isinstance(entry, str) and entry.lower() not in _IANA_CHARACTER_SETS:
             warnings.append(
                 DcatWarning(
@@ -482,10 +576,6 @@ def _dataset_warnings(obj: dict) -> list:
         _warn_issued_after_modified(obj.get("issued"), obj.get("modified")),
     )
     _append(warnings, _warn_language(obj.get("language")))
-    _append(warnings, _warn_iris("relation", obj.get("relation")))
-    _append(warnings, _warn_iri("image", obj.get("image")))
-    _append(warnings, _warn_iris("isReferencedBy", obj.get("isReferencedBy")))
-    _append(warnings, _warn_iris("conformsTo", obj.get("conformsTo")))
     return warnings
 
 
@@ -500,7 +590,6 @@ def _distribution_warnings(obj: dict) -> list:
     _append(warnings, _warn_character_encoding(obj.get("characterEncoding")))
     _append(warnings, _warn_media_type(obj.get("mediaType")))
     _append(warnings, _warn_language(obj.get("language")))
-    _append(warnings, _warn_iris("conformsTo", obj.get("conformsTo")))
     return warnings
 
 
@@ -512,7 +601,6 @@ def _dataservice_warnings(obj: dict) -> list:
         _warn_temporal_resolution(obj.get("temporalResolution"), _XSD_DURATION_MSG),
     )
     _append(warnings, _warn_language(obj.get("language")))
-    _append(warnings, _warn_iris("conformsTo", obj.get("conformsTo")))
     return warnings
 
 
@@ -648,14 +736,23 @@ def _walk_objects(node):
 def detect_dcat_warnings(data: dict) -> list:
     """Detect DCAT-US 3 content-quality warnings in a dataset record.
 
-    Walks the record, runs the universal `@id` IRI check on every object, and
-    dispatches each typed object to its class rules. Returns a flat list of
-    `DcatWarning` tuples (empty when the record is clean).
+    Walks the record and dispatches each typed object to its class rules.
+    Returns a flat list of `DcatWarning` tuples (empty when the record is
+    clean). There is no universal `@id`/IRI check here: every DCAT-US 3
+    definition declares `@id` as `{"type": "string", "format": "iri"}`, so an
+    invalid IRI is already a schema `format` error (GSA/data.gov#6243).
     """
     warnings = []
     for obj in _walk_objects(data):
-        _append(warnings, _warn_iri("@id", obj.get("@id")))
-        rule = _TYPE_RULES.get(obj.get("@type"))
+        type_value = obj.get("@type")
+        # `@type` is `{"type": "string", ...}` in every DCAT-US 3 definition;
+        # a non-string `@type` (e.g. a list or dict from a malformed record)
+        # is already a schema type error, not a content-quality one. It is
+        # also unhashable, so `_TYPE_RULES.get` would raise `TypeError:
+        # unhashable type` on it if dispatched anyway.
+        if not isinstance(type_value, str):
+            continue
+        rule = _TYPE_RULES.get(type_value)
         if rule is not None:
             _append(warnings, rule(obj))
     return warnings

--- a/harvester/utils/dcat_warnings.py
+++ b/harvester/utils/dcat_warnings.py
@@ -13,26 +13,19 @@ message so the storage-wiring story can populate `harvest_record_error.type`
 without parsing message text (mirroring how harvest errors are typed by
 exception class name in `harvester/harvest.py`).
 
-Boundary with the schema (GSA/data.gov#6243): a warning rule must never fire on
-a value the DCAT-US 3.0 JSON Schema already rejects. The schema owns JSON type,
-format, length, and enum checks; this module owns content-and-semantics checks
-on values the schema accepts. When a rule below guards on `isinstance(...)` (or
-similarly narrows its input) purely to defer to the schema, the guard's comment
-names the schema constraint it is deferring to. Restating a schema constraint
-here would report the same defect twice: once as a validator error, once as a
-warning. If you add a rule, check the field's definition under
-`schemas/dcatus3.0/definitions/` first and only warn on values the schema's
-type/format/length/enum already lets through.
+Boundary with the schema: a warning rule must never fire on a value the
+DCAT-US 3.0 JSON Schema already rejects. The schema owns type, format, length,
+and enum checks; this module owns content-and-semantics checks on values the
+schema accepts. Guards that narrow input (e.g. `isinstance`) exist to defer to
+the schema, not to restate it. Add a rule only after checking the field under
+`schemas/dcatus3.0/definitions/`.
 
-Known, accepted limitation: dropping the universal `@id` IRI walk (see below)
-means an `@id` on an object nested under a property the schema does not
-define (e.g. an ad hoc `extension` object) now produces no signal at all --
-not a schema error, not a warning -- because the schema never validates that
-object in the first place. We do not restore the universal walk: doing so
-would reinstate the exact double-report this issue is about for every
-schema-defined object (each definition declares `@id` as `{"type": "string",
-"format": "iri"}`), and a position-aware version would need to track which
-paths the schema actually covers, which this module does not do.
+Known limitation: there is no universal `@id` IRI walk. An `@id` on an object
+the schema does not define (e.g. an ad hoc `extension`) produces no signal,
+because the schema never validates that object. Restoring a universal walk
+would double-report every schema-defined `@id` (`{"type": "string", "format":
+"iri"}`); a position-aware walk would need to track which paths the schema
+covers, which this module does not do.
 
 Rules that validate against controlled vocabularies (ISO 639-1 languages, IANA
 character sets and media types, NARA restriction authority lists) read bundled
@@ -130,36 +123,16 @@ _US_COUNTRY_NAMES = {
     "united states of america",
 }
 
-# Used by `_parse_dcat_date` to defer to the validator's own definition of a
-# valid "date"/"date-time" (the validator itself is built with
-# `format_checker=FormatChecker()`, see `build_dcatus3_validator`). This is
-# not restating a schema constraint -- it is asking the schema's own checker
-# whether a value is in-bounds before treating it as a parsed date, so a
-# value the schema rejects (e.g. a date-time with no UTC offset) can't also
-# be double-reported as a `date_out_of_order` warning (GSA/data.gov#6243).
+# Same FormatChecker the DCAT-US 3 validator uses (see `build_dcatus3_validator`).
 _DATE_FORMAT_CHECKER = FormatChecker()
 
 
 def _parse_dcat_date(value):
     """Parse a DCAT date/date-time/YYYY/YYYY-MM string to a date, else None.
 
-    A `created`/`modified`/`issued`/etc. value is `anyOf[null, {format:
-    date-time}, {format: date}, {pattern: "^[0-9]{4}$"}, {pattern:
-    "^[0-9]{4}-[0-9]{2}$"}]` (see e.g. Dataset.json `created`). Only that
-    exact set parses here; anything else is already a schema error, not a
-    content-quality one. `format: date-time` is RFC 3339 and requires a UTC
-    offset, which `datetime.fromisoformat` alone does not enforce, so the
-    date-time branch below checks `FormatChecker` first rather than relying
-    on `fromisoformat` succeeding.
-
-    Every one of those alternatives is checked by the schema against the
-    value exactly as given -- the `^[0-9]{4}$`/`^[0-9]{4}-[0-9]{2}$` patterns
-    are anchored with no allowance for surrounding whitespace, and both
-    `FormatChecker` formats reject it too. So this parses `value` itself, not
-    a stripped copy: a padded string like `" 2025-06-01 "` is already a
-    schema `format`/`pattern` error (GSA/data.gov#6243), and stripping it
-    here would let it parse anyway and be double-reported as
-    `date_out_of_order`.
+    Only schema-valid forms parse. Date-times go through FormatChecker first
+    because fromisoformat is looser than RFC 3339 (UTC offset required).
+    Whitespace is not stripped: a padded string is already a schema error.
     """
     if not isinstance(value, str):
         return None
@@ -172,23 +145,12 @@ def _parse_dcat_date(value):
         if _DATE_FORMAT_CHECKER.conforms(value, "date"):
             return date.fromisoformat(value)
         if _DATE_FORMAT_CHECKER.conforms(value, "date-time"):
-            # RFC 3339 (what `format: date-time` requires) treats the "T"
-            # separator and the "Z" UTC designator as case-insensitive, and
-            # `FormatChecker` -- and therefore the schema -- accepts a
-            # lowercase "z" for the same reason it accepts a lowercase "t"
-            # (which `fromisoformat` already tolerates on its own). Only a
-            # trailing, case-insensitive "z" needs normalizing to the offset
-            # `fromisoformat` requires; anywhere else in a valid date-time
-            # string, "Z"/"z" can't appear. Leaving this schema-valid form
-            # unparseable would mean no `date_out_of_order` warning could
-            # ever fire for it (GSA/data.gov#6243).
+            # FormatChecker accepts trailing Z/z (RFC 3339);
+            # fromisoformat needs +00:00.
             normalized = re.sub(r"[Zz]$", "+00:00", value)
             return datetime.fromisoformat(normalized).date()
     except ValueError:
-        # `conforms()` accepts some values (e.g. a pattern-only "0000" year)
-        # that the stricter parse below still rejects; treat those as
-        # unparseable rather than raising out of warning detection, matching
-        # this function's pre-6243 behavior.
+        # FormatChecker accepts some values (e.g. year "0000") that still fail to parse.
         return None
     return None
 
@@ -205,9 +167,7 @@ def _date_later_than(value, other) -> bool:
 def _warn_duplicate_keywords(keywords) -> list:
     """Warn once per keyword that appears more than once.
 
-    Empty entries are skipped: `keyword` items carry `minLength: 1`, so ""
-    is already a schema violation, not a content-quality one. Whitespace-only
-    entries pass that constraint, so they are still counted here.
+    Empty strings are skipped (`minLength: 1`); whitespace-only entries still count.
     """
     if not isinstance(keywords, list):
         return []
@@ -226,8 +186,6 @@ def _warn_spatial_resolution(value) -> Optional[DcatWarning]:
     """Warn if spatialResolutionInMeters is non-numeric or not greater than zero."""
     if value is None:
         return None
-    # spatialResolutionInMeters is `type: ["null", "string"]`; a non-string
-    # value is already a schema type error, not a content-quality one.
     if not isinstance(value, str):
         return None
     if not _DECIMAL_RE.match(value):
@@ -252,8 +210,6 @@ def _warn_temporal_resolution(value, invalid_msg: str) -> Optional[DcatWarning]:
     """
     if value is None:
         return None
-    # temporalResolution is `type: ["null", "string"]`; a non-string value is
-    # already a schema type error, not a content-quality one.
     if not isinstance(value, str):
         return None
     if _XSD_DURATION_RE.match(value):
@@ -268,9 +224,7 @@ def _warn_byte_size(value) -> Optional[DcatWarning]:
     """Warn if byteSize does not parse to a number."""
     if value is None:
         return None
-    # byteSize is `type: ["null", "string"]`; a non-string value (e.g. a list)
-    # is already a schema type error. is_number() would otherwise raise
-    # TypeError on non-string/non-numeric values such as a list.
+    # is_number() raises TypeError on a list.
     if not isinstance(value, str):
         return None
     if is_number(value):
@@ -344,8 +298,6 @@ def _warn_tel_has_letters(value) -> Optional[DcatWarning]:
 
 def _warn_expected_data_type(value) -> Optional[DcatWarning]:
     """Warn if expectedDataType does not begin with `xsd:`."""
-    # Metric.expectedDataType is `"type": "string"`, a scalar; a non-string
-    # value (e.g. a list) is already a schema type error.
     if not isinstance(value, str):
         return None
     if not value.startswith("xsd:"):
@@ -361,20 +313,10 @@ def _warn_expected_data_type(value) -> Optional[DcatWarning]:
 def _warn_spatial_unresolved(field: str, value) -> Optional[DcatWarning]:
     """Warn if a spatial value cannot be resolved to a geographic area.
 
-    `bbox` and `geometry` are each `anyOf[null, string, object]`
-    (Location.json), and the object variant requires "type" and
-    "coordinates" for both. A value that is neither a string nor a dict
-    carrying those required keys is already a schema type/required-property
-    error for either field, not a content-quality one, so it is skipped here
-    rather than re-warned on.
-
-    `bbox`'s object variant additionally pins "type" to the constant
-    "Polygon"; an object whose "type" isn't exactly "Polygon" is already a
-    schema `const` error there, so it is skipped too (GSA/data.gov#6243) --
-    `translate_spatial` never gets the chance to judge it. `geometry`'s
-    object variant has no such constant (any "type" value passes the
-    schema), so a `geometry` dict `translate_spatial` can't resolve is still
-    a legitimate, schema-clean content-quality warning and must still fire.
+    Skip values that are neither a string nor a dict with "type" and
+    "coordinates" -- those are already schema errors. `bbox` objects must
+    also have `"type": "Polygon"` (schema `const`); `geometry` has no such
+    const, so an unresolvable geometry dict is still a content warning.
     """
     if value is None:
         return None
@@ -412,11 +354,8 @@ def _warn_us_postal_code(postal_code, country_name) -> Optional[DcatWarning]:
 def _warn_empty_address(address: dict) -> Optional[DcatWarning]:
     """Warn if an Address object has no populated fields.
 
-    Each Address field is `type: ["null", "string"]` (Address.json), so
-    `None` and "" are the only schema-valid "unpopulated" states. Any other
-    falsy value (e.g. `0`, `[]`) is already a schema type error, not an
-    empty-address content issue -- there is a populated, if wrongly-typed,
-    value, so it must not also count toward "no populated fields".
+    Only `None` and "" count as unpopulated; other falsy values are already
+    schema type errors.
     """
     fields = (
         "street-address",
@@ -451,11 +390,8 @@ def _as_list(value) -> list:
 def _warn_language(value) -> list:
     """Warn on language codes that are too short or not recognized ISO 639-1.
 
-    `language` is `anyOf[null, {string, maxLength 2}, {array of {string,
-    maxLength 2}}]`, so `language` may be a single string or an array of
-    strings; either way each entry is expected to already be at most 2
-    characters. An entry longer than 2 characters is already a schema
-    `maxLength` error, so it is skipped here rather than re-warned on.
+    `language` may be a string or an array of strings. Entries longer than 2
+    characters are already a schema `maxLength` error.
     """
     warnings = []
     for entry in _as_list(value):
@@ -482,9 +418,8 @@ def _warn_language(value) -> list:
 
 def _warn_character_encoding(value) -> list:
     """Warn on character encodings not recognized as IANA character set names."""
-    # Distribution.characterEncoding is `anyOf[null, {array of string}]`; a
-    # bare string (not wrapped in a list) is already a schema type error, so
-    # only a list is evaluated here (unlike `_warn_language`, no `_as_list`).
+    # Array-of-string only; a bare string is a schema type error
+    # (unlike `_warn_language`).
     if not isinstance(value, list):
         return []
     warnings = []
@@ -738,18 +673,12 @@ def detect_dcat_warnings(data: dict) -> list:
 
     Walks the record and dispatches each typed object to its class rules.
     Returns a flat list of `DcatWarning` tuples (empty when the record is
-    clean). There is no universal `@id`/IRI check here: every DCAT-US 3
-    definition declares `@id` as `{"type": "string", "format": "iri"}`, so an
-    invalid IRI is already a schema `format` error (GSA/data.gov#6243).
+    clean). Invalid `@id` IRIs are schema `format` errors, not warnings.
     """
     warnings = []
     for obj in _walk_objects(data):
         type_value = obj.get("@type")
-        # `@type` is `{"type": "string", ...}` in every DCAT-US 3 definition;
-        # a non-string `@type` (e.g. a list or dict from a malformed record)
-        # is already a schema type error, not a content-quality one. It is
-        # also unhashable, so `_TYPE_RULES.get` would raise `TypeError:
-        # unhashable type` on it if dispatched anyway.
+        # Non-string @type is a schema error, and unhashable for `_TYPE_RULES.get`.
         if not isinstance(type_value, str):
             continue
         rule = _TYPE_RULES.get(type_value)

--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -1388,20 +1388,14 @@ def get_format_from_str(validation_msg: str) -> str:
             return f"max {match.group(1)} items"
         return "max string length requirement"
 
-    # mirrors the "is too long" (maxLength/maxItems) case above, for the
-    # `minItems` container constraint (GSA/data.gov#6243). `assemble_
-    # validation_errors` appends the `[minItems=N]` hint the same way it
-    # does for `maxItems`.
     if "is too short" in validation_msg:
         match = re.search(r"\[minItems=(\d+)\]", validation_msg)
         if match:
             return f"min {match.group(1)} items"
         return "min items requirement"
 
-    # `uniqueItems` reads "has non-unique elements", whose last word alone
-    # ("elements") loses the rule being broken (GSA/data.gov#6243). match
-    # jsonschema's full wording, not just "non-unique" -- an invalid *value*
-    # containing that text would otherwise hijack its own error message.
+    # Match jsonschema's full "has non-unique elements" wording, not just
+    # "non-unique" -- an invalid value containing that text would hijack the match.
     if "has non-unique elements" in validation_msg:
         return "unique items"
 
@@ -1416,13 +1410,9 @@ def found_simple_message(
 ) -> bool:
     """
     determine whether the input validation error represents the most
-    succinct cause for error based on its json_path or dtype
+    succinct cause for error based on its json_path or dtype.
 
-    `forced` is a last-resort override used by `assemble_validation_errors`
-    (GSA/data.gov#6243) for the one case below that would otherwise leave a
-    schema-invalid record with no recorded message at all: a same-path
-    container `type` error that this function normally suppresses as
-    branch noise. See that function's own comments for when `forced` is set.
+    `forced` is a last-resort override set by `assemble_validation_errors`.
     """
     # these are all the unique dtypes found in the
     # non-federal schema (no different than federal)
@@ -1440,29 +1430,10 @@ def found_simple_message(
         if len(validation_error.instance) == 0:
             return True
 
-        # a container that fails a `type` check outright is its own simplest
-        # cause, and `type` errors carry no `context` to dig into, so
-        # dropping one loses the defect entirely (GSA/data.gov#6243). it's
-        # simple when the constraint is a list of types (e.g.
-        # `["null", "string"]` -- can't be a container at all), or when the
-        # error came straight off `iter_errors` (no parent, so an
-        # unconditional leaf like `@type: {"type": "string"}`).
-        #
-        # a single-type constraint reached through `error.context` is the
-        # ambiguous case: `anyOf`/`oneOf` decomposes into one branch per
-        # alternative, and "isn't that alternative's type" is noise when a
-        # sibling holds the real cause. `context` is flat -- every entry
-        # shares the `anyOf` as its `parent` -- so compare json_paths: noise
-        # sits at the path the `anyOf` is deciding on, while a real cause
-        # reached through a branch sits deeper (e.g. an item of an
-        # array-of-objects branch).
-        #
-        # `forced` covers the case where deferring to a sibling would lose
-        # the defect: when every alternative is a scalar/null type, all
-        # branches are same-path noise and no deeper cause exists to defer
-        # to. `assemble_validation_errors` sets it only after confirming the
-        # unforced pass recorded nothing, trading a vague message that names
-        # the right json_path for silence, which reads as "record is fine".
+        # `type` errors have no `context`. Keep them when the allowed types are
+        # a list, when this is a top-level error, or when the path is deeper
+        # than the parent (a real cause inside a branch). Same-path single-type
+        # errors are anyOf/oneOf branch noise unless `forced`.
         if validation_error.validator == "type":
             return bool(
                 isinstance(validation_error.validator_value, list)
@@ -1471,24 +1442,12 @@ def found_simple_message(
                 or forced
             )
 
-        # anyOf/oneOf/allOf/not are combinators: the failure here is just
-        # "no alternative matched" (or "matched the forbidden schema"), not
-        # a cause on its own. Each carries the per-alternative errors in
-        # `.context`, which `assemble_validation_errors` recurses into
-        # separately to look for the real cause -- reporting the combinator
-        # error directly would be exactly the vague branch-type message this
-        # rule exists to avoid (GSA/data.gov#6243).
+        # Combinators are not a cause; their `.context` holds the per-branch errors.
         if validation_error.validator in ("anyOf", "oneOf", "allOf", "not"):
             return False
 
-        # every other container-instance validator -- maxItems, minItems,
-        # uniqueItems, enum, const, minProperties, required, ... -- carries
-        # no `context` worth recursing into, so it's already the specific
-        # cause. Previously only `maxItems` and a `required`-message check
-        # were whitelisted here by name; every other one (e.g. `minItems`)
-        # fell through to `return False` and, having no `context` to recurse
-        # into and no sibling to defer to, was silently dropped instead of
-        # reported (GSA/data.gov#6243).
+        # Other container validators (maxItems, minItems, uniqueItems, ...) are
+        # already the specific cause.
         return True
     return True
 
@@ -1534,15 +1493,9 @@ def finalize_validation_messages(messages: defaultdict) -> list:
         # but >1 format/rule is used against it so grabbing
         # the last one which is a regex and does include the invalid data
         # excluding constants [0] == [n]
-        # jsonschema renders a container instance as its repr, so the
-        # quoted-run regex below would grab an arbitrary inner element (a list
-        # item, or worse, a dict key), find nothing at all for a container of
-        # numbers, or splice a whole array into the message. name the kind of
-        # value instead: bounded, and it can't mislead (GSA/data.gov#6243).
-        # any format for this path may carry the repr -- a `const` message
-        # quotes the *expected* value rather than the instance, so reading only
-        # the last one would name the value the schema wanted as the offender.
-        # "[]" already reads fine as itself, so it isn't treated as a container.
+        # jsonschema renders containers as repr; quoting an inner element (or a
+        # const's expected value) would mislead, so name the kind of value.
+        # "[]" already reads as itself.
         container = next(
             (f for f in formats if f[:1] in ("[", "{") and f[:2] != "[]"), None
         )
@@ -1551,9 +1504,7 @@ def finalize_validation_messages(messages: defaultdict) -> list:
         elif container is not None:
             invalid_value = "array value" if container[0] == "[" else "object value"
         else:
-            # a match object here has no groups when it matched the literal
-            # `[]` alternative, so read group(0); a scalar instance always
-            # has a quoted run to find.
+            # group(0): the `[]` alternative has no capture groups.
             match = re.search(r"'(.*?)'|\[\]", formats[-1])
             invalid_value = match.group(0) if match else None
 
@@ -1584,12 +1535,7 @@ def finalize_validation_messages(messages: defaultdict) -> list:
 
 
 def _count_messages(messages: defaultdict) -> int:
-    """Total number of accumulated messages across every json_path so far.
-
-    Used by `assemble_validation_errors` to tell whether a recursive pass
-    over an error's `context` recorded anything anywhere in that subtree,
-    without caring which path it landed on.
-    """
+    """Total messages accumulated across every json_path so far."""
     return sum(len(v) for v in messages.values())
 
 
@@ -1605,10 +1551,10 @@ def assemble_validation_errors(
     will often return the entire object followed by 'is not valid under any
     of the given schemas' which isn't helpful.
 
-    `_forced` is a private, keyword-only fallback flag -- callers outside
-    this module (namely `Record.validate()` in harvester/harvest.py) must
-    keep using the two-argument form. See the "nothing was recorded" block
-    below for what it does and why it exists (GSA/data.gov#6243).
+    `_forced` is a private fallback. Callers (Record.validate) must keep the
+    two-argument form. After an unforced context walk records nothing, we
+    re-walk forced so a same-path type error is reported vaguely instead of
+    silently. A walk that already recorded a specific cause is left alone.
     """
 
     if messages is None:
@@ -1629,12 +1575,8 @@ def assemble_validation_errors(
                     f"{error.message} [maxItems={error.validator_value}]"
                 )
             elif error.validator == "minItems" and "is too short" in error.message:
-                # jsonschema special-cases `minItems: 1` to the already
-                # self-explanatory "should be non-empty" (no count worth
-                # hinting); only the generic "is too short" wording (any
-                # other `minItems`) needs the hint appended, mirroring how
-                # the `maxItems`/`maxLength` hints above only matter for
-                # their own "is too long" wording.
+                # minItems: 1 already says "should be non-empty";
+                # only "is too short" needs the count.
                 formatted_message = (
                     f"{error.message} [minItems={error.validator_value}]"
                 )
@@ -1649,19 +1591,12 @@ def assemble_validation_errors(
             ):
                 messages[error.json_path].append(formatted_message)
 
-        # walk `context` unforced first: a specific cause deeper down always
-        # beats a vague one, and only the ordinary logic can find it.
+        # Prefer a specific cause in context before falling back.
         recorded_before = _count_messages(messages)
         assemble_validation_errors(error.context, messages)
 
-        # if that walk recorded nothing anywhere, every branch was same-path
-        # noise with no sibling to defer to (see `found_simple_message`), and
-        # the defect would vanish -- so re-walk forced, which reports it
-        # vaguely instead of silently (GSA/data.gov#6243). a walk that did
-        # record something skips this, which is what keeps a specific message
-        # (e.g. at $.contactPoint[0]['@type']) from also gaining a spurious
-        # one at its `anyOf`'s path. `_forced` only flips `type` errors, and
-        # those carry no `context`, so this cannot recurse further.
+        # Nothing recorded: re-walk forced so the defect is not dropped.
+        # `_forced` only flips `type` errors, which have no context to recurse.
         if error.context and _count_messages(messages) == recorded_before:
             assemble_validation_errors(error.context, messages, _forced=True)
 

--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -1342,16 +1342,41 @@ def get_format_from_str(validation_msg: str) -> str:
             return f"max {match.group(1)} items"
         return "max string length requirement"
 
+    # mirrors the "is too long" (maxLength/maxItems) case above, for the
+    # `minItems` container constraint (GSA/data.gov#6243). `assemble_
+    # validation_errors` appends the `[minItems=N]` hint the same way it
+    # does for `maxItems`.
+    if "is too short" in validation_msg:
+        match = re.search(r"\[minItems=(\d+)\]", validation_msg)
+        if match:
+            return f"min {match.group(1)} items"
+        return "min items requirement"
+
+    # `uniqueItems` reads "has non-unique elements", whose last word alone
+    # ("elements") loses the rule being broken (GSA/data.gov#6243). match
+    # jsonschema's full wording, not just "non-unique" -- an invalid *value*
+    # containing that text would otherwise hijack its own error message.
+    if "has non-unique elements" in validation_msg:
+        return "unique items"
+
     # for constants where a single value is acceptable
     if "was expected" in validation_msg:
         return f"constant value {validation_msg}"
     return validation_msg.split(" ")[-1]
 
 
-def found_simple_message(validation_error: ValidationError) -> bool:
+def found_simple_message(
+    validation_error: ValidationError, forced: bool = False
+) -> bool:
     """
     determine whether the input validation error represents the most
     succinct cause for error based on its json_path or dtype
+
+    `forced` is a last-resort override used by `assemble_validation_errors`
+    (GSA/data.gov#6243) for the one case below that would otherwise leave a
+    schema-invalid record with no recorded message at all: a same-path
+    container `type` error that this function normally suppresses as
+    branch noise. See that function's own comments for when `forced` is set.
     """
     # these are all the unique dtypes found in the
     # non-federal schema (no different than federal)
@@ -1361,22 +1386,64 @@ def found_simple_message(validation_error: ValidationError) -> bool:
     if validation_error.json_path == "$":
         return True
 
-    # we need to dig a little deeper when it's a list
+    # we need to dig a little deeper when it's a list or dict
     if isinstance(validation_error.instance, (dict, list)):
         # if it's empty you'll get something like
         # ['$.keyword', '[] should be non-empty']
         # which is simple and what we want
         if len(validation_error.instance) == 0:
             return True
-        # If it's looking for maxItems, you may have
-        # any number of items in the array:
-        if validation_error.validator == "maxItems":
-            return True
 
-        if validation_error.message.endswith("is a required property"):
-            return True
+        # a container that fails a `type` check outright is its own simplest
+        # cause, and `type` errors carry no `context` to dig into, so
+        # dropping one loses the defect entirely (GSA/data.gov#6243). it's
+        # simple when the constraint is a list of types (e.g.
+        # `["null", "string"]` -- can't be a container at all), or when the
+        # error came straight off `iter_errors` (no parent, so an
+        # unconditional leaf like `@type: {"type": "string"}`).
+        #
+        # a single-type constraint reached through `error.context` is the
+        # ambiguous case: `anyOf`/`oneOf` decomposes into one branch per
+        # alternative, and "isn't that alternative's type" is noise when a
+        # sibling holds the real cause. `context` is flat -- every entry
+        # shares the `anyOf` as its `parent` -- so compare json_paths: noise
+        # sits at the path the `anyOf` is deciding on, while a real cause
+        # reached through a branch sits deeper (e.g. an item of an
+        # array-of-objects branch).
+        #
+        # `forced` covers the case where deferring to a sibling would lose
+        # the defect: when every alternative is a scalar/null type, all
+        # branches are same-path noise and no deeper cause exists to defer
+        # to. `assemble_validation_errors` sets it only after confirming the
+        # unforced pass recorded nothing, trading a vague message that names
+        # the right json_path for silence, which reads as "record is fine".
+        if validation_error.validator == "type":
+            return bool(
+                isinstance(validation_error.validator_value, list)
+                or validation_error.parent is None
+                or validation_error.json_path != validation_error.parent.json_path
+                or forced
+            )
 
-        return False
+        # anyOf/oneOf/allOf/not are combinators: the failure here is just
+        # "no alternative matched" (or "matched the forbidden schema"), not
+        # a cause on its own. Each carries the per-alternative errors in
+        # `.context`, which `assemble_validation_errors` recurses into
+        # separately to look for the real cause -- reporting the combinator
+        # error directly would be exactly the vague branch-type message this
+        # rule exists to avoid (GSA/data.gov#6243).
+        if validation_error.validator in ("anyOf", "oneOf", "allOf", "not"):
+            return False
+
+        # every other container-instance validator -- maxItems, minItems,
+        # uniqueItems, enum, const, minProperties, required, ... -- carries
+        # no `context` worth recursing into, so it's already the specific
+        # cause. Previously only `maxItems` and a `required`-message check
+        # were whitelisted here by name; every other one (e.g. `minItems`)
+        # fell through to `return False` and, having no `context` to recurse
+        # into and no sibling to defer to, was silently dropped instead of
+        # reported (GSA/data.gov#6243).
+        return True
     return True
 
 
@@ -1421,12 +1488,30 @@ def finalize_validation_messages(messages: defaultdict) -> list:
         # but >1 format/rule is used against it so grabbing
         # the last one which is a regex and does include the invalid data
         # excluding constants [0] == [n]
+        # jsonschema renders a container instance as its repr, so the
+        # quoted-run regex below would grab an arbitrary inner element (a list
+        # item, or worse, a dict key), find nothing at all for a container of
+        # numbers, or splice a whole array into the message. name the kind of
+        # value instead: bounded, and it can't mislead (GSA/data.gov#6243).
+        # any format for this path may carry the repr -- a `const` message
+        # quotes the *expected* value rather than the instance, so reading only
+        # the last one would name the value the schema wanted as the offender.
+        # "[]" already reads fine as itself, so it isn't treated as a container.
+        container = next(
+            (f for f in formats if f[:1] in ("[", "{") and f[:2] != "[]"), None
+        )
         if formats[-1].startswith("None"):
             invalid_value = "None"
+        elif container is not None:
+            invalid_value = "array value" if container[0] == "[" else "object value"
         else:
-            invalid_value = re.search(r"'(.*?)'|\[\]", formats[-1]).group(0)
+            # a match object here has no groups when it matched the literal
+            # `[]` alternative, so read group(0); a scalar instance always
+            # has a quoted run to find.
+            match = re.search(r"'(.*?)'|\[\]", formats[-1])
+            invalid_value = match.group(0) if match else None
 
-        # if the 0th doesn't work none of them will
+        # if neither branch above found anything, none of them will
         if invalid_value is None:
             logger.warning(f"can't find invalid data from error message: {formats[0]}")
             continue
@@ -1452,7 +1537,19 @@ def finalize_validation_messages(messages: defaultdict) -> list:
     return output
 
 
-def assemble_validation_errors(validation_errors: list, messages=None) -> list:  #
+def _count_messages(messages: defaultdict) -> int:
+    """Total number of accumulated messages across every json_path so far.
+
+    Used by `assemble_validation_errors` to tell whether a recursive pass
+    over an error's `context` recorded anything anywhere in that subtree,
+    without caring which path it landed on.
+    """
+    return sum(len(v) for v in messages.values())
+
+
+def assemble_validation_errors(
+    validation_errors: list, messages=None, *, _forced: bool = False
+) -> list:
     """
     given a list of errors, follow each one recursively through its context
     and get the simplest cause for error. store the error in a defaultdict
@@ -1461,6 +1558,11 @@ def assemble_validation_errors(validation_errors: list, messages=None) -> list: 
     errors with lists or dicts (other than empty)
     will often return the entire object followed by 'is not valid under any
     of the given schemas' which isn't helpful.
+
+    `_forced` is a private, keyword-only fallback flag -- callers outside
+    this module (namely `Record.validate()` in harvester/harvest.py) must
+    keep using the two-argument form. See the "nothing was recorded" block
+    below for what it does and why it exists (GSA/data.gov#6243).
     """
 
     if messages is None:
@@ -1468,7 +1570,7 @@ def assemble_validation_errors(validation_errors: list, messages=None) -> list: 
         messages = defaultdict(list)
 
     for error in validation_errors:
-        if found_simple_message(error):
+        if found_simple_message(error, forced=_forced):
             # these aren't specific enough which make them unhelpful
             generic_msg = "is not valid under any of the given schemas"
             is_generic_msg = error.message.endswith(generic_msg)
@@ -1480,6 +1582,16 @@ def assemble_validation_errors(validation_errors: list, messages=None) -> list: 
                 formatted_message = (
                     f"{error.message} [maxItems={error.validator_value}]"
                 )
+            elif error.validator == "minItems" and "is too short" in error.message:
+                # jsonschema special-cases `minItems: 1` to the already
+                # self-explanatory "should be non-empty" (no count worth
+                # hinting); only the generic "is too short" wording (any
+                # other `minItems`) needs the hint appended, mirroring how
+                # the `maxItems`/`maxLength` hints above only matter for
+                # their own "is too long" wording.
+                formatted_message = (
+                    f"{error.message} [minItems={error.validator_value}]"
+                )
             else:
                 formatted_message = error.message
             # if not the generic message, and if the message is not already
@@ -1490,7 +1602,22 @@ def assemble_validation_errors(validation_errors: list, messages=None) -> list: 
                 and formatted_message not in messages[error.json_path]
             ):
                 messages[error.json_path].append(formatted_message)
+
+        # walk `context` unforced first: a specific cause deeper down always
+        # beats a vague one, and only the ordinary logic can find it.
+        recorded_before = _count_messages(messages)
         assemble_validation_errors(error.context, messages)
+
+        # if that walk recorded nothing anywhere, every branch was same-path
+        # noise with no sibling to defer to (see `found_simple_message`), and
+        # the defect would vanish -- so re-walk forced, which reports it
+        # vaguely instead of silently (GSA/data.gov#6243). a walk that did
+        # record something skips this, which is what keeps a specific message
+        # (e.g. at $.contactPoint[0]['@type']) from also gaining a spurious
+        # one at its `anyOf`'s path. `_forced` only flips `type` errors, and
+        # those carry no `context`, so this cannot recurse further.
+        if error.context and _count_messages(messages) == recorded_before:
+            assemble_validation_errors(error.context, messages, _forced=True)
 
     return finalize_validation_messages(messages)
 

--- a/scripts/new_relic_db_monitor.py
+++ b/scripts/new_relic_db_monitor.py
@@ -1,12 +1,9 @@
 import logging
 import os
 
-import newrelic.agent
 from sqlalchemy import create_engine, text
 
 logger = logging.getLogger(__name__)
-
-newrelic.agent.initialize()
 
 PG_ACTIVITY_SUMMARY = text("""
     WITH idle_transactions AS (
@@ -51,6 +48,9 @@ PG_ACTIVITY_SUMMARY = text("""
 
 def emit_idle_transaction_event():
     try:
+        import newrelic.agent
+
+        newrelic.agent.initialize()
         application = newrelic.agent.register_application(timeout=10)
 
         if not application.active:

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -642,14 +642,10 @@ class TestValidateWarnings:
         source_data_dcatus3_0_invalid,
         job_data_dcatus3_0_invalid,
     ):
-        """An invalid record that also warns is counted as errored and warned,
-        and reporting the warning must not clobber the record's error status.
+        """An invalid record that also warns is counted as errored and warned.
 
-        The error and the warning must come from two independent defects, not
-        the same value reported twice (GSA/data.gov#6243): the schema error is
-        the fixture's own missing `contactPoint` (a required Dataset field),
-        while the warning comes from an unrelated, schema-valid `language`
-        code. Neither defect implies the other.
+        The error and warning must come from independent defects (missing
+        `contactPoint` vs an unknown `language` code), not the same value twice.
         """
         test_record = self._first_dcatus3_record(
             interface,
@@ -661,9 +657,6 @@ class TestValidateWarnings:
         # give the record a real db id so we can assert its persisted status
         test_record.compare()
 
-        # source_data_dcatus3_0_invalid's first dataset is already schema-invalid
-        # (missing the mandatory `contactPoint`); an unknown ISO 639-1 language
-        # is a separate, unrelated content warning, not a schema error
         record = json.loads(test_record.source_raw)
         record["language"] = ["zz"]
         test_record._source_raw = json.dumps(record)

--- a/tests/integration/harvest/test_validate.py
+++ b/tests/integration/harvest/test_validate.py
@@ -643,7 +643,14 @@ class TestValidateWarnings:
         job_data_dcatus3_0_invalid,
     ):
         """An invalid record that also warns is counted as errored and warned,
-        and reporting the warning must not clobber the record's error status."""
+        and reporting the warning must not clobber the record's error status.
+
+        The error and the warning must come from two independent defects, not
+        the same value reported twice (GSA/data.gov#6243): the schema error is
+        the fixture's own missing `contactPoint` (a required Dataset field),
+        while the warning comes from an unrelated, schema-valid `language`
+        code. Neither defect implies the other.
+        """
         test_record = self._first_dcatus3_record(
             interface,
             organization_data,
@@ -654,9 +661,11 @@ class TestValidateWarnings:
         # give the record a real db id so we can assert its persisted status
         test_record.compare()
 
-        # a bad @id is both a schema error (format: iri) and an invalid_iri warning
+        # source_data_dcatus3_0_invalid's first dataset is already schema-invalid
+        # (missing the mandatory `contactPoint`); an unknown ISO 639-1 language
+        # is a separate, unrelated content warning, not a schema error
         record = json.loads(test_record.source_raw)
-        record["@id"] = "not a valid iri"
+        record["language"] = ["zz"]
         test_record._source_raw = json.dumps(record)
 
         assert not test_record.validate()
@@ -673,7 +682,7 @@ class TestValidateWarnings:
         warnings = interface.get_harvest_record_errors_by_job(
             harvest_source.job_id, severity="warning"
         )
-        assert any(w[0].type == "invalid_iri" for w in warnings)
+        assert any(w[0].type == "invalid_language" for w in warnings)
 
     def test_non_dcatus3_record_is_not_warned(
         self,

--- a/tests/unit/test_dcat_warning_error_overlap.py
+++ b/tests/unit/test_dcat_warning_error_overlap.py
@@ -1,23 +1,9 @@
 """Lock in the schema/warning boundary from GSA/data.gov#6243.
 
-GSA/data.gov#6243 reported a single dataset-quality defect twice: once as a
-schema `ValidationError` (severity=error) and again as a DCAT content
-`warning` (severity=warning), inflating both `records_errored` and
-`records_warned`. The fix removed the warning rules that restated schema
-constraints (the `invalid_iri` family, plus guards that now defer to the
-schema's type/format/length/enum checks).
-
-The invariant this module locks in place: **any value that trips a DCAT
-warning must be schema-valid, and any value that trips a schema error must
-produce no warning.** Warnings are for content the schema accepts; the
-validator owns type/format/length/enum.
-
-This is checked against the *real* `Draft202012Validator` built from
-`schemas/dcatus3.0/definitions/`, not by inspecting `dcat_warnings.py` source,
-because the whole point is to catch a *future* warning rule that
-(re)duplicates a schema constraint without anyone noticing the overlap by
-reading the code. Only a rule and a validator disagreeing at runtime proves
-the boundary holds.
+A value that trips a DCAT warning must be schema-valid, and a value that
+trips a schema error must produce no warning. Checked against the real
+Draft202012Validator from `schemas/dcatus3.0/definitions/`, so a future
+rule that duplicates a schema constraint fails at runtime.
 """
 
 import copy
@@ -86,12 +72,6 @@ def _schema_errors(mutated: dict) -> list:
 
 
 # --- Case table 1: every warning fires only on schema-clean data -----------
-#
-# One mutation per warning type still emitted by dcat_warnings.py (see
-# _TYPE_RULES and the rule functions). Each mutation is applied to a fresh
-# deep copy of the schema-valid base record and must itself remain
-# schema-valid; if it doesn't, assertion (a) below is the one that would
-# catch a rule that restates a schema constraint.
 
 
 def _duplicate_keyword(r):
@@ -148,9 +128,7 @@ def _invalid_specific_restriction(r):
 
 
 def _invalid_tel(r):
-    # A different letters-containing value than the baseline's, so the
-    # resulting warning message differs from the baseline one and shows up
-    # as new rather than being diffed away.
+    # Distinct from the baseline vanity number so this shows up as a new warning.
     r["contactPoint"][0]["tel"] = "1-800-CALLME"
 
 
@@ -175,35 +153,22 @@ def _invalid_cui_banner_marking(r):
 
 
 def _unresolvable_spatial_value(r):
-    # A different unresolvable value than the baseline's WKT polygon, so the
-    # resulting warning message is new rather than being diffed away.
+    # Distinct from the baseline WKT polygon so this shows up as a new warning.
     r["spatial"][0]["geometry"] = "somewhere over there"
 
 
 def _date_out_of_order_date_time_with_utc_offset(r):
-    # Positive counterpart to fix (c): a `date-time` value *with* a UTC
-    # offset ("Z") is schema-valid, so `_parse_dcat_date` must still parse it
-    # and still warn -- the guard must not have been over-tightened into
-    # rejecting every date-time string.
+    # "Z" is schema-valid RFC 3339; the date parser must still warn on it.
     r["created"] = "2025-01-01T00:00:00Z"  # later than modified and issued
 
 
 def _date_out_of_order_lowercase_rfc3339(r):
-    # Third review round, fix 3: a lowercase RFC 3339 date-time ("t"/"z") is
-    # still schema-valid (FormatChecker's `date-time` format is
-    # case-insensitive on both), but `_parse_dcat_date` only normalized an
-    # uppercase "Z" before handing the value to `datetime.fromisoformat`, so
-    # a lowercase one raised inside the `try`, was swallowed by the `except`,
-    # and produced neither a schema error nor a warning -- the defect was
-    # reported nowhere.
+    # Lowercase RFC 3339 "t"/"z" is schema-valid and must still warn.
     r["created"] = "2025-01-01t00:00:00z"  # later than modified and issued
 
 
 def _empty_address_explicit_empty_strings(r):
-    # Positive counterpart to fix (d): every field explicitly set to "" (not
-    # just omitted) is still schema-valid and must still warn -- the guard
-    # must not have been over-tightened into only recognizing an absent/None
-    # field as unpopulated.
+    # Explicit "" is still schema-valid and must still warn as empty.
     r["contactPoint"][0]["address"].append(
         {
             "@type": "Address",
@@ -292,19 +257,13 @@ class TestWarningsOnlyFireOnSchemaCleanData:
         mutated = _record()
         mutate(mutated)
 
-        # (a) the mutation must be schema-clean: this is the assertion that
-        # would fail if a warning rule restated a schema constraint.
+        # Would fail if a warning rule restated a schema constraint.
         assert _schema_errors(mutated) == []
 
-        # (b) the mutation must still produce the warning it was meant to.
         assert expected_type in _new_warning_types(mutated)
 
 
 # --- Case table 2: schema violations produce no warning ---------------------
-#
-# Mutations that are pure schema violations of fields dcat_warnings.py also
-# touches. Each must (a) actually be reported as a schema error and (b)
-# produce no new warning, confirming the defect is reported exactly once.
 
 
 def _bad_dataset_id(r):
@@ -352,9 +311,7 @@ def _blank_keywords(r):
 
 
 def _distribution_type_dict(r):
-    # pins fix (a): before it, `detect_dcat_warnings` raised
-    # `TypeError: unhashable type` on a non-string, non-hashable `@type`
-    # instead of returning cleanly.
+    # Non-string @type used to raise TypeError: unhashable type.
     r["distribution"][0]["@type"] = {"foo": "bar"}
 
 
@@ -387,32 +344,19 @@ def _address_replaced_with_non_string_postal_code_empty_list(r):
 
 
 def _spatial_resolution_in_meters_non_empty_list(r):
-    # rescued from silent loss by fix (e): before it, `assemble_validation_errors`
-    # reported zero errors for this list value even though the record is invalid.
     r["spatialResolutionInMeters"] = ["bad"]
 
 
 def _temporal_resolution_non_empty_dict(r):
-    # same silent-loss defect as above, for a dict-valued offender.
     r["temporalResolution"] = {"a": 1}
 
 
 def _nested_container_type_error_under_anyof(r):
-    # Third review round, fix 1: a genuine leaf `type` error reached through
-    # one branch of a decomposed `anyOf` (here, `contactPoint`'s array
-    # branch) used to be dropped entirely -- `found_simple_message` only
-    # recognized a container `type` error as simple when it had no parent,
-    # which excluded this one -- so `assemble_validation_errors` returned no
-    # error at all for a schema-invalid record.
     r["contactPoint"][0]["@type"] = ["Kind"]
 
 
 def _bbox_wrong_type(r):
-    # Third review round, fix 2: bbox's object variant pins "type" to the
-    # constant "Polygon" (Location.json); a dict with any other "type" is
-    # already a schema `const` error, but `_warn_spatial_unresolved` used to
-    # only check for the presence of "type"/"coordinates", so it also fired
-    # `unresolvable_spatial_value` on this.
+    # bbox objects must be type "Polygon"; anything else is a schema const error.
     r["spatial"][0]["bbox"] = {
         "type": "NoSuch",
         "coordinates": [[[-77.1, 38.7], [-76.9, 38.7], [-76.9, 38.9], [-77.1, 38.7]]],
@@ -420,59 +364,31 @@ def _bbox_wrong_type(r):
 
 
 def _padded_date(r):
-    # Third review round, fix 3: `_parse_dcat_date` used to strip whitespace
-    # before format-checking, so a padded value the schema rejects still
-    # parsed here and could produce `date_out_of_order`.
+    # Whitespace-padded dates are schema-invalid; must not be stripped and warned on.
     r["created"] = " 2025-06-01 "  # later than modified and issued, if parsed
 
 
 def _created_all_scalar_anyof_branches(r):
-    # Remaining bug from review: `created` is `anyOf[null, {format:
-    # date-time}, {format: date}, {pattern: "^[0-9]{4}$"}, {pattern:
-    # "^[0-9]{4}-[0-9]{2}$"}]` -- every alternative is scalar/null, so a list
-    # value decomposes into same-path `type` errors with no sibling cause to
-    # defer to. Before the forced fallback in `assemble_validation_errors`,
-    # this was reported as zero errors for a schema-invalid record.
     r["created"] = ["2025"]
 
 
 def _language_all_scalar_anyof_branches(r):
-    # Same defect as above: `language` is `anyOf[null, string, array of
-    # string]`, all scalar/null, so a dict value used to vanish entirely.
     r["language"] = {"a": 1}
 
 
 def _spatial_bbox_all_scalar_anyof_branches(r):
-    # Same defect, one level deeper: `bbox` is `anyOf[null, string, object]`,
-    # reached through `spatial`'s own `anyOf[null, array of Location]`. A
-    # list value here used to vanish entirely too.
     r["spatial"][0]["bbox"] = ["x"]
 
 
 def _access_rights_all_scalar_anyof_branches(r):
-    # Same defect, smallest case: `accessRights` is `anyOf[null, string]`.
     r["accessRights"] = ["x"]
 
 
 def _centroid_coordinates_maxitems_numeric(r):
-    # Third review round, fix 1: `centroid.coordinates` is `{"type":
-    # "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2}`
-    # (Location.json). A 3-element numeric array used to crash
-    # `finalize_validation_messages` -- the raw message "[-77, 38, 1] is too
-    # long [maxItems=2]" has no quoted run and no literal `[]`, so the regex
-    # that extracts the invalid value found nothing and `.group(0)` raised
-    # `AttributeError`, aborting validation mid-harvest.
     r["spatial"][0]["centroid"] = {"type": "Point", "coordinates": [-77, 38, 1]}
 
 
 def _centroid_coordinates_minitems_numeric(r):
-    # Third review round, fix 2: a 1-element `coordinates` array is too
-    # short (`minItems: 2`). Before the fix, `found_simple_message` only
-    # whitelisted `maxItems` by name for container instances, so this
-    # `minItems` violation was suppressed and `assemble_validation_errors`
-    # fell back to the vague "$.spatial[0].centroid, object value does not
-    # match any of the acceptable formats: 'null', 'string'" branch-type
-    # message instead of naming the real cause on `coordinates`.
     r["spatial"][0]["centroid"] = {"type": "Point", "coordinates": [-77]}
 
 

--- a/tests/unit/test_dcat_warning_error_overlap.py
+++ b/tests/unit/test_dcat_warning_error_overlap.py
@@ -1,0 +1,571 @@
+"""Lock in the schema/warning boundary from GSA/data.gov#6243.
+
+GSA/data.gov#6243 reported a single dataset-quality defect twice: once as a
+schema `ValidationError` (severity=error) and again as a DCAT content
+`warning` (severity=warning), inflating both `records_errored` and
+`records_warned`. The fix removed the warning rules that restated schema
+constraints (the `invalid_iri` family, plus guards that now defer to the
+schema's type/format/length/enum checks).
+
+The invariant this module locks in place: **any value that trips a DCAT
+warning must be schema-valid, and any value that trips a schema error must
+produce no warning.** Warnings are for content the schema accepts; the
+validator owns type/format/length/enum.
+
+This is checked against the *real* `Draft202012Validator` built from
+`schemas/dcatus3.0/definitions/`, not by inspecting `dcat_warnings.py` source,
+because the whole point is to catch a *future* warning rule that
+(re)duplicates a schema constraint without anyone noticing the overlap by
+reading the code. Only a rule and a validator disagreeing at runtime proves
+the boundary holds.
+"""
+
+import copy
+from pathlib import Path
+
+import pytest
+
+from harvester.utils.dcat_warnings import detect_dcat_warnings
+from harvester.utils.general_utils import (
+    assemble_validation_errors,
+    build_dcatus3_validator,
+    open_json,
+)
+
+ROOT_DIR = Path(__file__).parents[2]
+DCATUS3_DEFINITIONS = ROOT_DIR / "schemas" / "dcatus3.0" / "definitions"
+COMPLETE_EXAMPLE = (
+    ROOT_DIR
+    / "schemas"
+    / "dcatus3.0"
+    / "examples"
+    / "Dataset"
+    / "good"
+    / "complete_example.json"
+)
+DATASET_REF = "https://resources.data.gov/dcat-us/3.0.0/definitions/dataset"
+
+# Building the validator compiles every DCAT-US 3 definition; build it once
+# per module rather than once per test.
+VALIDATOR = build_dcatus3_validator(DCATUS3_DEFINITIONS, root_ref=DATASET_REF)
+
+# The upstream complete example is schema-valid but not warning-free: its
+# vanity tel number ("+1-555-CLIMATE") and its WKT `geometry` each already
+# trip a warning (invalid_tel, unresolvable_spatial_value). Those are a
+# separate, pre-existing false-positive question and out of scope here, so
+# every test below diffs against this baseline instead of assuming a record
+# starts with zero warnings.
+#
+# Baseline warnings are deliberately *not* precomputed into a module-level
+# constant here (unlike VALIDATOR above). Detecting the unresolvable-spatial
+# baseline warning exercises `translate_spatial`'s DB-backed lookup fallback,
+# which tests/conftest.py's autouse `default_function_fixture` only points at
+# a safe, per-test, rolled-back session once a test is actually running.
+# Computing it at import time (module collection, before any test/fixture
+# runs) would instead reach the real module-level `harvester.db_interface`
+# and leak an uncommitted transaction. So `_new_warning_types` recomputes the
+# baseline fresh on every call, inside the test.
+BASE_RECORD = open_json(COMPLETE_EXAMPLE)
+
+
+def _record() -> dict:
+    """A fresh deep copy of the base record for a test to mutate."""
+    return copy.deepcopy(BASE_RECORD)
+
+
+def _new_warning_types(mutated: dict) -> list:
+    """Warning types produced by `mutated` that are not already produced by
+    the unmutated base record."""
+    baseline = detect_dcat_warnings(BASE_RECORD)
+    produced = detect_dcat_warnings(mutated)
+    return [w.warning_type for w in produced if w not in baseline]
+
+
+def _schema_errors(mutated: dict) -> list:
+    return assemble_validation_errors(VALIDATOR.iter_errors(mutated))
+
+
+# --- Case table 1: every warning fires only on schema-clean data -----------
+#
+# One mutation per warning type still emitted by dcat_warnings.py (see
+# _TYPE_RULES and the rule functions). Each mutation is applied to a fresh
+# deep copy of the schema-valid base record and must itself remain
+# schema-valid; if it doesn't, assertion (a) below is the one that would
+# catch a rule that restates a schema constraint.
+
+
+def _duplicate_keyword(r):
+    r["keyword"][1] = r["keyword"][0]
+
+
+def _invalid_spatial_resolution(r):
+    r["spatialResolutionInMeters"] = "about 1km"
+
+
+def _invalid_temporal_resolution(r):
+    r["temporalResolution"] = "daily"
+
+
+def _legacy_access_rights(r):
+    r["accessRights"] = "non-public"
+
+
+def _date_out_of_order(r):
+    r["created"] = "2025-06-01"  # later than modified and issued
+
+
+def _invalid_language(r):
+    r["language"] = ["zz"]  # 2 chars, not a recognized ISO 639-1 code
+
+
+def _invalid_byte_size(r):
+    r["distribution"][0]["byteSize"] = "big"
+
+
+def _invalid_character_encoding(r):
+    r["distribution"][0]["characterEncoding"] = ["bogus"]
+
+
+def _invalid_media_type(r):
+    r["distribution"][0]["mediaType"] = "application/notreal"
+
+
+def _invalid_restriction_status(r):
+    r["distribution"][0]["accessRestriction"] = [
+        {"@type": "AccessRestriction", "restrictionStatus": "Bogus"}
+    ]
+
+
+def _invalid_specific_restriction(r):
+    # "Copyright" is a recognized *use* restriction term but not an access one.
+    r["distribution"][0]["accessRestriction"] = [
+        {
+            "@type": "AccessRestriction",
+            "restrictionStatus": "Unrestricted",
+            "specificRestriction": "Copyright",
+        }
+    ]
+
+
+def _invalid_tel(r):
+    # A different letters-containing value than the baseline's, so the
+    # resulting warning message differs from the baseline one and shows up
+    # as new rather than being diffed away.
+    r["contactPoint"][0]["tel"] = "1-800-CALLME"
+
+
+def _invalid_postal_code(r):
+    r["contactPoint"][0]["address"][0]["postal-code"] = "K1A0B1"
+
+
+def _empty_address(r):
+    r["contactPoint"][0]["address"].append({"@type": "Address"})
+
+
+def _invalid_expected_data_type(r):
+    r["hasQualityMeasurement"][0]["isMeasurementOf"]["expectedDataType"] = "decimal"
+
+
+def _invalid_cui_banner_marking(r):
+    r["distribution"][0]["cuiRestriction"] = {
+        "@type": "CUIRestriction",
+        "cuiBannerMarking": "SP-CTI",
+        "designationIndicator": "Controlled by: Agency XYZ",
+    }
+
+
+def _unresolvable_spatial_value(r):
+    # A different unresolvable value than the baseline's WKT polygon, so the
+    # resulting warning message is new rather than being diffed away.
+    r["spatial"][0]["geometry"] = "somewhere over there"
+
+
+def _date_out_of_order_date_time_with_utc_offset(r):
+    # Positive counterpart to fix (c): a `date-time` value *with* a UTC
+    # offset ("Z") is schema-valid, so `_parse_dcat_date` must still parse it
+    # and still warn -- the guard must not have been over-tightened into
+    # rejecting every date-time string.
+    r["created"] = "2025-01-01T00:00:00Z"  # later than modified and issued
+
+
+def _date_out_of_order_lowercase_rfc3339(r):
+    # Third review round, fix 3: a lowercase RFC 3339 date-time ("t"/"z") is
+    # still schema-valid (FormatChecker's `date-time` format is
+    # case-insensitive on both), but `_parse_dcat_date` only normalized an
+    # uppercase "Z" before handing the value to `datetime.fromisoformat`, so
+    # a lowercase one raised inside the `try`, was swallowed by the `except`,
+    # and produced neither a schema error nor a warning -- the defect was
+    # reported nowhere.
+    r["created"] = "2025-01-01t00:00:00z"  # later than modified and issued
+
+
+def _empty_address_explicit_empty_strings(r):
+    # Positive counterpart to fix (d): every field explicitly set to "" (not
+    # just omitted) is still schema-valid and must still warn -- the guard
+    # must not have been over-tightened into only recognizing an absent/None
+    # field as unpopulated.
+    r["contactPoint"][0]["address"].append(
+        {
+            "@type": "Address",
+            "street-address": "",
+            "locality": "",
+            "region": "",
+            "postal-code": "",
+            "country-name": "",
+        }
+    )
+
+
+WARNING_ON_CLEAN_DATA_CASES = [
+    pytest.param(_duplicate_keyword, "duplicate_keyword", id="duplicate_keyword"),
+    pytest.param(
+        _invalid_spatial_resolution,
+        "invalid_spatial_resolution",
+        id="invalid_spatial_resolution",
+    ),
+    pytest.param(
+        _invalid_temporal_resolution,
+        "invalid_temporal_resolution",
+        id="invalid_temporal_resolution",
+    ),
+    pytest.param(
+        _legacy_access_rights, "legacy_access_rights", id="legacy_access_rights"
+    ),
+    pytest.param(_date_out_of_order, "date_out_of_order", id="date_out_of_order"),
+    pytest.param(_invalid_language, "invalid_language", id="invalid_language"),
+    pytest.param(_invalid_byte_size, "invalid_byte_size", id="invalid_byte_size"),
+    pytest.param(
+        _invalid_character_encoding,
+        "invalid_character_encoding",
+        id="invalid_character_encoding",
+    ),
+    pytest.param(_invalid_media_type, "invalid_media_type", id="invalid_media_type"),
+    pytest.param(
+        _invalid_restriction_status,
+        "invalid_restriction_status",
+        id="invalid_restriction_status",
+    ),
+    pytest.param(
+        _invalid_specific_restriction,
+        "invalid_specific_restriction",
+        id="invalid_specific_restriction",
+    ),
+    pytest.param(_invalid_tel, "invalid_tel", id="invalid_tel"),
+    pytest.param(_invalid_postal_code, "invalid_postal_code", id="invalid_postal_code"),
+    pytest.param(_empty_address, "empty_address", id="empty_address"),
+    pytest.param(
+        _invalid_expected_data_type,
+        "invalid_expected_data_type",
+        id="invalid_expected_data_type",
+    ),
+    pytest.param(
+        _invalid_cui_banner_marking,
+        "invalid_cui_banner_marking",
+        id="invalid_cui_banner_marking",
+    ),
+    pytest.param(
+        _unresolvable_spatial_value,
+        "unresolvable_spatial_value",
+        id="unresolvable_spatial_value",
+    ),
+    pytest.param(
+        _date_out_of_order_date_time_with_utc_offset,
+        "date_out_of_order",
+        id="date_out_of_order_date_time_with_utc_offset",
+    ),
+    pytest.param(
+        _empty_address_explicit_empty_strings,
+        "empty_address",
+        id="empty_address_explicit_empty_strings",
+    ),
+    pytest.param(
+        _date_out_of_order_lowercase_rfc3339,
+        "date_out_of_order",
+        id="date_out_of_order_lowercase_rfc3339",
+    ),
+]
+
+
+class TestWarningsOnlyFireOnSchemaCleanData:
+    @pytest.mark.parametrize("mutate, expected_type", WARNING_ON_CLEAN_DATA_CASES)
+    def test_warning_fires_without_a_schema_error(self, mutate, expected_type):
+        mutated = _record()
+        mutate(mutated)
+
+        # (a) the mutation must be schema-clean: this is the assertion that
+        # would fail if a warning rule restated a schema constraint.
+        assert _schema_errors(mutated) == []
+
+        # (b) the mutation must still produce the warning it was meant to.
+        assert expected_type in _new_warning_types(mutated)
+
+
+# --- Case table 2: schema violations produce no warning ---------------------
+#
+# Mutations that are pure schema violations of fields dcat_warnings.py also
+# touches. Each must (a) actually be reported as a schema error and (b)
+# produce no new warning, confirming the defect is reported exactly once.
+
+
+def _bad_dataset_id(r):
+    r["@id"] = "qwer"  # the exact case from GSA/data.gov#6243
+
+
+def _bad_relation_iri(r):
+    r["relation"] = ["not a valid iri"]
+
+
+def _bad_is_referenced_by_iri(r):
+    r["isReferencedBy"] = ["not a valid iri"]
+
+
+def _bad_image_iri(r):
+    r["image"] = "not a valid iri"
+
+
+def _string_entry_in_conforms_to(r):
+    r["conformsTo"][0] = "just a string, not a Standard object"
+
+
+def _language_array_of_three_char_codes(r):
+    r["language"] = ["eng"]
+
+
+def _non_string_spatial_resolution_in_meters(r):
+    r["spatialResolutionInMeters"] = 1000
+
+
+def _non_string_temporal_resolution(r):
+    r["temporalResolution"] = 1
+
+
+def _non_empty_list_byte_size(r):
+    r["distribution"][0]["byteSize"] = ["524288000"]
+
+
+def _bare_string_character_encoding(r):
+    r["distribution"][0]["characterEncoding"] = "UTF-8"
+
+
+def _blank_keywords(r):
+    r["keyword"] = ["", ""]
+
+
+def _distribution_type_dict(r):
+    # pins fix (a): before it, `detect_dcat_warnings` raised
+    # `TypeError: unhashable type` on a non-string, non-hashable `@type`
+    # instead of returning cleanly.
+    r["distribution"][0]["@type"] = {"foo": "bar"}
+
+
+def _distribution_type_list(r):
+    r["distribution"][0]["@type"] = ["Distribution"]
+
+
+def _spatial_geometry_non_string_non_dict(r):
+    r["spatial"][0]["geometry"] = 5
+
+
+def _spatial_geometry_dict_missing_required_keys(r):
+    r["spatial"][0]["geometry"] = {"foo": 1}
+
+
+def _spatial_bbox_non_string_non_dict(r):
+    r["spatial"][0]["bbox"] = 5
+
+
+def _created_date_time_without_utc_offset(r):
+    r["created"] = "2025-01-01T00:00:00"
+
+
+def _address_replaced_with_non_string_postal_code_zero(r):
+    r["contactPoint"][0]["address"] = [{"@type": "Address", "postal-code": 0}]
+
+
+def _address_replaced_with_non_string_postal_code_empty_list(r):
+    r["contactPoint"][0]["address"] = [{"@type": "Address", "postal-code": []}]
+
+
+def _spatial_resolution_in_meters_non_empty_list(r):
+    # rescued from silent loss by fix (e): before it, `assemble_validation_errors`
+    # reported zero errors for this list value even though the record is invalid.
+    r["spatialResolutionInMeters"] = ["bad"]
+
+
+def _temporal_resolution_non_empty_dict(r):
+    # same silent-loss defect as above, for a dict-valued offender.
+    r["temporalResolution"] = {"a": 1}
+
+
+def _nested_container_type_error_under_anyof(r):
+    # Third review round, fix 1: a genuine leaf `type` error reached through
+    # one branch of a decomposed `anyOf` (here, `contactPoint`'s array
+    # branch) used to be dropped entirely -- `found_simple_message` only
+    # recognized a container `type` error as simple when it had no parent,
+    # which excluded this one -- so `assemble_validation_errors` returned no
+    # error at all for a schema-invalid record.
+    r["contactPoint"][0]["@type"] = ["Kind"]
+
+
+def _bbox_wrong_type(r):
+    # Third review round, fix 2: bbox's object variant pins "type" to the
+    # constant "Polygon" (Location.json); a dict with any other "type" is
+    # already a schema `const` error, but `_warn_spatial_unresolved` used to
+    # only check for the presence of "type"/"coordinates", so it also fired
+    # `unresolvable_spatial_value` on this.
+    r["spatial"][0]["bbox"] = {
+        "type": "NoSuch",
+        "coordinates": [[[-77.1, 38.7], [-76.9, 38.7], [-76.9, 38.9], [-77.1, 38.7]]],
+    }
+
+
+def _padded_date(r):
+    # Third review round, fix 3: `_parse_dcat_date` used to strip whitespace
+    # before format-checking, so a padded value the schema rejects still
+    # parsed here and could produce `date_out_of_order`.
+    r["created"] = " 2025-06-01 "  # later than modified and issued, if parsed
+
+
+def _created_all_scalar_anyof_branches(r):
+    # Remaining bug from review: `created` is `anyOf[null, {format:
+    # date-time}, {format: date}, {pattern: "^[0-9]{4}$"}, {pattern:
+    # "^[0-9]{4}-[0-9]{2}$"}]` -- every alternative is scalar/null, so a list
+    # value decomposes into same-path `type` errors with no sibling cause to
+    # defer to. Before the forced fallback in `assemble_validation_errors`,
+    # this was reported as zero errors for a schema-invalid record.
+    r["created"] = ["2025"]
+
+
+def _language_all_scalar_anyof_branches(r):
+    # Same defect as above: `language` is `anyOf[null, string, array of
+    # string]`, all scalar/null, so a dict value used to vanish entirely.
+    r["language"] = {"a": 1}
+
+
+def _spatial_bbox_all_scalar_anyof_branches(r):
+    # Same defect, one level deeper: `bbox` is `anyOf[null, string, object]`,
+    # reached through `spatial`'s own `anyOf[null, array of Location]`. A
+    # list value here used to vanish entirely too.
+    r["spatial"][0]["bbox"] = ["x"]
+
+
+def _access_rights_all_scalar_anyof_branches(r):
+    # Same defect, smallest case: `accessRights` is `anyOf[null, string]`.
+    r["accessRights"] = ["x"]
+
+
+def _centroid_coordinates_maxitems_numeric(r):
+    # Third review round, fix 1: `centroid.coordinates` is `{"type":
+    # "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2}`
+    # (Location.json). A 3-element numeric array used to crash
+    # `finalize_validation_messages` -- the raw message "[-77, 38, 1] is too
+    # long [maxItems=2]" has no quoted run and no literal `[]`, so the regex
+    # that extracts the invalid value found nothing and `.group(0)` raised
+    # `AttributeError`, aborting validation mid-harvest.
+    r["spatial"][0]["centroid"] = {"type": "Point", "coordinates": [-77, 38, 1]}
+
+
+def _centroid_coordinates_minitems_numeric(r):
+    # Third review round, fix 2: a 1-element `coordinates` array is too
+    # short (`minItems: 2`). Before the fix, `found_simple_message` only
+    # whitelisted `maxItems` by name for container instances, so this
+    # `minItems` violation was suppressed and `assemble_validation_errors`
+    # fell back to the vague "$.spatial[0].centroid, object value does not
+    # match any of the acceptable formats: 'null', 'string'" branch-type
+    # message instead of naming the real cause on `coordinates`.
+    r["spatial"][0]["centroid"] = {"type": "Point", "coordinates": [-77]}
+
+
+SCHEMA_VIOLATION_CASES = [
+    pytest.param(_bad_dataset_id, id="bad_dataset_id"),
+    pytest.param(_bad_relation_iri, id="bad_relation_iri"),
+    pytest.param(_bad_is_referenced_by_iri, id="bad_is_referenced_by_iri"),
+    pytest.param(_bad_image_iri, id="bad_image_iri"),
+    pytest.param(_string_entry_in_conforms_to, id="string_entry_in_conforms_to"),
+    pytest.param(
+        _language_array_of_three_char_codes,
+        id="language_array_of_three_char_codes",
+    ),
+    pytest.param(
+        _non_string_spatial_resolution_in_meters,
+        id="non_string_spatial_resolution_in_meters",
+    ),
+    pytest.param(_non_string_temporal_resolution, id="non_string_temporal_resolution"),
+    pytest.param(_non_empty_list_byte_size, id="non_empty_list_byte_size"),
+    pytest.param(_bare_string_character_encoding, id="bare_string_character_encoding"),
+    pytest.param(_blank_keywords, id="blank_keywords"),
+    pytest.param(_distribution_type_dict, id="distribution_type_dict"),
+    pytest.param(_distribution_type_list, id="distribution_type_list"),
+    pytest.param(
+        _spatial_geometry_non_string_non_dict,
+        id="spatial_geometry_non_string_non_dict",
+    ),
+    pytest.param(
+        _spatial_geometry_dict_missing_required_keys,
+        id="spatial_geometry_dict_missing_required_keys",
+    ),
+    pytest.param(
+        _spatial_bbox_non_string_non_dict, id="spatial_bbox_non_string_non_dict"
+    ),
+    pytest.param(
+        _created_date_time_without_utc_offset,
+        id="created_date_time_without_utc_offset",
+    ),
+    pytest.param(
+        _address_replaced_with_non_string_postal_code_zero,
+        id="address_replaced_with_non_string_postal_code_zero",
+    ),
+    pytest.param(
+        _address_replaced_with_non_string_postal_code_empty_list,
+        id="address_replaced_with_non_string_postal_code_empty_list",
+    ),
+    pytest.param(
+        _spatial_resolution_in_meters_non_empty_list,
+        id="spatial_resolution_in_meters_non_empty_list",
+    ),
+    pytest.param(
+        _temporal_resolution_non_empty_dict,
+        id="temporal_resolution_non_empty_dict",
+    ),
+    pytest.param(
+        _nested_container_type_error_under_anyof,
+        id="nested_container_type_error_under_anyof",
+    ),
+    pytest.param(_bbox_wrong_type, id="bbox_wrong_type"),
+    pytest.param(_padded_date, id="padded_date"),
+    pytest.param(
+        _created_all_scalar_anyof_branches,
+        id="created_all_scalar_anyof_branches",
+    ),
+    pytest.param(
+        _language_all_scalar_anyof_branches,
+        id="language_all_scalar_anyof_branches",
+    ),
+    pytest.param(
+        _spatial_bbox_all_scalar_anyof_branches,
+        id="spatial_bbox_all_scalar_anyof_branches",
+    ),
+    pytest.param(
+        _access_rights_all_scalar_anyof_branches,
+        id="access_rights_all_scalar_anyof_branches",
+    ),
+    pytest.param(
+        _centroid_coordinates_maxitems_numeric,
+        id="centroid_coordinates_maxitems_numeric",
+    ),
+    pytest.param(
+        _centroid_coordinates_minitems_numeric,
+        id="centroid_coordinates_minitems_numeric",
+    ),
+]
+
+
+class TestSchemaViolationsProduceNoWarning:
+    @pytest.mark.parametrize("mutate", SCHEMA_VIOLATION_CASES)
+    def test_schema_violation_has_no_matching_warning(self, mutate):
+        mutated = _record()
+        mutate(mutated)
+
+        assert _schema_errors(mutated), "mutation should be a schema violation"
+
+        assert _new_warning_types(mutated) == []

--- a/tests/unit/test_dcat_warnings.py
+++ b/tests/unit/test_dcat_warnings.py
@@ -10,7 +10,7 @@ every test.
 
 from pathlib import Path
 
-from harvester.utils.dcat_warnings import DcatWarning, detect_dcat_warnings
+from harvester.utils.dcat_warnings import detect_dcat_warnings
 from harvester.utils.general_utils import open_json
 
 COMPLETE_EXAMPLE = (
@@ -28,33 +28,6 @@ def types(warnings):
     return [w.warning_type for w in warnings]
 
 
-class TestIdIri:
-    def test_valid_iri_produces_no_warning(self):
-        data = {"@id": "https://example.gov/datasets/one", "@type": "Dataset"}
-        assert detect_dcat_warnings(data) == []
-
-    def test_invalid_iri_warns(self):
-        data = {"@id": "not a valid iri", "@type": "Dataset"}
-        warnings = detect_dcat_warnings(data)
-        assert warnings == [
-            DcatWarning(
-                "invalid_iri", '`@id` value "not a valid iri" is not a valid IRI.'
-            )
-        ]
-
-    def test_missing_id_is_ignored(self):
-        assert detect_dcat_warnings({"@type": "Dataset"}) == []
-
-    def test_nested_object_id_is_checked(self):
-        data = {
-            "@type": "Dataset",
-            "distribution": [{"@type": "Distribution", "@id": "bad iri"}],
-        }
-        warnings = detect_dcat_warnings(data)
-        assert types(warnings) == ["invalid_iri"]
-        assert '`@id` value "bad iri"' in warnings[0].message
-
-
 class TestDuplicateKeywords:
     def test_unique_keywords_pass(self):
         data = {"@type": "Dataset", "keyword": ["climate", "weather"]}
@@ -65,6 +38,12 @@ class TestDuplicateKeywords:
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["duplicate_keyword"]
         assert "climate" in warnings[0].message
+
+    def test_duplicate_blank_keywords_produce_no_warning(self):
+        # `keyword` items carry `minLength: 1`; an empty string is already a
+        # schema violation, so it must not also be reported as a warning.
+        data = {"@type": "Dataset", "keyword": ["", ""]}
+        assert detect_dcat_warnings(data) == []
 
 
 class TestSpatialResolutionInMeters:
@@ -107,6 +86,13 @@ class TestSpatialResolutionInMeters:
             warnings = detect_dcat_warnings(data)
             assert types(warnings) == ["invalid_spatial_resolution"]
 
+    def test_non_string_value_produces_no_warning(self):
+        # spatialResolutionInMeters is `type: ["null", "string"]`; a non-string
+        # value is already a schema type error, so this rule must not also
+        # warn on it (that would be the same defect reported twice).
+        data = {"@type": "Dataset", "spatialResolutionInMeters": 5}
+        assert detect_dcat_warnings(data) == []
+
 
 class TestTemporalResolution:
     def test_valid_iso8601_duration_passes(self):
@@ -129,6 +115,12 @@ class TestTemporalResolution:
         data = {"@type": "Dataset", "temporalResolution": "P"}
         assert types(detect_dcat_warnings(data)) == ["invalid_temporal_resolution"]
 
+    def test_non_string_value_produces_no_warning(self):
+        # temporalResolution is `type: ["null", "string"]`; a non-string
+        # value is already a schema type error.
+        data = {"@type": "Dataset", "temporalResolution": 5}
+        assert detect_dcat_warnings(data) == []
+
 
 class TestByteSize:
     def test_numeric_byte_size_passes(self):
@@ -140,6 +132,19 @@ class TestByteSize:
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["invalid_byte_size"]
         assert "does not appear to be a valid number" in warnings[0].message
+
+    def test_non_string_value_produces_no_warning(self):
+        # byteSize is `type: ["null", "string"]`; a non-string value is
+        # already a schema type error.
+        data = {"@type": "Distribution", "byteSize": 524288000}
+        assert detect_dcat_warnings(data) == []
+
+    def test_list_value_produces_no_warning_and_does_not_crash(self):
+        # Regression: is_number(["big"]) used to raise TypeError, which
+        # propagated out of detect_dcat_warnings. A list is already a schema
+        # type error, so it must be skipped, not crash.
+        data = {"@type": "Distribution", "byteSize": []}
+        assert detect_dcat_warnings(data) == []
 
 
 class TestLegacyAccessRights:
@@ -190,6 +195,71 @@ class TestDateOrdering:
         data = {"@type": "Dataset", "created": "2025", "issued": "2024"}
         assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
 
+    def test_yyyy_mm_dd_dates_compare(self):
+        data = {"@type": "Dataset", "created": "2025-06-01", "issued": "2024-01-01"}
+        assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
+
+    def test_date_time_with_offset_compares(self):
+        # `created` is `format: date-time`, which the schema requires to be
+        # RFC 3339 (a UTC offset present). "Z" is a valid RFC 3339 offset.
+        data = {
+            "@type": "Dataset",
+            "created": "2025-01-01T00:00:00Z",
+            "issued": "2024-01-01T00:00:00Z",
+        }
+        assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
+
+    def test_lowercase_rfc3339_date_time_warns_and_does_not_crash(self):
+        # A lowercase "t"/"z" date-time is still RFC 3339 (FormatChecker
+        # accepts it, so the schema accepts it too), and `created` here is
+        # genuinely later than `issued` -- so this must both parse without
+        # raising and produce the ordering warning (GSA/data.gov#6243). Before
+        # the fix, parsing a lowercase "z" raised inside `_parse_dcat_date`,
+        # the `except ValueError` swallowed it, and the mismatch silently
+        # produced no warning at all for a record that does have the defect.
+        data = {
+            "@type": "Dataset",
+            "created": "2025-01-01t00:00:00z",
+            "issued": "2024-01-01t00:00:00z",
+        }
+        assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
+
+    def test_date_time_without_offset_produces_no_warning(self):
+        # `datetime.fromisoformat` alone would accept a date-time with no UTC
+        # offset, but the schema's `format: date-time` requires one (RFC
+        # 3339), so this value is already a schema `format` error. It must
+        # not also be parsed here and reported as `date_out_of_order`.
+        data = {
+            "@type": "Dataset",
+            "created": "2025-01-01T00:00:00",
+            "issued": "2024-01-01T00:00:00",
+        }
+        assert detect_dcat_warnings(data) == []
+
+    def test_whitespace_padded_date_produces_no_warning(self):
+        # The schema's `^[0-9]{4}$`/`^[0-9]{4}-[0-9]{2}$` patterns and its
+        # `date`/`date-time` formats all check the value exactly as given, so
+        # a padded string is already a schema error (GSA/data.gov#6243). It
+        # must not be stripped and parsed here anyway, which would double-
+        # report it as `date_out_of_order`.
+        data = {
+            "@type": "Dataset",
+            "created": " 2025-06-01 ",
+            "issued": "2024-01-01",
+        }
+        assert detect_dcat_warnings(data) == []
+
+    def test_unpadded_equivalent_of_padded_date_still_warns(self):
+        # Positive counterpart to the previous test: the same date value
+        # without the padding is schema-valid and must still warn, so the
+        # fix isn't over-tightened into never parsing `created` at all.
+        data = {
+            "@type": "Dataset",
+            "created": "2025-06-01",
+            "issued": "2024-01-01",
+        }
+        assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
+
 
 class TestPeriodOfTime:
     def test_start_before_end_passes(self):
@@ -209,39 +279,6 @@ class TestPeriodOfTime:
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["date_out_of_order"]
         assert "cannot be after its end" in warnings[0].message
-
-
-class TestIriArrays:
-    def test_valid_iri_arrays_pass(self):
-        data = {
-            "@type": "Dataset",
-            "relation": ["https://example.gov/a"],
-            "isReferencedBy": ["https://example.gov/b"],
-        }
-        assert detect_dcat_warnings(data) == []
-
-    def test_invalid_relation_iri_warns(self):
-        data = {"@type": "Dataset", "relation": ["not an iri"]}
-        warnings = detect_dcat_warnings(data)
-        assert types(warnings) == ["invalid_iri"]
-        assert "`relation` value" in warnings[0].message
-
-    def test_conformsTo_object_entries_are_skipped(self):
-        # Standard objects on conformsTo are covered by the universal @id walk,
-        # not by the string-IRI check.
-        data = {
-            "@type": "Dataset",
-            "conformsTo": [
-                {"@type": "Standard", "@id": "https://example.gov/std", "title": "x"}
-            ],
-        }
-        assert detect_dcat_warnings(data) == []
-
-    def test_image_invalid_iri_warns(self):
-        data = {"@type": "Dataset", "image": "not an iri"}
-        warnings = detect_dcat_warnings(data)
-        assert types(warnings) == ["invalid_iri"]
-        assert "`image` value" in warnings[0].message
 
 
 class TestTel:
@@ -266,6 +303,12 @@ class TestExpectedDataType:
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["invalid_expected_data_type"]
         assert "xsd:" in warnings[0].message
+
+    def test_non_string_value_produces_no_warning(self):
+        # Metric.expectedDataType is `"type": "string"`; a non-string value
+        # (e.g. a list) is already a schema type error.
+        data = {"@type": "Metric", "expectedDataType": ["xsd:decimal"]}
+        assert detect_dcat_warnings(data) == []
 
 
 class TestAddress:
@@ -300,6 +343,25 @@ class TestAddress:
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["empty_address"]
 
+    def test_wrong_typed_postal_code_zero_produces_no_empty_address_warning(self):
+        # Every Address field is `type: ["null", "string"]`; `0` is a schema
+        # type error there, not an "unpopulated" value, so this address must
+        # not also be reported as empty (it has a populated, if
+        # wrongly-typed, field).
+        data = {"@type": "Address", "postal-code": 0}
+        assert detect_dcat_warnings(data) == []
+
+    def test_wrong_typed_postal_code_empty_list_produces_no_empty_address_warning(self):
+        data = {"@type": "Address", "postal-code": []}
+        assert detect_dcat_warnings(data) == []
+
+    def test_all_fields_missing_still_warns(self):
+        # No fields set at all (as opposed to explicit None/"") is still the
+        # schema-valid "unpopulated" case and must still warn.
+        data = {"@type": "Address"}
+        warnings = detect_dcat_warnings(data)
+        assert types(warnings) == ["empty_address"]
+
 
 class TestCuiBannerMarking:
     def test_valid_marking_passes(self):
@@ -324,6 +386,65 @@ class TestLocationSpatial:
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["unresolvable_spatial_value"]
         assert "could not be resolved" in warnings[0].message
+
+    def test_resolvable_polygon_object_passes(self):
+        data = {
+            "@type": "Location",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [[-77.04, 38.79], [-76.9, 38.89], [-76.91, 38.93], [-77.04, 38.79]]
+                ],
+            },
+        }
+        assert detect_dcat_warnings(data) == []
+
+    def test_non_string_non_object_geometry_produces_no_warning(self):
+        # `geometry` is `anyOf[null, string, object]`; a bare number is
+        # already a schema type error.
+        data = {"@type": "Location", "geometry": 5}
+        assert detect_dcat_warnings(data) == []
+
+    def test_geometry_dict_missing_required_keys_produces_no_warning(self):
+        # The object variant of `geometry` requires "type" and "coordinates";
+        # a dict without them is already a schema required-property error.
+        data = {"@type": "Location", "geometry": {"foo": 1}}
+        assert detect_dcat_warnings(data) == []
+
+    def test_non_string_non_object_bbox_produces_no_warning(self):
+        data = {"@type": "Location", "bbox": 5}
+        assert detect_dcat_warnings(data) == []
+
+    def test_bbox_dict_missing_required_keys_produces_no_warning(self):
+        data = {"@type": "Location", "bbox": {"foo": 1}}
+        assert detect_dcat_warnings(data) == []
+
+    def test_bbox_dict_wrong_type_produces_no_warning(self):
+        # bbox's object variant pins "type" to the constant "Polygon"
+        # (Location.json); a dict whose "type" isn't exactly "Polygon" is
+        # already a schema `const` error there, so this must defer to it
+        # entirely rather than ask `translate_spatial` to resolve it
+        # (GSA/data.gov#6243).
+        data = {
+            "@type": "Location",
+            "bbox": {
+                "type": "NotAPolygon",
+                "coordinates": [[[-77.1, 38.7], [-76.9, 38.7], [-77.1, 38.7]]],
+            },
+        }
+        assert detect_dcat_warnings(data) == []
+
+    def test_geometry_dict_arbitrary_type_still_warns_when_unresolvable(self):
+        # geometry's object variant has no such constant -- any "type" value
+        # is schema-valid there -- so a dict `translate_spatial` can't
+        # resolve is still a legitimate, schema-clean content-quality
+        # warning, unlike the bbox case above.
+        data = {
+            "@type": "Location",
+            "geometry": {"type": "NotAPolygon", "coordinates": [1, 2]},
+        }
+        warnings = detect_dcat_warnings(data)
+        assert types(warnings) == ["unresolvable_spatial_value"]
 
 
 class TestLanguage:
@@ -353,6 +474,12 @@ class TestLanguage:
         assert types(warnings) == ["invalid_language"]
         assert '"zz"' in warnings[0].message
 
+    def test_entry_longer_than_two_chars_produces_no_warning(self):
+        # `language` entries carry `maxLength: 2`; a 3+ character entry is
+        # already a schema `maxLength` error, whether scalar or in an array.
+        assert detect_dcat_warnings({"@type": "Dataset", "language": "eng"}) == []
+        assert detect_dcat_warnings({"@type": "Dataset", "language": ["eng"]}) == []
+
 
 class TestCharacterEncoding:
     def test_recognized_charset_passes(self):
@@ -364,6 +491,13 @@ class TestCharacterEncoding:
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["invalid_character_encoding"]
         assert "IANA character set" in warnings[0].message
+
+    def test_bare_string_value_produces_no_warning(self):
+        # Distribution.characterEncoding is `anyOf[null, {array of string}]`;
+        # a bare string (not wrapped in a list) is already a schema type
+        # error.
+        data = {"@type": "Distribution", "characterEncoding": "bogus"}
+        assert detect_dcat_warnings(data) == []
 
 
 class TestMediaType:
@@ -476,3 +610,36 @@ class TestTraversalAndCleanRecord:
             "invalid_byte_size",
             "invalid_tel",
         }
+
+
+class TestNonStringTypeDispatch:
+    # `@type` is `{"type": "string", ...}` in every DCAT-US 3 definition; a
+    # non-string `@type` is already a schema type error. It is also
+    # unhashable when it is a list or dict, so dispatching on it via
+    # `_TYPE_RULES.get(...)` without this guard raises `TypeError: unhashable
+    # type` and aborts warning detection for the whole record.
+
+    def test_list_type_is_skipped_without_raising(self):
+        data = {
+            "@type": "Dataset",
+            "distribution": [{"@type": [], "byteSize": "big"}],
+        }
+        assert detect_dcat_warnings(data) == []
+
+    def test_dict_type_is_skipped_without_raising(self):
+        data = {
+            "@type": "Dataset",
+            "distribution": [{"@type": {}, "byteSize": "big"}],
+        }
+        assert detect_dcat_warnings(data) == []
+
+    def test_other_objects_still_processed_when_one_has_a_bad_type(self):
+        # A malformed @type on one nested object must not swallow warnings
+        # from sibling objects.
+        data = {
+            "@type": "Dataset",
+            "keyword": ["a", "a"],
+            "distribution": [{"@type": [], "byteSize": "big"}],
+        }
+        warnings = detect_dcat_warnings(data)
+        assert types(warnings) == ["duplicate_keyword"]

--- a/tests/unit/test_dcat_warnings.py
+++ b/tests/unit/test_dcat_warnings.py
@@ -40,8 +40,7 @@ class TestDuplicateKeywords:
         assert "climate" in warnings[0].message
 
     def test_duplicate_blank_keywords_produce_no_warning(self):
-        # `keyword` items carry `minLength: 1`; an empty string is already a
-        # schema violation, so it must not also be reported as a warning.
+        # Empty strings are schema `minLength: 1`; must not also warn.
         data = {"@type": "Dataset", "keyword": ["", ""]}
         assert detect_dcat_warnings(data) == []
 
@@ -87,9 +86,6 @@ class TestSpatialResolutionInMeters:
             assert types(warnings) == ["invalid_spatial_resolution"]
 
     def test_non_string_value_produces_no_warning(self):
-        # spatialResolutionInMeters is `type: ["null", "string"]`; a non-string
-        # value is already a schema type error, so this rule must not also
-        # warn on it (that would be the same defect reported twice).
         data = {"@type": "Dataset", "spatialResolutionInMeters": 5}
         assert detect_dcat_warnings(data) == []
 
@@ -116,8 +112,6 @@ class TestTemporalResolution:
         assert types(detect_dcat_warnings(data)) == ["invalid_temporal_resolution"]
 
     def test_non_string_value_produces_no_warning(self):
-        # temporalResolution is `type: ["null", "string"]`; a non-string
-        # value is already a schema type error.
         data = {"@type": "Dataset", "temporalResolution": 5}
         assert detect_dcat_warnings(data) == []
 
@@ -134,15 +128,11 @@ class TestByteSize:
         assert "does not appear to be a valid number" in warnings[0].message
 
     def test_non_string_value_produces_no_warning(self):
-        # byteSize is `type: ["null", "string"]`; a non-string value is
-        # already a schema type error.
         data = {"@type": "Distribution", "byteSize": 524288000}
         assert detect_dcat_warnings(data) == []
 
     def test_list_value_produces_no_warning_and_does_not_crash(self):
-        # Regression: is_number(["big"]) used to raise TypeError, which
-        # propagated out of detect_dcat_warnings. A list is already a schema
-        # type error, so it must be skipped, not crash.
+        # is_number(["big"]) used to raise TypeError out of detect_dcat_warnings.
         data = {"@type": "Distribution", "byteSize": []}
         assert detect_dcat_warnings(data) == []
 
@@ -200,8 +190,7 @@ class TestDateOrdering:
         assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
 
     def test_date_time_with_offset_compares(self):
-        # `created` is `format: date-time`, which the schema requires to be
-        # RFC 3339 (a UTC offset present). "Z" is a valid RFC 3339 offset.
+        # `format: date-time` requires a UTC offset; "Z" is valid RFC 3339.
         data = {
             "@type": "Dataset",
             "created": "2025-01-01T00:00:00Z",
@@ -210,13 +199,8 @@ class TestDateOrdering:
         assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
 
     def test_lowercase_rfc3339_date_time_warns_and_does_not_crash(self):
-        # A lowercase "t"/"z" date-time is still RFC 3339 (FormatChecker
-        # accepts it, so the schema accepts it too), and `created` here is
-        # genuinely later than `issued` -- so this must both parse without
-        # raising and produce the ordering warning (GSA/data.gov#6243). Before
-        # the fix, parsing a lowercase "z" raised inside `_parse_dcat_date`,
-        # the `except ValueError` swallowed it, and the mismatch silently
-        # produced no warning at all for a record that does have the defect.
+        # Lowercase "t"/"z" is still RFC 3339; used to raise inside the parser
+        # and silently produce no warning.
         data = {
             "@type": "Dataset",
             "created": "2025-01-01t00:00:00z",
@@ -225,10 +209,7 @@ class TestDateOrdering:
         assert types(detect_dcat_warnings(data)) == ["date_out_of_order"]
 
     def test_date_time_without_offset_produces_no_warning(self):
-        # `datetime.fromisoformat` alone would accept a date-time with no UTC
-        # offset, but the schema's `format: date-time` requires one (RFC
-        # 3339), so this value is already a schema `format` error. It must
-        # not also be parsed here and reported as `date_out_of_order`.
+        # fromisoformat accepts a date-time with no offset; the schema does not.
         data = {
             "@type": "Dataset",
             "created": "2025-01-01T00:00:00",
@@ -237,11 +218,7 @@ class TestDateOrdering:
         assert detect_dcat_warnings(data) == []
 
     def test_whitespace_padded_date_produces_no_warning(self):
-        # The schema's `^[0-9]{4}$`/`^[0-9]{4}-[0-9]{2}$` patterns and its
-        # `date`/`date-time` formats all check the value exactly as given, so
-        # a padded string is already a schema error (GSA/data.gov#6243). It
-        # must not be stripped and parsed here anyway, which would double-
-        # report it as `date_out_of_order`.
+        # Padded strings are schema-invalid; must not be stripped and warned on.
         data = {
             "@type": "Dataset",
             "created": " 2025-06-01 ",
@@ -250,9 +227,7 @@ class TestDateOrdering:
         assert detect_dcat_warnings(data) == []
 
     def test_unpadded_equivalent_of_padded_date_still_warns(self):
-        # Positive counterpart to the previous test: the same date value
-        # without the padding is schema-valid and must still warn, so the
-        # fix isn't over-tightened into never parsing `created` at all.
+        # Same date without padding is schema-valid and must still warn.
         data = {
             "@type": "Dataset",
             "created": "2025-06-01",
@@ -305,8 +280,6 @@ class TestExpectedDataType:
         assert "xsd:" in warnings[0].message
 
     def test_non_string_value_produces_no_warning(self):
-        # Metric.expectedDataType is `"type": "string"`; a non-string value
-        # (e.g. a list) is already a schema type error.
         data = {"@type": "Metric", "expectedDataType": ["xsd:decimal"]}
         assert detect_dcat_warnings(data) == []
 
@@ -344,10 +317,7 @@ class TestAddress:
         assert types(warnings) == ["empty_address"]
 
     def test_wrong_typed_postal_code_zero_produces_no_empty_address_warning(self):
-        # Every Address field is `type: ["null", "string"]`; `0` is a schema
-        # type error there, not an "unpopulated" value, so this address must
-        # not also be reported as empty (it has a populated, if
-        # wrongly-typed, field).
+        # `0` is a type error, not an unpopulated field, so this is not empty.
         data = {"@type": "Address", "postal-code": 0}
         assert detect_dcat_warnings(data) == []
 
@@ -356,8 +326,7 @@ class TestAddress:
         assert detect_dcat_warnings(data) == []
 
     def test_all_fields_missing_still_warns(self):
-        # No fields set at all (as opposed to explicit None/"") is still the
-        # schema-valid "unpopulated" case and must still warn.
+        # Missing fields (as opposed to explicit None/"") is still unpopulated.
         data = {"@type": "Address"}
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["empty_address"]
@@ -400,14 +369,10 @@ class TestLocationSpatial:
         assert detect_dcat_warnings(data) == []
 
     def test_non_string_non_object_geometry_produces_no_warning(self):
-        # `geometry` is `anyOf[null, string, object]`; a bare number is
-        # already a schema type error.
         data = {"@type": "Location", "geometry": 5}
         assert detect_dcat_warnings(data) == []
 
     def test_geometry_dict_missing_required_keys_produces_no_warning(self):
-        # The object variant of `geometry` requires "type" and "coordinates";
-        # a dict without them is already a schema required-property error.
         data = {"@type": "Location", "geometry": {"foo": 1}}
         assert detect_dcat_warnings(data) == []
 
@@ -420,11 +385,7 @@ class TestLocationSpatial:
         assert detect_dcat_warnings(data) == []
 
     def test_bbox_dict_wrong_type_produces_no_warning(self):
-        # bbox's object variant pins "type" to the constant "Polygon"
-        # (Location.json); a dict whose "type" isn't exactly "Polygon" is
-        # already a schema `const` error there, so this must defer to it
-        # entirely rather than ask `translate_spatial` to resolve it
-        # (GSA/data.gov#6243).
+        # bbox objects must be type "Polygon"; anything else is a schema const error.
         data = {
             "@type": "Location",
             "bbox": {
@@ -435,10 +396,7 @@ class TestLocationSpatial:
         assert detect_dcat_warnings(data) == []
 
     def test_geometry_dict_arbitrary_type_still_warns_when_unresolvable(self):
-        # geometry's object variant has no such constant -- any "type" value
-        # is schema-valid there -- so a dict `translate_spatial` can't
-        # resolve is still a legitimate, schema-clean content-quality
-        # warning, unlike the bbox case above.
+        # geometry has no type const, so an unresolvable dict is still a warning.
         data = {
             "@type": "Location",
             "geometry": {"type": "NotAPolygon", "coordinates": [1, 2]},
@@ -475,8 +433,7 @@ class TestLanguage:
         assert '"zz"' in warnings[0].message
 
     def test_entry_longer_than_two_chars_produces_no_warning(self):
-        # `language` entries carry `maxLength: 2`; a 3+ character entry is
-        # already a schema `maxLength` error, whether scalar or in an array.
+        # Entries longer than 2 characters are schema `maxLength` errors.
         assert detect_dcat_warnings({"@type": "Dataset", "language": "eng"}) == []
         assert detect_dcat_warnings({"@type": "Dataset", "language": ["eng"]}) == []
 
@@ -493,9 +450,7 @@ class TestCharacterEncoding:
         assert "IANA character set" in warnings[0].message
 
     def test_bare_string_value_produces_no_warning(self):
-        # Distribution.characterEncoding is `anyOf[null, {array of string}]`;
-        # a bare string (not wrapped in a list) is already a schema type
-        # error.
+        # characterEncoding is array-of-string only; a bare string is a type error.
         data = {"@type": "Distribution", "characterEncoding": "bogus"}
         assert detect_dcat_warnings(data) == []
 
@@ -613,11 +568,8 @@ class TestTraversalAndCleanRecord:
 
 
 class TestNonStringTypeDispatch:
-    # `@type` is `{"type": "string", ...}` in every DCAT-US 3 definition; a
-    # non-string `@type` is already a schema type error. It is also
-    # unhashable when it is a list or dict, so dispatching on it via
-    # `_TYPE_RULES.get(...)` without this guard raises `TypeError: unhashable
-    # type` and aborts warning detection for the whole record.
+    # Non-string @type is unhashable; dispatching via `_TYPE_RULES.get` used
+    # to raise TypeError and abort warning detection for the whole record.
 
     def test_list_type_is_skipped_without_raising(self):
         data = {
@@ -634,8 +586,7 @@ class TestNonStringTypeDispatch:
         assert detect_dcat_warnings(data) == []
 
     def test_other_objects_still_processed_when_one_has_a_bad_type(self):
-        # A malformed @type on one nested object must not swallow warnings
-        # from sibling objects.
+        # A malformed @type on one object must not swallow sibling warnings.
         data = {
             "@type": "Dataset",
             "keyword": ["a", "a"],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -46,8 +46,8 @@ from harvester.utils.general_utils import (
     validate_geojson,
 )
 
-# built once against the real dcatus 3.0 schema so tests can reproduce
-# GSA/data.gov#6243-style validator errors on the bundled complete example
+# Real DCAT-US 3.0 validator, used to reproduce assembler errors on the
+# complete example.
 DCATUS3_ROOT_DIR = Path(__file__).parents[2]
 DCATUS3_DEFINITIONS = DCATUS3_ROOT_DIR / "schemas" / "dcatus3.0" / "definitions"
 DCATUS3_COMPLETE_EXAMPLE_PATH = (
@@ -356,14 +356,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_type_error_list_value_is_reported(
         self, dcatus3_complete_example
     ):
-        """Regression test for GSA/data.gov#6243: a `type` error whose
-        offending value is a non-empty list must not be silently dropped.
-        `spatialResolutionInMeters` is `"type": ["null", "string"]`, so a
-        list value is unambiguously invalid, but before the fix
-        `found_simple_message` treated it as "dig deeper via context" even
-        though `type` errors never carry a `context` -- so nothing was
-        ever recorded for that path.
-        """
+        """A non-empty list that fails `type: ["null", "string"]` must be
+        reported, not dropped."""
         dcatus3_complete_example["spatialResolutionInMeters"] = ["bad"]
 
         errors = assemble_validation_errors(
@@ -379,13 +373,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_type_error_dict_value_is_reported(
         self, dcatus3_complete_example
     ):
-        """Same defect as above but for a dict-valued offender. Also pins
-        down the message rendering: the invalid value is named by its JSON
-        type ("object value") rather than by regexing an arbitrary quoted
-        fragment out of the raw jsonschema message, which for a dict would
-        otherwise latch onto one of its *keys* (nonsense in a user-facing
-        message).
-        """
+        """Same as the list case; name the offender as "object value", not a
+        dict key."""
         dcatus3_complete_example["temporalResolution"] = {"a": 1}
 
         errors = assemble_validation_errors(
@@ -401,16 +390,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_type_error_single_type_leaf_is_reported(
         self, dcatus3_complete_example
     ):
-        """Regression test for GSA/data.gov#6243: a `type` error whose schema
-        constraint is a single type (not a list) must also not be silently
-        dropped when it is a leaf constraint rather than one branch of a
-        decomposed `anyOf`/`oneOf`. A nested Distribution's `@type` is
-        plainly `{"type": "string"}`, so the resulting error comes straight
-        off `iter_errors` with no `parent` -- unlike the `anyOf`-branch `type`
-        error covered by
-        `test_assemble_validation_messages_anyof_context_still_finds_specific_cause`,
-        nothing else will report this one.
-        """
+        """A leaf `type: string` error with no parent (nested `@type`) must
+        still be reported."""
         dcatus3_complete_example["distribution"][0]["@type"] = {"a": 1}
 
         errors = assemble_validation_errors(
@@ -438,16 +419,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_anyof_context_still_finds_specific_cause(
         self, dcatus3_complete_example
     ):
-        """Regression test: `contactPoint` is validated via `anyOf` (null,
-        or an array of vcard objects). Removing a required property from
-        one of those objects makes the whole `anyOf` fail, and its
-        `.context` contains both the specific cause (a `required` error at
-        `$.contactPoint[0]`) and a less useful `type` error for the `null`
-        branch at `$.contactPoint` (a non-empty list failing a single-type
-        check). The fix for the container `type`-error drop must not
-        surface that second, generic-ish message -- only the specific one
-        should come through, exactly as before the fix.
-        """
+        """An anyOf failure should surface the specific cause, not the
+        null-branch type error."""
         del dcatus3_complete_example["contactPoint"][0]["hasEmail"]
 
         errors = assemble_validation_errors(
@@ -462,18 +435,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_nested_container_type_error_under_anyof(
         self, dcatus3_complete_example
     ):
-        """Regression test for GSA/data.gov#6243 (third review round): a
-        genuine leaf `type` error reached through one branch of a decomposed
-        `anyOf` must not be dropped just because it has a `parent`.
-        `contactPoint` is `anyOf[{$ref: kind}, {array of kind}]`; setting a
-        nested item's `@type` to a list makes both branches fail, and
-        `.context` holds three errors: the top-level `anyOf`, a `type` error
-        for the `null`/single-kind branch at `$.contactPoint` (same
-        `json_path` as its parent -- noise, since a sibling holds the real
-        cause), and the real cause, a `type` error for
-        `$.contactPoint[0]['@type']` (a deeper `json_path` than its parent).
-        Only the latter should be reported.
-        """
+        """A leaf type error reached through anyOf (deeper json_path than its
+        parent) must be reported."""
         dcatus3_complete_example["contactPoint"][0]["@type"] = ["Kind"]
 
         errors = assemble_validation_errors(
@@ -489,13 +452,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_plain_leaf_type_error_is_unaffected(
         self, dcatus3_complete_example
     ):
-        """Contrast case for GSA/data.gov#6243's forced fallback: `title` is
-        plainly `{"type": "string"}` at the schema root, not wrapped in an
-        `anyOf`, so its error carries no `context` and no `parent` at all --
-        it was already reported before the fallback existed, and the
-        fallback must not change it (it never even reaches the "nothing was
-        recorded" check, since there is no `context` to recurse into).
-        """
+        """A plain `type: string` leaf with no context is unchanged by the
+        forced fallback."""
         dcatus3_complete_example["title"] = {"a": 1}
 
         errors = assemble_validation_errors(
@@ -511,19 +469,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued(
         self, dcatus3_complete_example
     ):
-        """Regression test for GSA/data.gov#6243 (the remaining bug found by
-        review): when a container value fails an `anyOf` whose alternatives
-        are *all* scalar/null types, every child `type` error in `.context`
-        lands at the same `json_path` as the `anyOf` itself, so
-        `found_simple_message` suppresses every single one of them as
-        same-path branch noise (correctly, in isolation -- it's designed to
-        defer to a sibling with a more specific cause). But here there is no
-        such sibling: `accessRights` is `anyOf[null, string]`, both scalar,
-        so nothing anywhere in the subtree was ever going to be more
-        specific. Before the forced fallback, this meant the whole `anyOf`
-        produced zero recorded messages for a record that is, in fact,
-        schema-invalid -- a silent drop, not merely an imprecise one.
-        """
+        """When every anyOf alternative is scalar, report a vague type error
+        rather than silence."""
         dcatus3_complete_example["accessRights"] = ["x"]
 
         errors = assemble_validation_errors(
@@ -539,12 +486,7 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued_dict(
         self, dcatus3_complete_example
     ):
-        """Same silent-drop defect as above, for a dict-valued offender and a
-        3-way `anyOf` (`language` is `anyOf[null, string, array]`): all three
-        child `type` errors are same-path branch noise with no sibling to
-        defer to, so all three get recorded by the forced fallback once it
-        confirms none of them would otherwise be reported.
-        """
+        """Same all-scalar anyOf rescue, for a dict against `language`."""
         dcatus3_complete_example["language"] = {"a": 1}
 
         errors = assemble_validation_errors(
@@ -560,16 +502,7 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued_date(
         self, dcatus3_complete_example
     ):
-        """Same silent-drop defect, for `created`, whose `anyOf` decomposes
-        one level deeper (a nested `anyOf` groups the date-time/date/pattern
-        string alternatives). The forced fallback fires at that nested level
-        -- where it finds and records a `type` error -- so the outer level's
-        own `null`-branch sibling never needs forcing (something was already
-        recorded in the subtree by the time the outer level checks), which
-        is why only `'string'` appears here rather than `'null', 'string'`:
-        the design's "at least one message, not silence" goal is met without
-        also walking every remaining sibling once a cause is found.
-        """
+        """Same all-scalar anyOf rescue, for `created` (nested anyOf of date forms)."""
         dcatus3_complete_example["created"] = ["2025"]
 
         errors = assemble_validation_errors(
@@ -585,12 +518,7 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued_nested(
         self, dcatus3_complete_example
     ):
-        """Same silent-drop defect, one level deeper still: `spatial[0].bbox`
-        is `anyOf[null, string, object]`, reached through `spatial`'s own
-        `anyOf[null, array of Location]`. The forced fallback must fire at
-        the `bbox` level (where the true defect is) rather than the outer
-        `spatial` level, and must still name the nested `json_path`.
-        """
+        """Same all-scalar anyOf rescue, nested under `spatial[0].bbox`."""
         dcatus3_complete_example["spatial"][0]["bbox"] = ["x"]
 
         errors = assemble_validation_errors(
@@ -606,19 +534,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_maxitems_numeric_array_does_not_crash(
         self, dcatus3_complete_example
     ):
-        """Regression test for GSA/data.gov#6243 (final review round, fix 1):
-        a `maxItems` violation whose instance is a numeric array (not an
-        array of strings) used to crash `finalize_validation_messages` --
-        `re.search(r"'(.*?)'|\\[\\]", ...)` finds neither a quoted run nor a
-        literal `[]` in "[-77, 38, 1] is too long [maxItems=2]", so
-        `.group(0)` raised `AttributeError` on the `None` match, aborting
-        validation mid-harvest. `centroid.coordinates` is `{"type": "array",
-        "items": {"type": "number"}, "minItems": 2, "maxItems": 2}`
-        (Location.json), so a 3-element numeric array hits exactly this.
-
-        A container instance is named by kind rather than spliced into the
-        message, so an oversized array can't bloat the stored error.
-        """
+        """A numeric maxItems array must not crash message assembly; name it
+        as "array value"."""
         dcatus3_complete_example["spatial"][0]["centroid"] = {
             "type": "Point",
             "coordinates": [-77, 38, 1],
@@ -637,19 +554,8 @@ class TestGeneralUtils:
     def test_assemble_validation_messages_minitems_names_specific_cause(
         self, dcatus3_complete_example
     ):
-        """Regression test for GSA/data.gov#6243 (final review round, fix 2):
-        before this fix, `found_simple_message` only whitelisted `maxItems`
-        (plus `required` and, from an earlier round, same-path `type`) as a
-        container validator worth reporting directly -- every other
-        container constraint, including `minItems`, fell through to
-        `return False` and was suppressed, leaving `assemble_validation_
-        errors` to recurse into `.context` and land on the vague branch-type
-        message for `centroid`'s `anyOf` instead of the real cause on
-        `coordinates`. A 1-element `coordinates` array is too short
-        (`minItems: 2`) and must be reported at its own, more specific
-        `json_path` rather than as "$.spatial[0].centroid, object value does
-        not match any of the acceptable formats: 'null', 'string'".
-        """
+        """A minItems violation must be reported at its own path, not as a
+        parent anyOf type error."""
         dcatus3_complete_example["spatial"][0]["centroid"] = {
             "type": "Point",
             "coordinates": [-77],

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,6 +3,7 @@ import json
 import logging
 import time
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -18,6 +19,7 @@ from harvester.utils.general_utils import (
     USER_AGENT,
     RetrySession,
     assemble_validation_errors,
+    build_dcatus3_validator,
     create_retry_session,
     describe_identifier_error,
     download_file,
@@ -41,6 +43,30 @@ from harvester.utils.general_utils import (
     translate_spatial_to_geojson,
     validate_geojson,
 )
+
+# built once against the real dcatus 3.0 schema so tests can reproduce
+# GSA/data.gov#6243-style validator errors on the bundled complete example
+DCATUS3_ROOT_DIR = Path(__file__).parents[2]
+DCATUS3_DEFINITIONS = DCATUS3_ROOT_DIR / "schemas" / "dcatus3.0" / "definitions"
+DCATUS3_COMPLETE_EXAMPLE_PATH = (
+    DCATUS3_ROOT_DIR
+    / "schemas"
+    / "dcatus3.0"
+    / "examples"
+    / "Dataset"
+    / "good"
+    / "complete_example.json"
+)
+DCATUS3_DATASET_VALIDATOR = build_dcatus3_validator(
+    DCATUS3_DEFINITIONS,
+    root_ref="https://resources.data.gov/dcat-us/3.0.0/definitions/dataset",
+)
+
+
+@pytest.fixture
+def dcatus3_complete_example():
+    with open(DCATUS3_COMPLETE_EXAMPLE_PATH) as f:
+        return json.load(f)
 
 
 class TestCKANUtils:
@@ -324,6 +350,318 @@ class TestGeneralUtils:
         )
         keyword_error = next(e for e in errors if "$.keyword" in e.message)
         assert "max 1000 items" in keyword_error.message
+
+    def test_assemble_validation_messages_type_error_list_value_is_reported(
+        self, dcatus3_complete_example
+    ):
+        """Regression test for GSA/data.gov#6243: a `type` error whose
+        offending value is a non-empty list must not be silently dropped.
+        `spatialResolutionInMeters` is `"type": ["null", "string"]`, so a
+        list value is unambiguously invalid, but before the fix
+        `found_simple_message` treated it as "dig deeper via context" even
+        though `type` errors never carry a `context` -- so nothing was
+        ever recorded for that path.
+        """
+        dcatus3_complete_example["spatialResolutionInMeters"] = ["bad"]
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.spatialResolutionInMeters, array value does not match any "
+            "of the acceptable formats: 'string'"
+        )
+
+    def test_assemble_validation_messages_type_error_dict_value_is_reported(
+        self, dcatus3_complete_example
+    ):
+        """Same defect as above but for a dict-valued offender. Also pins
+        down the message rendering: the invalid value is named by its JSON
+        type ("object value") rather than by regexing an arbitrary quoted
+        fragment out of the raw jsonschema message, which for a dict would
+        otherwise latch onto one of its *keys* (nonsense in a user-facing
+        message).
+        """
+        dcatus3_complete_example["temporalResolution"] = {"a": 1}
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.temporalResolution, object value does not match any of the "
+            "acceptable formats: 'string'"
+        )
+
+    def test_assemble_validation_messages_type_error_single_type_leaf_is_reported(
+        self, dcatus3_complete_example
+    ):
+        """Regression test for GSA/data.gov#6243: a `type` error whose schema
+        constraint is a single type (not a list) must also not be silently
+        dropped when it is a leaf constraint rather than one branch of a
+        decomposed `anyOf`/`oneOf`. A nested Distribution's `@type` is
+        plainly `{"type": "string"}`, so the resulting error comes straight
+        off `iter_errors` with no `parent` -- unlike the `anyOf`-branch `type`
+        error covered by
+        `test_assemble_validation_messages_anyof_context_still_finds_specific_cause`,
+        nothing else will report this one.
+        """
+        dcatus3_complete_example["distribution"][0]["@type"] = {"a": 1}
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.distribution[0]['@type'], object value does not match any of "
+            "the acceptable formats: 'string'"
+        )
+
+        dcatus3_complete_example["distribution"][0]["@type"] = ["a"]
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.distribution[0]['@type'], array value does not match any of "
+            "the acceptable formats: 'string'"
+        )
+
+    def test_assemble_validation_messages_anyof_context_still_finds_specific_cause(
+        self, dcatus3_complete_example
+    ):
+        """Regression test: `contactPoint` is validated via `anyOf` (null,
+        or an array of vcard objects). Removing a required property from
+        one of those objects makes the whole `anyOf` fail, and its
+        `.context` contains both the specific cause (a `required` error at
+        `$.contactPoint[0]`) and a less useful `type` error for the `null`
+        branch at `$.contactPoint` (a non-empty list failing a single-type
+        check). The fix for the container `type`-error drop must not
+        surface that second, generic-ish message -- only the specific one
+        should come through, exactly as before the fix.
+        """
+        del dcatus3_complete_example["contactPoint"][0]["hasEmail"]
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert (
+            errors[0].message == "$.contactPoint[0], 'hasEmail' is a required property"
+        )
+
+    def test_assemble_validation_messages_nested_container_type_error_under_anyof(
+        self, dcatus3_complete_example
+    ):
+        """Regression test for GSA/data.gov#6243 (third review round): a
+        genuine leaf `type` error reached through one branch of a decomposed
+        `anyOf` must not be dropped just because it has a `parent`.
+        `contactPoint` is `anyOf[{$ref: kind}, {array of kind}]`; setting a
+        nested item's `@type` to a list makes both branches fail, and
+        `.context` holds three errors: the top-level `anyOf`, a `type` error
+        for the `null`/single-kind branch at `$.contactPoint` (same
+        `json_path` as its parent -- noise, since a sibling holds the real
+        cause), and the real cause, a `type` error for
+        `$.contactPoint[0]['@type']` (a deeper `json_path` than its parent).
+        Only the latter should be reported.
+        """
+        dcatus3_complete_example["contactPoint"][0]["@type"] = ["Kind"]
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.contactPoint[0]['@type'], array value does not match any of "
+            "the acceptable formats: 'string'"
+        )
+
+    def test_assemble_validation_messages_plain_leaf_type_error_is_unaffected(
+        self, dcatus3_complete_example
+    ):
+        """Contrast case for GSA/data.gov#6243's forced fallback: `title` is
+        plainly `{"type": "string"}` at the schema root, not wrapped in an
+        `anyOf`, so its error carries no `context` and no `parent` at all --
+        it was already reported before the fallback existed, and the
+        fallback must not change it (it never even reaches the "nothing was
+        recorded" check, since there is no `context` to recurse into).
+        """
+        dcatus3_complete_example["title"] = {"a": 1}
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.title, object value does not match any of the acceptable "
+            "formats: 'string'"
+        )
+
+    def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued(
+        self, dcatus3_complete_example
+    ):
+        """Regression test for GSA/data.gov#6243 (the remaining bug found by
+        review): when a container value fails an `anyOf` whose alternatives
+        are *all* scalar/null types, every child `type` error in `.context`
+        lands at the same `json_path` as the `anyOf` itself, so
+        `found_simple_message` suppresses every single one of them as
+        same-path branch noise (correctly, in isolation -- it's designed to
+        defer to a sibling with a more specific cause). But here there is no
+        such sibling: `accessRights` is `anyOf[null, string]`, both scalar,
+        so nothing anywhere in the subtree was ever going to be more
+        specific. Before the forced fallback, this meant the whole `anyOf`
+        produced zero recorded messages for a record that is, in fact,
+        schema-invalid -- a silent drop, not merely an imprecise one.
+        """
+        dcatus3_complete_example["accessRights"] = ["x"]
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.accessRights, array value does not match any of the "
+            "acceptable formats: 'null', 'string'"
+        )
+
+    def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued_dict(
+        self, dcatus3_complete_example
+    ):
+        """Same silent-drop defect as above, for a dict-valued offender and a
+        3-way `anyOf` (`language` is `anyOf[null, string, array]`): all three
+        child `type` errors are same-path branch noise with no sibling to
+        defer to, so all three get recorded by the forced fallback once it
+        confirms none of them would otherwise be reported.
+        """
+        dcatus3_complete_example["language"] = {"a": 1}
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.language, object value does not match any of the acceptable "
+            "formats: 'null', 'string', 'array'"
+        )
+
+    def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued_date(
+        self, dcatus3_complete_example
+    ):
+        """Same silent-drop defect, for `created`, whose `anyOf` decomposes
+        one level deeper (a nested `anyOf` groups the date-time/date/pattern
+        string alternatives). The forced fallback fires at that nested level
+        -- where it finds and records a `type` error -- so the outer level's
+        own `null`-branch sibling never needs forcing (something was already
+        recorded in the subtree by the time the outer level checks), which
+        is why only `'string'` appears here rather than `'null', 'string'`:
+        the design's "at least one message, not silence" goal is met without
+        also walking every remaining sibling once a cause is found.
+        """
+        dcatus3_complete_example["created"] = ["2025"]
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.created, array value does not match any of the acceptable "
+            "formats: 'string'"
+        )
+
+    def test_assemble_validation_messages_anyof_of_all_scalar_types_is_rescued_nested(
+        self, dcatus3_complete_example
+    ):
+        """Same silent-drop defect, one level deeper still: `spatial[0].bbox`
+        is `anyOf[null, string, object]`, reached through `spatial`'s own
+        `anyOf[null, array of Location]`. The forced fallback must fire at
+        the `bbox` level (where the true defect is) rather than the outer
+        `spatial` level, and must still name the nested `json_path`.
+        """
+        dcatus3_complete_example["spatial"][0]["bbox"] = ["x"]
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.spatial[0].bbox, array value does not match any of the "
+            "acceptable formats: 'null', 'string', 'object'"
+        )
+
+    def test_assemble_validation_messages_maxitems_numeric_array_does_not_crash(
+        self, dcatus3_complete_example
+    ):
+        """Regression test for GSA/data.gov#6243 (final review round, fix 1):
+        a `maxItems` violation whose instance is a numeric array (not an
+        array of strings) used to crash `finalize_validation_messages` --
+        `re.search(r"'(.*?)'|\\[\\]", ...)` finds neither a quoted run nor a
+        literal `[]` in "[-77, 38, 1] is too long [maxItems=2]", so
+        `.group(0)` raised `AttributeError` on the `None` match, aborting
+        validation mid-harvest. `centroid.coordinates` is `{"type": "array",
+        "items": {"type": "number"}, "minItems": 2, "maxItems": 2}`
+        (Location.json), so a 3-element numeric array hits exactly this.
+
+        A container instance is named by kind rather than spliced into the
+        message, so an oversized array can't bloat the stored error.
+        """
+        dcatus3_complete_example["spatial"][0]["centroid"] = {
+            "type": "Point",
+            "coordinates": [-77, 38, 1],
+        }
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.spatial[0].centroid.coordinates, array value does not match "
+            "any of the acceptable formats: max 2 items"
+        )
+
+    def test_assemble_validation_messages_minitems_names_specific_cause(
+        self, dcatus3_complete_example
+    ):
+        """Regression test for GSA/data.gov#6243 (final review round, fix 2):
+        before this fix, `found_simple_message` only whitelisted `maxItems`
+        (plus `required` and, from an earlier round, same-path `type`) as a
+        container validator worth reporting directly -- every other
+        container constraint, including `minItems`, fell through to
+        `return False` and was suppressed, leaving `assemble_validation_
+        errors` to recurse into `.context` and land on the vague branch-type
+        message for `centroid`'s `anyOf` instead of the real cause on
+        `coordinates`. A 1-element `coordinates` array is too short
+        (`minItems: 2`) and must be reported at its own, more specific
+        `json_path` rather than as "$.spatial[0].centroid, object value does
+        not match any of the acceptable formats: 'null', 'string'".
+        """
+        dcatus3_complete_example["spatial"][0]["centroid"] = {
+            "type": "Point",
+            "coordinates": [-77],
+        }
+
+        errors = assemble_validation_errors(
+            DCATUS3_DATASET_VALIDATOR.iter_errors(dcatus3_complete_example)
+        )
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "$.spatial[0].centroid.coordinates, array value does not match "
+            "any of the acceptable formats: min 2 items"
+        )
 
     def test_find_indexes_for_duplicates(self):
         data = [


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/6243

Harvesting counted one dataset-quality defect twice: a schema `ValidationError` and a content warning. The reported example is `@id: "qwer"`, which produced a `format: iri` error and an `invalid_iri` warning.

**Fix:** JSON Schema owns type, format, length, and enum. `dcat_warnings` only runs content checks on values JSON Schema already accepts.

### Removed IRI checks

JSON Schema already requires an IRI on these fields, so the extra warning was a second ticket for the same defect.

- `_is_valid_iri`, `_warn_iri`, `_warn_iris` — deleted. Every DCAT-US 3 `@id` is `{"type": "string", "format": "iri"}`; `relation`, `image`, `isReferencedBy`, and `conformsTo` are schema-enforced IRIs too.
- `detect_dcat_warnings` — no longer walks every object for `@id`. That walk was the source of the `invalid_iri` warning on `"qwer"`.
- `_dataset_warnings`, `_distribution_warnings`, `_dataservice_warnings` — no longer call `_warn_iris` / `_warn_iri` for `relation`, `image`, `isReferencedBy`, or `conformsTo`.

### Content warnings that still run

These methods still flag schema-valid data that looks wrong. Each one now returns no warning for the listed values, because JSON Schema already reports those values as errors.

- `_warn_duplicate_keywords` — still warns when a keyword appears more than once. Empty `""` entries are skipped: `keyword` items have `minLength: 1`, so an empty string is already a schema error.
- `_warn_spatial_resolution` — still warns when a string is not a number greater than zero. Non-string values are skipped: `spatialResolutionInMeters` is `["null", "string"]`.
- `_warn_temporal_resolution` — still warns when a string is not an xsd:duration. Non-string values are skipped: `temporalResolution` is `["null", "string"]`.
- `_warn_byte_size` — still warns when a string does not parse as a number. Non-string values are skipped: `byteSize` is `["null", "string"]`. A list such as `[]` used to reach `is_number()` and raise `TypeError`.
- `_warn_expected_data_type` — still warns when a string does not start with `xsd:`. Non-string values are skipped: `expectedDataType` is a scalar string.
- `_warn_spatial_unresolved` — still warns when a schema-valid `bbox` or `geometry` cannot be resolved to a place. Skipped when the value is not a string or object, when an object is missing `type`/`coordinates`, or when a `bbox` object’s `type` is not `"Polygon"` (already a schema `const` error).
- `_warn_empty_address` — still warns when every Address field is `None` or `""`. Wrongly typed values such as `0` or `[]` are no longer treated as empty: those are already schema type errors.
- `_warn_language` — still warns when a 2-character code is missing or not ISO 639-1. Codes longer than 2 characters are skipped: the schema already enforces `maxLength: 2`.
- `_warn_character_encoding` — still warns when a list entry is not an IANA character set. A bare string is skipped: `characterEncoding` must be `null` or an array of strings.
- `_parse_dcat_date` (used by the `date_out_of_order` warnings) — still compares dates that JSON Schema accepts. Padded strings, missing UTC offsets, and other schema-invalid dates are no longer parsed, so `_warn_created_after` / `_warn_issued_after_modified` cannot emit a second warning for the same defect.

`detect_dcat_warnings` also skips a non-string `@type` instead of looking that value up in `_TYPE_RULES`. A list or dict `@type` is already a schema type error, and used to raise `TypeError: unhashable type`.

### Also found while removing the overlap

`assemble_validation_errors` stored no message for some schema failures (`created: ["2025"]` and similar). The assembler now records one error at the failing field instead of dropping every validator note.

`tests/unit/test_dcat_warning_error_overlap.py` pins the boundary: a warning must not fire on a schema-invalid value, and a schema error must not also produce a warning.

## PR TASKS

- [x] Code well documented
- [x] Tests written, run and passed
- [x] Files linted