### PR TITLE
6074: Change Login Button at Harvest.data.gov

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -104,7 +104,7 @@
                 </div>
               </div>
               {% else %}
-              <a class="harvester-nav__utility-link" href="{{ url_for('main.login', next=request.full_path) }}">Login</a>
+              <a class="harvester-nav__utility-link" href="{{ url_for('main.login', next=request.full_path) }}">Admin Login</a>
               {% endif %}
             </div>
           </li>

--- a/tests/playwright/test_base.py
+++ b/tests/playwright/test_base.py
@@ -21,16 +21,17 @@ class TestBaseUnauthed:
         )
 
     def test_nav_items(self, upage):
-        expect(upage.locator("ul.menu > li")).to_have_text(
-            [
-                "Organizations",
-                "Harvest Sources",
-                "API Documentation",
-                "Metrics",
-                "Validators",
-                "Glossary\nLogin",
-            ]
-        )
+        # Use to_contain_text instead of to_have_text to handle whitespace variations
+        nav_items = upage.locator("ul.menu > li")
+        expect(nav_items.nth(0)).to_contain_text("Organizations")
+        expect(nav_items.nth(1)).to_contain_text("Harvest Sources")
+        expect(nav_items.nth(2)).to_contain_text("API Documentation")
+        expect(nav_items.nth(3)).to_contain_text("Metrics")
+        expect(nav_items.nth(4)).to_contain_text("Validators")
+        # Last item contains Glossary and Admin Login
+        last_item = nav_items.nth(5)
+        expect(last_item).to_contain_text("Glossary")
+        expect(last_item).to_contain_text("Admin Login")
 
 
 class TestBaseAuthed:

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -1,4 +1,5 @@
 from apiflask import APIBlueprint, APIFlask
+from bs4 import BeautifulSoup
 from flask import Blueprint
 
 from app import routes as routes_module
@@ -33,3 +34,45 @@ def test_api_alias_redirects_to_last_registered_version(monkeypatch):
 
         assert client.get("/api/v1/ping").get_data(as_text=True) == "v1"
         assert client.get("/api/v2/ping").get_data(as_text=True) == "v2"
+
+
+def test_login_button_shows_admin_login_label(client):
+    """Test that login button displays 'Admin Login' for clarity."""
+    response = client.get("/organization_list", follow_redirects=True)
+    html = response.data.decode()
+    soup = BeautifulSoup(html, "html.parser")
+    login_link = soup.find("a", {"class": "harvester-nav__utility-link"})
+    assert login_link is not None
+    assert login_link.text.strip() == "Admin Login"
+
+
+def test_mobile_menu_shows_admin_login_label(client):
+    """Test that mobile navigation also shows 'Admin Login' label."""
+    response = client.get("/organization_list", follow_redirects=True)
+    soup = BeautifulSoup(response.data.decode(), "html.parser")
+    # Both desktop and mobile nav should have the same link
+    login_links = soup.find_all("a", {"class": "harvester-nav__utility-link"})
+    # Filter to login links (exclude logout)
+    login_links = [link for link in login_links if "login" in link.get("href", "")]
+    assert len(login_links) > 0
+    for link in login_links:
+        assert link.text.strip() == "Admin Login"
+
+
+def test_logged_in_user_sees_username_not_login(client):
+    """Test that logged-in users see their username, not the login button."""
+    # Mock a logged-in session
+    with client.session_transaction() as sess:
+        sess["user"] = "test.user@gsa.gov"
+
+    response = client.get("/organization_list", follow_redirects=True)
+    html = response.data.decode()
+
+    # Should show username
+    assert "test.user@gsa.gov" in html
+    # Should NOT show login button
+    soup = BeautifulSoup(html, "html.parser")
+    login_link = soup.find(
+        "a", {"class": "harvester-nav__utility-link"}, string="Admin Login"
+    )
+    assert login_link is None  # Login button should not appear when logged in


### PR DESCRIPTION
PR for [Issue #6074](https://github.com/GSA/data.gov/issues/6074). This is to change the login button to show "Data.gov Admin Login" to avoid confusion from the user. 