### PR TITLE
6255: Read DCAT-US 1.1 isPartOf field into parent_identifier

### DIFF
--- a/example_data/dcatus/dcatus1_1_ispartof.json
+++ b/example_data/dcatus/dcatus1_1_ispartof.json
@@ -1,0 +1,54 @@
+{
+  "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
+  "@id": "https://example.gov/data.json",
+  "@type": "dcat:Catalog",
+  "conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
+  "describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
+  "dataset": [
+    {
+      "accessLevel": "public",
+      "bureauCode": ["000:00"],
+      "contactPoint": {
+        "fn": "Test Contact",
+        "hasEmail": "mailto:collection@example.gov"
+      },
+      "description": "The collection of annual report datasets.",
+      "distribution": [
+        {
+          "accessURL": "https://example.gov/collections/annual-report"
+        }
+      ],
+      "identifier": "https://example.gov/collections/annual-report",
+      "keyword": ["annual report"],
+      "modified": "R/P1Y",
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Test Agency"
+      },
+      "title": "Annual Report Collection"
+    },
+    {
+      "accessLevel": "public",
+      "bureauCode": ["000:00"],
+      "contactPoint": {
+        "fn": "Test Contact",
+        "hasEmail": "mailto:collection@example.gov"
+      },
+      "description": "The 2024 annual report dataset, part of the annual report collection.",
+      "distribution": [
+        {
+          "accessURL": "https://example.gov/datasets/annual-report-2024"
+        }
+      ],
+      "identifier": "https://example.gov/datasets/annual-report-2024",
+      "isPartOf": "https://example.gov/collections/annual-report",
+      "keyword": ["annual report"],
+      "modified": "2024-01-01",
+      "programCode": ["000:000"],
+      "publisher": {
+        "name": "Test Agency"
+      },
+      "title": "Annual Report 2024"
+    }
+  ]
+}

--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -588,7 +588,13 @@ class HarvestSource:
 
                 elif self.source_type == "document":
                     if self.schema_type.startswith("dcatus"):
-                        parent_identifier = record.pop("parent_identifier", None)
+                        # "parent_identifier" is only present for dcatus3.0
+                        # records nested under a DatasetSeries/DataService.
+                        # DCAT-US 1.1 records instead declare their parent
+                        # directly via "isPartOf".
+                        parent_identifier = record.pop(
+                            "parent_identifier", None
+                        ) or normalize_dataset_identifier(record.get("isPartOf"))
                         dataset = json.dumps(sort_dataset(record))
                     elif self.schema_type.startswith("iso19115"):
                         # single document ISO

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,6 +394,21 @@ def source_data_dcatus3_0_series_member_also_top_level(organization_data: dict) 
 
 
 @pytest.fixture
+def source_data_dcatus1_1_ispartof(organization_data: dict) -> dict:
+    return {
+        "id": "f0b1c3d5-7890-4bcd-ef01-234567890198",
+        "name": "Test Source DCAT-US 1.1 (isPartOf)",
+        "notification_emails": ["email@example.com"],
+        "organization_id": organization_data["id"],
+        "frequency": "daily",
+        "url": f"{HARVEST_SOURCE_URL}/dcatus/dcatus1_1_ispartof.json",
+        "schema_type": "dcatus1.1: federal",
+        "source_type": "document",
+        "notification_frequency": "always",
+    }
+
+
+@pytest.fixture
 def source_data_dcatus_same_title(organization_data: dict) -> dict:
     return {
         "id": "50301cdb-5766-46ed-8f46-ca63844315a2",

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -394,8 +394,7 @@ class TestHarvestJobFullFlow:
         records = (
             interface.db.query(HarvestRecord)
             .filter(
-                HarvestRecord.harvest_source_id
-                == source_data_dcatus1_1_ispartof["id"]
+                HarvestRecord.harvest_source_id == source_data_dcatus1_1_ispartof["id"]
             )
             .all()
         )

--- a/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
+++ b/tests/integration/harvest_job_flows/test_harvest_job_full_flow.py
@@ -365,6 +365,58 @@ class TestHarvestJobFullFlow:
         )
 
     @patch("harvester.harvest.HarvestSource.send_notification_emails")
+    def test_harvest_dcatus1_1_ispartof_persists_parent(
+        self,
+        send_notification_emails_mock: MagicMock,
+        interface,
+        organization_data,
+        source_data_dcatus1_1_ispartof,
+    ):
+        """AC: a DCAT-US 1.1 dataset's "isPartOf" field is read as its
+        parent_identifier, the same way DCAT-US 3.0 series/service
+        membership is."""
+        interface.add_organization(organization_data)
+        interface.add_harvest_source(source_data_dcatus1_1_ispartof)
+        harvest_job = interface.add_harvest_job(
+            {
+                "status": "new",
+                "harvest_source_id": source_data_dcatus1_1_ispartof["id"],
+            }
+        )
+
+        job_id = harvest_job.id
+        harvest_job_starter(job_id, "harvest")
+
+        harvest_job = interface.get_harvest_job(job_id)
+        assert harvest_job.status == "complete"
+        assert harvest_job.records_added == 2
+
+        records = (
+            interface.db.query(HarvestRecord)
+            .filter(
+                HarvestRecord.harvest_source_id
+                == source_data_dcatus1_1_ispartof["id"]
+            )
+            .all()
+        )
+        assert len(records) == 2
+
+        child_record = next(
+            r
+            for r in records
+            if r.identifier == "https://example.gov/datasets/annual-report-2024"
+        )
+        parent_record = next(
+            r
+            for r in records
+            if r.identifier == "https://example.gov/collections/annual-report"
+        )
+        assert child_record.parent_identifier == (
+            "https://example.gov/collections/annual-report"
+        )
+        assert parent_record.parent_identifier is None
+
+    @patch("harvester.harvest.HarvestSource.send_notification_emails")
     def test_multiple_harvest_jobs(
         self,
         send_notification_emails_mock: MagicMock,


### PR DESCRIPTION
## Summary
- DCAT-US 1.1 datasets declare their parent collection via a native `isPartOf` field, but the harvester only ever read `parent_identifier` off a record dict populated by the DCAT-US 3.0 series/service nested-extraction path (`extract_dcatus3_nested_datasets`). Plain "document" sources on DCAT-US 1.1 never had `isPartOf` read into `parent_identifier`, so `harvest_record.parent_identifier` stayed null even though the raw `isPartOf` value passed through into `dataset.dcat`.
- Fix: fall back to `record.get("isPartOf")` when no `parent_identifier` key is already present (dcatus3.0 nested records still take priority since they set it explicitly).
- Confirmed against catalog-dev: `isPartOf` showed correctly in the child dataset's raw metadata, but neither the child→parent link nor the parent→children list rendered, because `harvest_record.parent_identifier` was never populated.

Part of GSA/data.gov#6255

## Test plan
- [x] New fixture `example_data/dcatus/dcatus1_1_ispartof.json` (a DCAT-US 1.1 collection + one member with `isPartOf`)
- [x] New integration test `test_harvest_dcatus1_1_ispartof_persists_parent` asserting the child's `parent_identifier` resolves to the collection's identifier, and the collection's own `parent_identifier` stays null
- [x] `poetry run pytest tests/integration/harvest_job_flows/test_harvest_job_full_flow.py -k "ispartof or series_members or waf_collection"`