### PR TITLE
6255: Fix WAF collection root incorrectly tagged as its own parent

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -584,7 +584,10 @@ class HarvestSource:
                 elif self.source_type == "waf-collection":
                     record["content"] = download_file(record["identifier"], ".xml")
                     dataset = record["content"]
-                    parent_identifier = self.collection_parent_url
+                    # The collection root itself has no parent; only tag its
+                    # children with the collection's parent identifier.
+                    if record["identifier"] != self.collection_parent_url:
+                        parent_identifier = self.collection_parent_url
 
                 elif self.source_type == "document":
                     if self.schema_type.startswith("dcatus"):

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -600,18 +600,18 @@ class TestHarvestJobFullFlow:
         assert len(harvest_job.record_errors) == 4
         assert harvest_job.records_errored == 4
 
+        collection_parent_url = source_data_waf_collection["collection_parent_url"]
         for record in harvest_job.records:
             if record.status == "success":
-                assert (
-                    record.parent_identifier
-                    == source_data_waf_collection["collection_parent_url"]
-                )
+                if record.identifier == collection_parent_url:
+                    # the collection root itself has no parent
+                    assert record.parent_identifier is None
+                    continue
+
+                assert record.parent_identifier == collection_parent_url
 
                 # make sure the parent url is in the transformed dcat data in the dataset
-                assert (
-                    record.dataset.dcat["isPartOf"]
-                    == source_data_waf_collection["collection_parent_url"]
-                )
+                assert record.dataset.dcat["isPartOf"] == collection_parent_url
         # call on error
         assert send_notification_emails_mock.called
 


### PR DESCRIPTION
## Summary
- The WAF collection root record was unconditionally tagged with `parent_identifier = collection_parent_url`, pointing at itself instead of having no parent.
- This broke the catalog's "am I a collection root with children" detection (`dataset_detail_by_slug_or_id` in datagov-catalog), since it relies on the root record having a null `parent_identifier`.

Part of GSA/data.gov#6255

## Test plan
- [x] Updated `test_harvest_waf_collection` to assert the root record has `parent_identifier is None` and only its children get tagged with `collection_parent_url`
- [x] `poetry run pytest tests/integration/harvest_job_flows/test_harvest_job_full_flow.py -k test_harvest_waf_collection`