### PR TITLE
Queue deploys, drop watermark reconstruction from OpenSearch migration detection

### DIFF
--- a/.github/scripts/detect-opensearch-migration-label.sh
+++ b/.github/scripts/detect-opensearch-migration-label.sh
@@ -4,11 +4,8 @@ set -euo pipefail
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
 
-head_sha=${1:?Usage: detect-opensearch-migration-label.sh <head_sha> <workflow_file> <branch> [label]}
-workflow_file=${2:?Usage: detect-opensearch-migration-label.sh <head_sha> <workflow_file> <branch> [label]}
-branch=${3:?Usage: detect-opensearch-migration-label.sh <head_sha> <workflow_file> <branch> [label]}
-label=${4:-force re-index recommended}
-fallback_workflow_file=${FALLBACK_WORKFLOW_FILE:-}
+head_sha=${1:?Usage: detect-opensearch-migration-label.sh <head_sha> [label]}
+label=${2:-force re-index recommended}
 gh_api_max_attempts=${GH_API_MAX_ATTEMPTS:-3}
 gh_api_retry_seconds=${GH_API_RETRY_SECONDS:-2}
 
@@ -20,12 +17,11 @@ emit() {
 }
 
 pull_requests_with_label() {
-  local sha=$1
   local attempt matched
 
   for ((attempt = 1; attempt <= gh_api_max_attempts; attempt++)); do
     if matched=$(
-      gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls" \
+      gh api "repos/${GITHUB_REPOSITORY}/commits/${head_sha}/pulls" \
         --jq ".[] | select(.labels[]?.name == \"${label}\") | .number"
     ); then
       printf '%s' "$matched"
@@ -33,112 +29,25 @@ pull_requests_with_label() {
     fi
 
     if [[ "$attempt" -eq "$gh_api_max_attempts" ]]; then
-      echo "Failed to inspect pull requests for commit ${sha} after ${attempt} attempts." >&2
+      echo "Failed to inspect pull requests for commit ${head_sha} after ${attempt} attempts." >&2
       return 1
     fi
-    echo "Unable to inspect pull requests for commit ${sha}; retrying (${attempt}/${gh_api_max_attempts})." >&2
+    echo "Unable to inspect pull requests for commit ${head_sha}; retrying (${attempt}/${gh_api_max_attempts})." >&2
     sleep "$gh_api_retry_seconds"
   done
 }
 
-workflow_candidates() {
-  local candidate_workflow exclude_head jq_filter
-  candidate_workflow="$1"
-  exclude_head=${2:-false}
-  jq_filter='.workflow_runs[].head_sha // empty'
-
-  if [[ "$exclude_head" == "true" ]]; then
-    jq_filter=".workflow_runs[] | select(.head_sha != \"${head_sha}\") | .head_sha"
-  fi
-
-  gh api -X GET \
-    "repos/${GITHUB_REPOSITORY}/actions/workflows/${candidate_workflow}/runs" \
-    -f "branch=${branch}" -f status=success -f per_page=10 \
-    --jq "$jq_filter"
-}
-
-base_sha=""
-compare=""
-rejected_status=""
-
-# Candidates arrive newest first, but a force-push orphans the runs it rewrote.
-# Keep walking until one is still an ancestor of HEAD.
-select_watermark() {
-  local candidates candidate candidate_compare status
-  candidates="$1"
-
-  while read -r candidate; do
-    [[ -z "$candidate" ]] && continue
-    candidate_compare=$(gh api "repos/${GITHUB_REPOSITORY}/compare/${candidate}...${head_sha}")
-    status=$(jq -r '.status' <<<"$candidate_compare")
-    if [[ "$status" == "ahead" || "$status" == "identical" ]]; then
-      base_sha="$candidate"
-      compare="$candidate_compare"
-      return 0
-    fi
-    rejected_status="$status"
-    echo "Skipping watermark ${candidate}: compare status is '${status}'." >&2
-  done <<<"$candidates"
-
-  return 1
-}
-
-primary_candidates=$(workflow_candidates "$workflow_file")
-
-if [[ -n "$primary_candidates" ]]; then
-  if ! select_watermark "$primary_candidates"; then
-    echo "No ${workflow_file} run on ${branch} is an ancestor of ${head_sha}: compare status is '${rejected_status}'." >&2
-    exit 1
-  fi
-elif [[ -n "$fallback_workflow_file" ]]; then
-  echo "No successful ${workflow_file} run; using ${fallback_workflow_file} to bootstrap the watermark."
-  fallback_candidates=$(workflow_candidates "$fallback_workflow_file" true)
-  if ! select_watermark "$fallback_candidates"; then
-    # Nothing released on this lineage yet, so there is no range to diff. Treat
-    # it as a clean bootstrap instead of wedging every future push.
-    echo "No ${fallback_workflow_file} run on ${branch} is an ancestor of ${head_sha}; bootstrapping without a diff."
-    emit "base_sha=${head_sha}"
-    emit "migration_needed=false"
-    emit "pr_numbers="
-    exit 0
-  fi
-else
-  echo "No successful release run on ${branch} is available as a watermark." >&2
+if ! matches=$(pull_requests_with_label); then
   exit 1
 fi
 
-total_commits=$(jq -r '.total_commits' <<<"$compare")
-listed_commits=$(jq -r '.commits | length' <<<"$compare")
-
-if [[ "$total_commits" -gt "$listed_commits" ]]; then
-  echo "The compare response is truncated (${listed_commits}/${total_commits} commits)." >&2
-  exit 1
-fi
-
-matches=""
-while read -r sha; do
-  [[ -z "$sha" ]] && continue
-  if ! matched=$(pull_requests_with_label "$sha"); then
-    exit 1
-  fi
-  if [[ -n "$matched" ]]; then
-    matches+="${matched}"$'\n'
-  fi
-done < <(jq -r '.commits[].sha' <<<"$compare")
-
-emit "base_sha=${base_sha}"
 if [[ -n "$matches" ]]; then
-  pr_numbers=$(
-    printf '%s' "$matches" |
-      sed '/^$/d' |
-      sort -un |
-      paste -sd, -
-  )
+  pr_numbers=$(printf '%s' "$matches" | sort -un | paste -sd, -)
   emit "migration_needed=true"
   emit "pr_numbers=${pr_numbers}"
   echo "OpenSearch migration required by PR(s): ${pr_numbers}."
 else
   emit "migration_needed=false"
   emit "pr_numbers="
-  echo "No OpenSearch migration label found."
+  echo "No OpenSearch migration label found on ${head_sha}."
 fi

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -11,19 +11,15 @@ permissions:
 concurrency:
   group: release-develop
   cancel-in-progress: false
+  queue: max
 
 jobs:
   detect-opensearch-migration:
     name: Detect OpenSearch migration
     permissions:
-      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/detect-opensearch-migration.yml
-    with:
-      workflow_file: deploy-development.yml
-      fallback_workflow_file: commit.yml
-      branch: develop
 
   release-development:
     name: Release development

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,18 +11,15 @@ permissions:
 concurrency:
   group: release-main
   cancel-in-progress: false
+  queue: max
 
 jobs:
   detect-opensearch-migration:
     name: Detect OpenSearch migration
     permissions:
-      actions: read
       contents: read
       pull-requests: read
     uses: ./.github/workflows/detect-opensearch-migration.yml
-    with:
-      workflow_file: deploy.yml
-      branch: main
 
   release-staging:
     name: Release staging

--- a/.github/workflows/detect-opensearch-migration.yml
+++ b/.github/workflows/detect-opensearch-migration.yml
@@ -2,30 +2,13 @@ name: Detect OpenSearch migration
 
 on:
   workflow_call:
-    inputs:
-      workflow_file:
-        description: "Top-level workflow file whose last success is the watermark"
-        required: true
-        type: string
-      branch:
-        description: "Branch deployed by the calling workflow"
-        required: true
-        type: string
-      fallback_workflow_file:
-        description: "Previous release workflow used only when the primary has no history"
-        required: false
-        default: ""
-        type: string
     outputs:
       migration_needed:
-        description: "Whether a merged PR since the watermark requires migration"
+        description: "Whether the triggering commit's PR carries the migration label"
         value: ${{ jobs.detect.outputs.migration_needed }}
       pr_numbers:
         description: "Comma-separated PR numbers carrying the migration label"
         value: ${{ jobs.detect.outputs.pr_numbers }}
-      base_sha:
-        description: "Last successfully released commit"
-        value: ${{ jobs.detect.outputs.base_sha }}
 
 permissions:
   contents: read
@@ -34,13 +17,11 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     permissions:
-      actions: read
       contents: read
       pull-requests: read
     outputs:
       migration_needed: ${{ steps.detect.outputs.migration_needed }}
       pr_numbers: ${{ steps.detect.outputs.pr_numbers }}
-      base_sha: ${{ steps.detect.outputs.base_sha }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v7
@@ -50,23 +31,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          FALLBACK_WORKFLOW_FILE: ${{ inputs.fallback_workflow_file }}
-        run: >-
-          .github/scripts/detect-opensearch-migration-label.sh
-          "$GITHUB_SHA"
-          "${{ inputs.workflow_file }}"
-          "${{ inputs.branch }}"
+        run: .github/scripts/detect-opensearch-migration-label.sh "$GITHUB_SHA"
 
       - name: Summarize result
         env:
           MIGRATION_NEEDED: ${{ steps.detect.outputs.migration_needed }}
           PR_NUMBERS: ${{ steps.detect.outputs.pr_numbers }}
-          BASE_SHA: ${{ steps.detect.outputs.base_sha }}
         run: |
           {
             echo "### OpenSearch migration detection"
             echo
-            echo "- Last successful release: \`${BASE_SHA}\`"
+            echo "- Commit: \`${GITHUB_SHA}\`"
             echo "- Migration required: \`${MIGRATION_NEEDED}\`"
             echo "- Labeled PRs: \`${PR_NUMBERS:-none}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ops/opensearch-zero-downtime-deployment.md
+++ b/docs/ops/opensearch-zero-downtime-deployment.md
@@ -4,9 +4,10 @@ Pull requests carrying the `force re-index recommended` label use a replacement
 OpenSearch cluster when they are merged. This runs in development for merges to
 `develop`, then in staging and production for merges to `main`.
 
-The label detector scans from the last successful release rather than inspecting
-only the current push. This preserves the migration request when GitHub replaces a
-pending release with a newer merge.
+The label detector checks only the commit that triggered the current release run.
+`deploy.yml` and `deploy-development.yml` use `queue: max`, so GitHub queues every
+push behind the one in progress instead of replacing a pending run with a newer
+merge — each merge still gets its own dedicated run and its own label check.
 
 ## Release sequence
 

--- a/tests/scripts/test_detect_opensearch_migration_label.py
+++ b/tests/scripts/test_detect_opensearch_migration_label.py
@@ -1,4 +1,3 @@
-import json
 import os
 import subprocess
 from pathlib import Path
@@ -10,9 +9,7 @@ SCRIPT = (
     / "detect-opensearch-migration-label.sh"
 )
 
-BASE = "1111111111111111111111111111111111111111"
 HEAD = "9999999999999999999999999999999999999999"
-ORPHAN = "2222222222222222222222222222222222222222"
 
 
 def _write_executable(path, contents):
@@ -20,22 +17,12 @@ def _write_executable(path, contents):
     path.chmod(0o755)
 
 
-def _shas(value):
-    return value if isinstance(value, str) else " ".join(value)
-
-
 def _run(
     tmp_path,
     *,
-    commits=("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",),
-    labeled_shas=(),
-    base_sha=BASE,
-    fallback_base_sha="",
-    fallback_workflow_file="",
-    status="ahead",
-    total_commits=None,
-    compare_statuses=None,
+    labeled=False,
     pull_api_failures=0,
+    head_sha=HEAD,
 ):
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -43,45 +30,12 @@ def _run(
     output_file = tmp_path / "outputs"
     pull_attempts_file = tmp_path / "pull-attempts"
     pull_attempts_file.write_text("0")
-    compare_dir = tmp_path / "compare"
-    compare_dir.mkdir()
-
-    def _compare(compare_status):
-        return json.dumps(
-            {
-                "status": compare_status,
-                "total_commits": (
-                    len(commits) if total_commits is None else total_commits
-                ),
-                "commits": [{"sha": sha} for sha in commits],
-            }
-        )
-
-    (compare_dir / "default.json").write_text(_compare(status))
-    for sha, sha_status in (compare_statuses or {}).items():
-        (compare_dir / f"{sha}.json").write_text(_compare(sha_status))
 
     _write_executable(
         fake_bin / "gh",
         """#!/bin/bash
 echo "$*" >> "$GH_CALLS_FILE"
-if [[ "$*" == *"/actions/workflows/"* ]]; then
-  if [[ -n "$GH_FALLBACK_WORKFLOW_FILE" ]] &&
-    [[ "$*" == *"/${GH_FALLBACK_WORKFLOW_FILE}/"* ]]; then
-    printf '%s\\n' $GH_FALLBACK_BASE_SHA
-  else
-    printf '%s\\n' $GH_BASE_SHA
-  fi
-elif [[ "$*" == *"/compare/"* ]]; then
-  args="$*"
-  ref=${args##*/compare/}
-  base=${ref%%...*}
-  if [[ -f "$GH_COMPARE_DIR/${base}.json" ]]; then
-    cat "$GH_COMPARE_DIR/${base}.json"
-  else
-    cat "$GH_COMPARE_DIR/default.json"
-  fi
-elif [[ "$*" == *"/commits/"*"/pulls"* ]]; then
+if [[ "$*" == *"/commits/"*"/pulls"* ]]; then
   attempts=$(cat "$GH_PULL_ATTEMPTS_FILE")
   attempts=$((attempts + 1))
   echo "$attempts" > "$GH_PULL_ATTEMPTS_FILE"
@@ -89,11 +43,9 @@ elif [[ "$*" == *"/commits/"*"/pulls"* ]]; then
     echo "Simulated pull request API failure" >&2
     exit 1
   fi
-  for sha in $GH_LABELED_SHAS; do
-    if [[ "$*" == *"/commits/${sha}/pulls"* ]]; then
-      echo 42
-    fi
-  done
+  if [[ "$GH_LABELED" == "true" ]]; then
+    echo 42
+  fi
 else
   echo "Unexpected gh call: $*" >&2
   exit 1
@@ -102,7 +54,7 @@ fi
     )
 
     result = subprocess.run(
-        [str(SCRIPT), HEAD, "deploy.yml", "main"],
+        [str(SCRIPT), head_sha],
         capture_output=True,
         env={
             **os.environ,
@@ -110,16 +62,11 @@ fi
             "GITHUB_REPOSITORY": "GSA/datagov-harvester",
             "GITHUB_OUTPUT": str(output_file),
             "GH_CALLS_FILE": str(calls_file),
-            "GH_BASE_SHA": _shas(base_sha),
-            "GH_FALLBACK_BASE_SHA": _shas(fallback_base_sha),
-            "GH_FALLBACK_WORKFLOW_FILE": fallback_workflow_file,
-            "GH_COMPARE_DIR": str(compare_dir),
-            "GH_LABELED_SHAS": " ".join(labeled_shas),
+            "GH_LABELED": "true" if labeled else "false",
             "GH_PULL_API_FAILURES": str(pull_api_failures),
             "GH_PULL_ATTEMPTS_FILE": str(pull_attempts_file),
             "GH_API_MAX_ATTEMPTS": "3",
             "GH_API_RETRY_SECONDS": "0",
-            "FALLBACK_WORKFLOW_FILE": fallback_workflow_file,
         },
         text=True,
         timeout=10,
@@ -129,163 +76,36 @@ fi
     return result, outputs, calls
 
 
-def test_detects_a_labeled_pr_since_the_last_success(tmp_path):
-    sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    result, outputs, _ = _run(tmp_path, commits=(sha,), labeled_shas=(sha,))
+def test_detects_the_label_on_the_triggering_commit(tmp_path):
+    result, outputs, calls = _run(tmp_path, labeled=True)
 
     assert result.returncode == 0, result.stderr
     assert "migration_needed=true" in outputs
     assert "pr_numbers=42" in outputs
-    assert f"base_sha={BASE}" in outputs
+    assert f"/commits/{HEAD}/pulls" in calls
 
 
-def test_reports_no_migration_for_unlabeled_commits(tmp_path):
-    result, outputs, _ = _run(tmp_path)
+def test_reports_no_migration_when_unlabeled(tmp_path):
+    result, outputs, _ = _run(tmp_path, labeled=False)
 
     assert result.returncode == 0, result.stderr
     assert "migration_needed=false" in outputs
     assert "pr_numbers=" in outputs
-
-
-def test_uses_the_last_successful_run_as_the_watermark(tmp_path):
-    result, _, calls = _run(tmp_path)
-
-    assert result.returncode == 0
-    watermark_call = next(
-        line for line in calls.splitlines() if "/actions/workflows/" in line
-    )
-    assert "-X GET" in watermark_call
-    assert "branch=main" in watermark_call
-    assert "status=success" in watermark_call
-
-
-def test_fails_without_a_successful_release_watermark(tmp_path):
-    result, outputs, _ = _run(tmp_path, base_sha="")
-
-    assert result.returncode == 1
-    assert "No successful" in result.stderr
-    assert outputs == ""
-
-
-def test_bootstraps_from_a_previous_release_workflow(tmp_path):
-    result, outputs, calls = _run(
-        tmp_path,
-        base_sha="",
-        fallback_base_sha=BASE,
-        fallback_workflow_file="commit.yml",
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert f"base_sha={BASE}" in outputs
-    assert "/actions/workflows/deploy.yml/runs" in calls
-    assert "/actions/workflows/commit.yml/runs" in calls
-    fallback_call = next(
-        line
-        for line in calls.splitlines()
-        if "/actions/workflows/commit.yml/runs" in line
-    )
-    assert f'select(.head_sha != "{HEAD}")' in fallback_call
-
-
-def test_fails_when_the_compare_response_is_truncated(tmp_path):
-    result, outputs, _ = _run(tmp_path, total_commits=251)
-
-    assert result.returncode == 1
-    assert "truncated" in result.stderr
-    assert outputs == ""
-
-
-def test_fails_when_history_is_not_ahead_or_identical(tmp_path):
-    result, outputs, _ = _run(tmp_path, status="diverged")
-
-    assert result.returncode == 1
-    assert "compare status is 'diverged'" in result.stderr
-    assert outputs == ""
-
-
-def test_walks_past_a_watermark_orphaned_by_a_force_push(tmp_path):
-    result, outputs, _ = _run(
-        tmp_path,
-        base_sha=(ORPHAN, BASE),
-        compare_statuses={ORPHAN: "diverged", BASE: "ahead"},
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert f"base_sha={BASE}" in outputs
-    assert f"Skipping watermark {ORPHAN}" in result.stderr
-
-
-def test_bootstrap_tolerates_a_rewritten_fallback_history(tmp_path):
-    result, outputs, _ = _run(
-        tmp_path,
-        base_sha="",
-        fallback_base_sha=ORPHAN,
-        fallback_workflow_file="commit.yml",
-        compare_statuses={ORPHAN: "diverged"},
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert f"base_sha={HEAD}" in outputs
-    assert "migration_needed=false" in outputs
-    assert "pr_numbers=" in outputs
-    assert "bootstrapping without a diff" in result.stdout
-
-
-def test_bootstrap_tolerates_an_empty_fallback_history(tmp_path):
-    result, outputs, _ = _run(
-        tmp_path,
-        base_sha="",
-        fallback_base_sha="",
-        fallback_workflow_file="commit.yml",
-    )
-
-    assert result.returncode == 0, result.stderr
-    assert f"base_sha={HEAD}" in outputs
-    assert "migration_needed=false" in outputs
-
-
-def test_identical_commit_is_a_valid_unlabeled_rerun(tmp_path):
-    result, outputs, _ = _run(tmp_path, commits=(), status="identical", total_commits=0)
-
-    assert result.returncode == 0
-    assert "migration_needed=false" in outputs
-
-
-def test_deduplicates_a_pr_associated_with_multiple_commits(tmp_path):
-    commits = (
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    )
-    result, outputs, _ = _run(tmp_path, commits=commits, labeled_shas=commits)
-
-    assert result.returncode == 0
-    assert outputs.count("pr_numbers=42") == 1
 
 
 def test_retries_a_transient_pull_request_api_failure(tmp_path):
-    sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    result, outputs, calls = _run(
-        tmp_path,
-        commits=(sha,),
-        labeled_shas=(sha,),
-        pull_api_failures=1,
-    )
+    result, outputs, calls = _run(tmp_path, labeled=True, pull_api_failures=1)
 
     assert result.returncode == 0, result.stderr
     assert "migration_needed=true" in outputs
-    assert calls.count(f"/commits/{sha}/pulls") == 2
+    assert calls.count(f"/commits/{HEAD}/pulls") == 2
     assert "retrying (1/3)" in result.stderr
 
 
 def test_fails_closed_after_repeated_pull_request_api_failures(tmp_path):
-    sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    result, outputs, calls = _run(
-        tmp_path,
-        commits=(sha,),
-        pull_api_failures=3,
-    )
+    result, outputs, calls = _run(tmp_path, pull_api_failures=3)
 
     assert result.returncode == 1
     assert outputs == ""
-    assert calls.count(f"/commits/{sha}/pulls") == 3
-    assert f"commit {sha} after 3 attempts" in result.stderr
+    assert calls.count(f"/commits/{HEAD}/pulls") == 3
+    assert f"commit {HEAD} after 3 attempts" in result.stderr


### PR DESCRIPTION
**Before:** the OpenSearch migration label detector reconstructed "the last successful release" by querying GitHub Actions run history, then rescanned every commit since that watermark for a `force re-index recommended` label. It needed to do this because GitHub's default `concurrency` behavior cancels a *pending* run outright the moment a newer push queues behind it — so a labeled PR's dedicated run could vanish before it ever executed if another merge landed first, and the watermark walk was the only way to recover a label from a run that never ran. That reconstruction carried its own hand-rolled workarounds (a force-push walk, a compare-truncation guard) and was exactly the kind of guessed-history logic that has already caused a false-positive rebuild once.

**After:** `deploy.yml` and `deploy-development.yml` add `queue: max` to their `concurrency` blocks, so every push queues behind the one in progress instead of replacing it — nothing gets cancelled, and every merge gets its own dedicated run. With no runs ever dropped, the detector no longer needs history: it just checks whether the commit that triggered *this* run has an associated PR carrying the label. Deletes the watermark walk, the run-history query, the force-push handling, and the compare-truncation guard, along with the tests that covered them.

## Testing

`tests/scripts/test_detect_opensearch_migration_label.py` rewritten for the single-commit check (label found, no label, transient API retry, fails closed after repeated failures). Full `tests/scripts` suite (63 tests) passes; ruff/black/isort clean.

Note: `actionlint` (Homebrew, v1.7.12) doesn't yet recognize the `queue` concurrency key — confirmed as a known upstream gap ([rhysd/actionlint#657](https://github.com/rhysd/actionlint/issues/657)), not an error in this YAML. It isn't wired into any CI workflow in this repo.

Not exercised against a live queue-of-merges scenario — worth confirming on `develop` first that a normal single-commit push still detects/skips migration correctly.