### PR TITLE
Fix E501 lint violations in test_load_manager.py

### DIFF
--- a/tests/integration/app/test_load_manager.py
+++ b/tests/integration/app/test_load_manager.py
@@ -81,7 +81,6 @@ class TestLoadManager:
         assert job.status == "in_progress"
 
         # assert schedule_next_job ops
-        # ruff: noqa: E501
         future_job = interface_no_jobs.get_new_harvest_jobs_by_source_in_future(
             job.harvest_source_id
         )[0]
@@ -362,7 +361,10 @@ class TestLoadManager:
                 "guid": task_guid_val,
                 "sequence_id": 197,
                 "name": f"harvest-job-{jobs[0].id}-harvest",
-                "command": "python harvester/harvest.py 47442c62-716d-4678-947c-61990106685f harvest",
+                "command": (
+                    "python harvester/harvest.py "
+                    "47442c62-716d-4678-947c-61990106685f harvest"
+                ),
                 "state": "RUNNING",
                 "memory_in_mb": 1536,
                 "disk_in_mb": 4096,
@@ -412,7 +414,10 @@ class TestLoadManager:
                 "guid": "3a24b55a02b0-eb7b-4eeb-9f45-645cedd3d93b",
                 "sequence_id": 197,
                 "name": f"harvest-job-{jobs[0].id}-harvest",
-                "command": "python harvester/harvest.py 47442c62-716d-4678-947c-61990106685f harvest",
+                "command": (
+                    "python harvester/harvest.py "
+                    "47442c62-716d-4678-947c-61990106685f harvest"
+                ),
                 "state": "CANCELING",
                 "memory_in_mb": 1536,
                 "disk_in_mb": 4096,


### PR DESCRIPTION
## Summary
- Two "command" test-fixture strings in `test_load_manager.py` are 102 chars long; they were only passing lint because of a file-level `# ruff: noqa: E501` directive that has since been dropped elsewhere in this file's history.
- Wraps the two long strings and removes the now-unneeded blanket suppression (they were the only two lines over 88 chars in the file).

Standalone lint cleanup unrelated to any specific issue.

## Test plan
- [x] `ruff check .` passes repo-wide
- [x] `pytest tests/integration/app/test_load_manager.py` passes (18/18)