### PR TITLE
5455: add alembic migration tests

### DIFF
--- a/migrations/versions/cf577d46fccd_new_initial_base_migration.py
+++ b/migrations/versions/cf577d46fccd_new_initial_base_migration.py
@@ -266,3 +266,14 @@ def downgrade():
 
     op.drop_table("harvest_user")
     # ### end Alembic commands ###
+
+    # drop_table doesn't drop the postgres ENUM types the columns depended on,
+    # so a re-upgrade after this downgrade fails with "type already exists"
+    bind = op.get_bind()
+    sa.Enum(name="record_status").drop(bind, checkfirst=True)
+    sa.Enum(name="record_action").drop(bind, checkfirst=True)
+    sa.Enum(name="job_status").drop(bind, checkfirst=True)
+    sa.Enum(name="notification_frequency").drop(bind, checkfirst=True)
+    sa.Enum(name="source_type").drop(bind, checkfirst=True)
+    sa.Enum(name="schema_type").drop(bind, checkfirst=True)
+    sa.Enum(name="frequency").drop(bind, checkfirst=True)

--- a/tests/integration/database/test_migrations.py
+++ b/tests/integration/database/test_migrations.py
@@ -1,0 +1,43 @@
+import pytest
+from alembic.script import ScriptDirectory
+from flask import current_app
+from flask_migrate import downgrade, upgrade
+
+from database.models import db
+
+
+@pytest.fixture(autouse=True)
+def dbapp(app):
+    """Override the root conftest's dbapp fixture.
+
+    Migrations manage their own schema from an empty database, so this
+    drops all ORM-created tables instead of also recreating them.
+    """
+    with app.app_context():
+        db.drop_all()
+    yield
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+
+def _ordered_revisions(app):
+    with app.app_context():
+        config = current_app.extensions["migrate"].migrate.get_config()
+        script = ScriptDirectory.from_config(config)
+        revisions = list(script.walk_revisions("base", "heads"))
+        revisions.reverse()
+        return revisions
+
+
+def test_migrations_upgrade_and_downgrade_cleanly(app):
+    revisions = _ordered_revisions(app)
+    assert len(revisions) > 0
+
+    with app.app_context():
+        for revision in revisions:
+            upgrade(revision=revision.revision)
+
+            down = revision.down_revision or "base"
+            downgrade(revision=down)
+            upgrade(revision=revision.revision)

--- a/tests/integration/database/test_migrations.py
+++ b/tests/integration/database/test_migrations.py
@@ -30,7 +30,13 @@ def _ordered_revisions(app):
         return revisions
 
 
-def test_migrations_upgrade_and_downgrade_cleanly(app):
+def test_migrations_upgrade_and_downgrade_cleanly(app, monkeypatch):
+    # migrations/env.py calls logging.config.fileConfig() on every upgrade/downgrade,
+    # which (with its default disable_existing_loggers=True) permanently disables any
+    # logger not listed in alembic.ini's [loggers] section, e.g. "harvest_admin" -
+    # breaking later tests that assert on caplog for those loggers.
+    monkeypatch.setattr("logging.config.fileConfig", lambda *args, **kwargs: None)
+
     revisions = _ordered_revisions(app)
     assert len(revisions) > 0
 


### PR DESCRIPTION
## Summary
- Add a test that walks every Alembic revision (base -> head) and verifies upgrade -> downgrade -> upgrade succeeds for each one, using a real Postgres instead of the ORM's `create_all()`.
- Fix a bug the new test caught: the initial migration's `downgrade()` dropped tables but never dropped the Postgres ENUM types those columns depended on, so downgrading and re-upgrading failed with "type already exists".

## Test plan
- [x] `make test-integration` passes locally, including the new migration test alongside the rest of the suite (no fixture leakage into other tests)
- [x] Confirmed the fix is needed: reverted it locally and watched the new test fail with `DuplicateObject: type "frequency" already exists`
- [x] Runs automatically on every push via the existing `test-ci` -> `test-integration` step, no new CI wiring required

Follow-up (not in scope here): a reviewer on GSA/data.gov#5455 suggested moving `flask db upgrade` out of `app-start.sh` (which has a startup timeout) into its own release step.