### PR TITLE
Reduce degenerate WKT polygons instead of dropping them

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -27,6 +27,7 @@ from jsonschema import Draft202012Validator, FormatChecker
 from jsonschema.exceptions import ValidationError
 from referencing import Registry
 from referencing.jsonschema import DRAFT202012
+from shapely.geometry import LineString, Point
 from shapely.geometry import mapping as shapely_geom_mapping
 
 logging.basicConfig(level=logging.INFO)
@@ -1139,6 +1140,28 @@ _WKT_GEOMETRY_RE = re.compile(
 )
 
 
+def _reduce_degenerate_polygon(geom):
+    """Collapse a zero-area Polygon exterior ring into a Point or LineString.
+
+    Coordinate rounding by some sources (e.g. bboxes rounded to 2 decimal
+    places for a small survey area) can collapse a Polygon's corners onto
+    each other or onto a line. shapely still parses these, but
+    geojson_validator's less_three_unique_nodes/exterior_not_ccw checks
+    reject them outright. munge_spatial already reduces this same situation
+    for v1.1 comma-separated bboxes, so mirror that here instead of losing
+    the geometry.
+    """
+    if geom.geom_type != "Polygon":
+        return geom
+
+    unique_coords = list(dict.fromkeys(geom.exterior.coords))
+    if len(unique_coords) == 1:
+        return Point(unique_coords[0])
+    if len(unique_coords) == 2:
+        return LineString(unique_coords)
+    return geom
+
+
 def translate_wkt_to_geojson(spatial_value: str) -> str:
     """Convert a WKT geometry string into a GeoJSON string, if possible."""
 
@@ -1150,6 +1173,7 @@ def translate_wkt_to_geojson(spatial_value: str) -> str:
         # GeoJSON is 2D; drop any Z/M dimension rather than let the
         # 3d_coordinates check in validate_geojson silently discard it.
         geom = shapely.force_2d(geom)
+        geom = _reduce_degenerate_polygon(geom)
         return json.dumps(shapely_geom_mapping(geom))
     except:  # noqa: E722
         logger.warning(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -285,6 +285,47 @@ class TestCKANUtils:
         # Looks like WKT (has the "POLYGON" prefix) but isn't parseable.
         assert translate_wkt_to_geojson("POLYGON((not valid))") == ""
 
+    def test_translate_wkt_to_geojson_degenerate_polygon_becomes_point(self):
+        # Coordinate rounding can collapse a small survey area's bbox onto
+        # a single point. shapely parses this ring fine, but
+        # geojson_validator rejects it (less_three_unique_nodes) unless we
+        # reduce it the same way munge_spatial does for v1.1 bboxes.
+        assert (
+            translate_wkt_to_geojson(
+                "POLYGON((-115.63 32.49, -115.63 32.49, -115.63 32.49, "
+                "-115.63 32.49, -115.63 32.49))"
+            )
+            == '{"type": "Point", "coordinates": [-115.63, 32.49]}'
+        )
+
+    def test_translate_wkt_to_geojson_degenerate_polygon_becomes_linestring(self):
+        # Two unique corners (a sliver) reduces to a LineString rather than
+        # being rejected as a degenerate Polygon.
+        assert translate_wkt_to_geojson(
+            "POLYGON((-87.88 43.34, -87.88 43.35, -87.88 43.35, "
+            "-87.88 43.34, -87.88 43.34))"
+        ) == (
+            '{"type": "LineString", "coordinates": '
+            "[[-87.88, 43.34], [-87.88, 43.35]]}"
+        )
+
+    def test_translate_wkt_to_geojson_valid_triangle_unaffected(self):
+        # Three unique corners is a valid, non-degenerate Polygon and must
+        # not be reduced.
+        assert translate_wkt_to_geojson("POLYGON((0 0, 1 0, 0 1, 0 0))") == (
+            '{"type": "Polygon", "coordinates": '
+            "[[[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]]]}"
+        )
+
+    def test_translate_spatial_to_geojson_degenerate_wkt_polygon(self):
+        # End-to-end through translate_spatial_to_geojson: a degenerate WKT
+        # bbox must resolve to a geometry instead of being dropped (None).
+        geojson = translate_spatial_to_geojson(
+            "POLYGON((-115.63 32.49, -115.63 32.49, -115.63 32.49, "
+            "-115.63 32.49, -115.63 32.49))"
+        )
+        assert geojson == {"type": "Point", "coordinates": [-115.63, 32.49]}
+
     def test_translate_spatial_to_geojson_wkt_polygon(self):
         geojson = translate_spatial_to_geojson(
             "POLYGON((-125 24, -66 24, -66 50, -125 50, -125 24))"


### PR DESCRIPTION
## Summary

Coordinate rounding by some sources collapses a WKT bbox's corners onto each other or onto a line, producing a geometry `geojson_validator` rejects outright. `munge_spatial` already reduces this same situation for v1.1 comma-separated bboxes; `translate_wkt_to_geojson` did not.

- Reduce a degenerate WKT `Polygon` to a `Point` (1 unique vertex) or `LineString` (2 unique vertices) before validation, matching `munge_spatial`'s existing behavior.
- Valid, non-degenerate polygons are unchanged.

Verified against the live OpenTopography DCAT-US 3.0 feed (#6197): 83 of 802 datasets (10.3%) were losing `translated_spatial` this way; all 802 now resolve.

Closes GSA/data.gov#6294

## Test plan

- [x] Added unit tests for degenerate-to-Point, degenerate-to-LineString, and valid-triangle-unaffected cases
- [x] `pytest tests/unit/` — 526 passed (12 pre-existing, unrelated `test_auth_logging.py` failures confirmed present on `main` before this change)
- [x] `pytest tests/integration/harvest_job_flows/ -k spatial` — 2 passed
- [x] Re-ran the real OpenTopography feed through `translate_spatial_to_geojson` — 0/802 datasets lose spatial (was 83/802)