### PR TITLE
6254: Bump postcss override to patch GHSA-6g55-p6wh-862q

### DIFF
--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -7130,9 +7130,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -7555,9 +7555,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -7575,7 +7575,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -53,7 +53,7 @@
   },
   "overrides": {
     "@uswds/compile": {
-      "postcss": "8.5.15"
+      "postcss": "8.5.26"
     },
     "picomatch@2.3.1": "2.3.2",
     "shell-quote": "1.10.0"


### PR DESCRIPTION
## Summary
- Fixes Dependabot alerts [#194](https://github.com/GSA/datagov-harvester/security/dependabot/194) (GHSA-fxqj-rqcc-2cmp, incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset, fixed in postcss `8.5.23`) and [#180](https://github.com/GSA/datagov-harvester/security/dependabot/180) (GHSA-r28c-9q8g-f849, an earlier related path-traversal issue, fixed in `8.5.18`) — both on `app/static/package-lock.json`.
- Same root cause as [datagov-catalog#416](https://github.com/GSA/datagov-catalog/pull/416): `@uswds/compile` (latest available release, `1.3.2`) hard-pins `postcss` to an exact vulnerable version across several of its own dependency paths (direct, via `autoprefixer`, `gulp-postcss`, `postcss-csso`, `postcss-load-config`) — there's no newer `@uswds/compile` release to bump to, so Dependabot can't auto-fix it.
- `app/static/package.json` already had an `overrides` block forcing `postcss` within `@uswds/compile`'s dependency tree (from a prior, unrelated CVE fix) — but it was pinned to `8.5.15`, itself still vulnerable. Bumped the pinned version to `8.5.26` (latest 8.5.x, well past both fixes above).
- Regenerated `app/static/package-lock.json` via `npm install`.

## Test plan
- [x] `npm ls postcss` confirms every dependency under `@uswds/compile` now dedupes to `postcss@8.5.26`
- [x] `npm audit` no longer flags postcss
- [x] `npm run build` (Sass + Rollup) completes successfully — only pre-existing, unrelated Sass deprecation warnings

## Note
`vite`'s own separate `postcss` dependency (currently resolving to `8.5.21`, outside this override's scope) isn't part of these alerts and was left untouched.