### PR TITLE
6255: Index parent_identifier as a top-level OpenSearch field

### DIFF
--- a/search/documents.py
+++ b/search/documents.py
@@ -108,12 +108,17 @@ class DatasetDocument:
 
         popularity = dataset.popularity if dataset.popularity is not None else None
 
+        parent_identifier = getattr(
+            getattr(dataset, "harvest_record", None), "parent_identifier", None
+        )
+
         document = {
             "_index": self.INDEX_NAME,
             "_id": dataset.id,
             "title": index_fields["title"],
             "slug": dataset.slug,
             "type": dataset.type,
+            "parent_identifier": parent_identifier,
             "last_harvested_date": last_harvested,
             "description": index_fields["description"],
             "publisher": index_fields["publisher"],

--- a/search/mappings.py
+++ b/search/mappings.py
@@ -9,6 +9,7 @@ MAPPINGS = {
         },
         "slug": {"type": "keyword"},
         "type": {"type": "keyword"},
+        "parent_identifier": {"type": "keyword"},
         "last_harvested_date": {"type": "date"},
         "dcat": {
             "type": "nested",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1695,7 +1695,9 @@ def sample_dataset():
         organization=DummyOrg(),
         popularity=7,
         harvest_record_id="hr-1",
-        harvest_record=SimpleNamespace(source_transform={"title": "Transformed"}),
+        harvest_record=SimpleNamespace(
+            source_transform={"title": "Transformed"}, parent_identifier="parent-1"
+        ),
     )
 
 

--- a/tests/integration/search/test_client.py
+++ b/tests/integration/search/test_client.py
@@ -28,6 +28,7 @@ def test_mappings_include_catalog_compatible_fields():
     normalizer = client.SETTINGS["analysis"]["normalizer"][client.KEYWORD_NORMALIZER]
 
     assert mappings["dcat"]["properties"]["isPartOf"] == {"type": "keyword"}
+    assert mappings["parent_identifier"] == {"type": "keyword"}
     assert mappings["theme"] == {
         "type": "text",
         "analyzer": client.TEXT_ANALYZER,

--- a/tests/integration/search/test_documents.py
+++ b/tests/integration/search/test_documents.py
@@ -98,6 +98,7 @@ def test_dataset_to_document(sample_dataset, monkeypatch):
     assert document["title"] == "Dataset Title"
     assert document["publisher"] == "Publisher"
     assert document["dcat"]["isPartOf"] == "collection-1"
+    assert document["parent_identifier"] == "parent-1"
     assert document["distribution_titles"] == ["CSV download", "API endpoint"]
     assert document["has_spatial"] is True
     assert document["has_download"] is False
@@ -122,6 +123,17 @@ def test_dataset_to_document_handles_missing_date_and_organization(sample_datase
 
     assert document["last_harvested_date"] is None
     assert document["organization"] == {}
+
+
+def test_dataset_to_document_parent_identifier_missing_harvest_record(
+    sample_dataset,
+):
+    sample_dataset.harvest_record = None
+
+    dataset_doc = DatasetDocument(sample_dataset)
+    document = dataset_doc.dataset_to_document()
+
+    assert document["parent_identifier"] is None
 
 
 def test_dataset_to_document_uses_configured_catalog_base_url(


### PR DESCRIPTION
## Summary
- Add a top-level `parent_identifier` keyword field to the OpenSearch mapping, sourced from `HarvestRecord.parent_identifier` (already populated for ISO WAF collections, DCAT-US 1.1 explicit parents, and DCAT-US 3.0 DataService/DatasetSeries members).
- Purely additive: `dcat.isPartOf` is untouched, existing queries keep working.

## Dependency
`datagov-catalog` PR #423 switches its `collection` filter to this new field — that PR requires this one to merge and the index to be rebuilt first (`flask search rebuild-index`), otherwise the filter has nothing to match on.

Part of GSA/data.gov#6255

## Test plan
- [x] `make test-unit` / `make test-integration` equivalent (`poetry run pytest tests/unit/search tests/unit/test_opensearch_transform.py tests/integration/search`, 155 passed)
- [x] `make lint-check` (clean on changed files; pre-existing unrelated node_modules isort noise)