### PR TITLE
6254: Widen postcss override to cover vite's separate dependency

### DIFF
--- a/app/static/package-lock.json
+++ b/app/static/package-lock.json
@@ -9999,35 +9999,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",

--- a/app/static/package.json
+++ b/app/static/package.json
@@ -52,9 +52,7 @@
     "@rollup/rollup-linux-x64-gnu": "^4.13.2"
   },
   "overrides": {
-    "@uswds/compile": {
-      "postcss": "8.5.26"
-    },
+    "postcss": "8.5.26",
     "picomatch@2.3.1": "2.3.2",
     "shell-quote": "1.10.0"
   }


### PR DESCRIPTION
## Summary
- Fixes [Dependabot alert #194](https://github.com/GSA/datagov-harvester/security/dependabot/194) (GHSA-6g55-p6wh-862q's incomplete fix, patched in postcss `8.5.23`), which remained open on `app/static/package-lock.json` after [#877](https://github.com/GSA/datagov-harvester/pull/877).
- #877 fixed the `@uswds/compile` dependency chain by scoping the existing `overrides` entry to `postcss` under that package only. That left `vite@8.1.5`'s own separate `postcss` dependency (resolving to `8.5.21`, still vulnerable) untouched, which is exactly what this alert is now flagging.
- Widened the override from `{"@uswds/compile": {"postcss": "8.5.26"}}` to a plain top-level `"postcss": "8.5.26"`, forcing every resolution in the tree (including vite's) to the patched version.
- `vite` isn't invoked by any script in this package (`build`/`gulp`/`watch`/`rollup` don't touch it), so this is low-risk — its own build wasn't exercised either way.

## Test plan
- [x] `npm ls postcss` — every entry, including under `vite`, now dedupes to `8.5.26`
- [x] `npm audit` no longer lists postcss (remaining findings are pre-existing and unrelated)
- [x] `npm run build` (Sass + Rollup) completes successfully