### PR TITLE
6145: fail deploy on migration failure

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -12,7 +12,7 @@ inputs:
   command:
     description: "cf command to execute"
     required: false
-    default: "cf push datagov-harvest --strategy rolling --no-wait"
+    default: "cf push datagov-harvest --strategy rolling"
   manifest_vars:
     description: "Additional cf manifest --var arguments"
     required: false

--- a/.github/workflows/release-space.yml
+++ b/.github/workflows/release-space.yml
@@ -192,10 +192,7 @@ jobs:
         uses: ./.github/actions/deploy
         with:
           cf_space: ${{ env.CF_SPACE }}
-          command: >-
-            ${{ inputs.migrate_opensearch
-              && 'cf push datagov-harvest --strategy rolling'
-              || 'cf push datagov-harvest --strategy rolling --no-wait' }}
+          command: cf push datagov-harvest --strategy rolling
           cf_username: ${{ secrets.CF_SERVICE_USER }}
           cf_password: ${{ secrets.CF_SERVICE_AUTH }}
 

--- a/app-start.sh
+++ b/app-start.sh
@@ -6,7 +6,10 @@ DIR="$(dirname "${BASH_SOURCE[0]}")"
 # if there is no CF_INSTANCE_INDEX environment variable
 if [ "$CF_INSTANCE_INDEX" = "0" -o -z "$CF_INSTANCE_INDEX" ]; then
     echo Running migrations
-    flask db upgrade 
+    if ! flask db upgrade; then
+        echo "flask db upgrade failed; refusing to start the application." >&2
+        exit 1
+    fi
 fi
 
 exec newrelic-admin run-program gunicorn "wsgi:application" --config "$DIR/gunicorn.conf.py" -b "0.0.0.0:$PORT" --chdir $DIR --timeout 120 --worker-class gthread --workers 3 --forwarded-allow-ips='*'


### PR DESCRIPTION
[#6145
](https://github.com/GSA/data.gov/issues/6145)

## Summary
- `app-start.sh` discarded `flask db upgrade`'s exit code and always `exec`'d gunicorn, so a broken migration crash-looped silently instead of failing container boot.
- Normal deploys (`release-space.yml` / `action.yml`) used `cf push --strategy rolling --no-wait`, so GitHub Actions never observed CF's health-check verdict even when the container did fail.
- Together, these meant a bad migration could reach prod with no failure signal at any layer (container, CF health check, or CI). This caused a silent harvesting outage (the incident behind #6145).

## Changes
- `app-start.sh`: exit non-zero if `flask db upgrade` fails, instead of falling through to start gunicorn anyway.
- `.github/workflows/release-space.yml`, `.github/actions/deploy/action.yml`: drop `--no-wait` from the default `cf push` so the deploy blocks on and observes CF's rolling health-check result (mirrors the existing `migrate_opensearch` branch's behavior).

## Test plan
- [x] Local logic test of `app-start.sh` with stubbed `flask`/`newrelic-admin`: migration failure on instance 0 exits non-zero and never starts gunicorn; migration success on instance 0 starts gunicorn; instance 1 skips migration entirely and always starts.
- [x] Empirical validation against the `development` CF space: push a throwaway failing migration to confirm CF's rolling strategy fails cleanly and the failure propagates through `release-space.yml` → `disable-on-release-failure`. Will update this PR with the run link.

Related: #6145 (this fix), #6147 (schema-drift detection, separate), #6258 (blue/green migration rebuild, separate, larger).