### PR TITLE
6295: Dispatch DCAT-US 3 content warnings on CURIE-prefixed @type

### DIFF
--- a/example_data/dcatus/dcatus3_0_warning_curie.json
+++ b/example_data/dcatus/dcatus3_0_warning_curie.json
@@ -1,0 +1,85 @@
+{
+  "@type": "dcat:Catalog",
+  "@id": "https://example.gov/data.json",
+  "conformsTo": {
+    "@type": "dct:Standard",
+    "title": "DCAT-US 3.0"
+  },
+  "title": "Example DCAT-US 3.0 Catalog (CURIE-prefixed @type warnings)",
+  "description": "Same shape as dcatus3_0_warning.json, but every @type is a CURIE (e.g. dcat:Dataset) rather than a bare class name, matching real-world feeds such as https://portal.opentopography.org/csw/catalog30.json (GSA/data.gov#6295).",
+  "dataset": [
+    {
+      "@type": "dcat:Dataset",
+      "title": "Curie Warned Dataset One",
+      "description": "Schema-valid, but issued is later than modified.",
+      "identifier": "https://example.gov/datasets/curie-warning-one",
+      "issued": "2030-01-01",
+      "modified": "2020-01-01",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "Test Agency"
+      },
+      "contactPoint": {
+        "@type": "vcard:Contact",
+        "fn": "Test Contact One",
+        "hasEmail": "mailto:one@example.gov"
+      }
+    },
+    {
+      "@type": "dcat:Dataset",
+      "title": "Curie Warned Dataset Two",
+      "description": "Schema-valid, but the distribution declares an unrecognized media type.",
+      "identifier": "https://example.gov/datasets/curie-warning-two",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "Test Agency"
+      },
+      "contactPoint": {
+        "@type": "vcard:Contact",
+        "fn": "Test Contact Two",
+        "hasEmail": "mailto:two@example.gov"
+      },
+      "distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "downloadURL": "https://example.gov/datasets/curie-warning-two.csv",
+          "mediaType": "notareal/type"
+        }
+      ]
+    },
+    {
+      "@type": "dcat:Dataset",
+      "title": "Curie Warned Dataset Three",
+      "description": "Schema-valid, but the spatial Location's bbox cannot be resolved to a geographic area.",
+      "identifier": "https://example.gov/datasets/curie-warning-three",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "Test Agency"
+      },
+      "contactPoint": {
+        "@type": "vcard:Contact",
+        "fn": "Test Contact Three",
+        "hasEmail": "mailto:three@example.gov"
+      },
+      "spatial": {
+        "@type": "dct:Location",
+        "bbox": "somewhere over there"
+      }
+    },
+    {
+      "@type": "dcat:Dataset",
+      "title": "Clean Curie Dataset Four",
+      "description": "Schema-valid and warning-free, so errors-only reads still have a control record.",
+      "identifier": "https://example.gov/datasets/curie-warning-four",
+      "publisher": {
+        "@type": "org:Organization",
+        "name": "Test Agency"
+      },
+      "contactPoint": {
+        "@type": "vcard:Contact",
+        "fn": "Test Contact Four",
+        "hasEmail": "mailto:four@example.gov"
+      }
+    }
+  ]
+}

--- a/harvester/utils/dcat_warnings.py
+++ b/harvester/utils/dcat_warnings.py
@@ -657,6 +657,18 @@ _TYPE_RULES = {
 }
 
 
+def _local_name(type_value: str) -> str:
+    """Strip a CURIE prefix from an @type, e.g. "dcat:Dataset" -> "Dataset".
+
+    The DCAT-US 3 schema allows @type to be a bare class name or a prefixed
+    CURIE (no enum/const on the field), and real feeds commonly send the
+    CURIE form (e.g. "dcat:Dataset", "dct:Location"). Matching on the local
+    name keeps `_TYPE_RULES` prefix-agnostic instead of hardcoding every
+    prefix a source might use.
+    """
+    return type_value.rsplit(":", 1)[-1]
+
+
 def _walk_objects(node):
     """Yield every dict nested anywhere within a record (depth-first)."""
     if isinstance(node, dict):
@@ -671,9 +683,11 @@ def _walk_objects(node):
 def detect_dcat_warnings(data: dict) -> list:
     """Detect DCAT-US 3 content-quality warnings in a dataset record.
 
-    Walks the record and dispatches each typed object to its class rules.
-    Returns a flat list of `DcatWarning` tuples (empty when the record is
-    clean). Invalid `@id` IRIs are schema `format` errors, not warnings.
+    Walks the record and dispatches each typed object to its class rules,
+    matching on the @type's local name so a CURIE-prefixed value (e.g.
+    "dcat:Dataset") dispatches the same as its bare form ("Dataset"). Returns
+    a flat list of `DcatWarning` tuples (empty when the record is clean).
+    Invalid `@id` IRIs are schema `format` errors, not warnings.
     """
     warnings = []
     for obj in _walk_objects(data):
@@ -681,7 +695,7 @@ def detect_dcat_warnings(data: dict) -> list:
         # Non-string @type is a schema error, and unhashable for `_TYPE_RULES.get`.
         if not isinstance(type_value, str):
             continue
-        rule = _TYPE_RULES.get(type_value)
+        rule = _TYPE_RULES.get(_local_name(type_value))
         if rule is not None:
             _append(warnings, rule(obj))
     return warnings

--- a/tests/unit/test_dcat_warnings.py
+++ b/tests/unit/test_dcat_warnings.py
@@ -8,9 +8,13 @@ than the full templated string, so message wording can change without churning
 every test.
 """
 
+from pathlib import Path
+
 from harvester.utils.dcat_warnings import detect_dcat_warnings
 from harvester.utils.general_utils import open_json
 from harvester.utils.schema_paths import DCATUS3_COMPLETE_EXAMPLE
+
+_EXAMPLE_DATA_DIR = Path(__file__).resolve().parents[2] / "example_data" / "dcatus"
 
 
 def types(warnings):
@@ -597,3 +601,105 @@ class TestNonStringTypeDispatch:
         }
         warnings = detect_dcat_warnings(data)
         assert types(warnings) == ["duplicate_keyword"]
+
+
+class TestCuriePrefixedTypeDispatch:
+    # GSA/data.gov#6295: real feeds (e.g. https://portal.opentopography.org
+    # /csw/catalog30.json) send CURIE-prefixed @type values like "dcat:Dataset"
+    # rather than bare class names. `_TYPE_RULES` used to key on bare names
+    # only, so every rule silently failed to dispatch for such a source.
+
+    def test_prefixed_location_dispatches_same_as_bare(self):
+        prefixed = {"@type": "dct:Location", "bbox": "somewhere over there"}
+        bare = {"@type": "Location", "bbox": "somewhere over there"}
+        assert detect_dcat_warnings(prefixed) == detect_dcat_warnings(bare)
+        assert types(detect_dcat_warnings(prefixed)) == ["unresolvable_spatial_value"]
+
+    def test_prefixed_dataset_dispatches_same_as_bare(self):
+        prefixed = {"@type": "dcat:Dataset", "keyword": ["a", "a"]}
+        bare = {"@type": "Dataset", "keyword": ["a", "a"]}
+        assert detect_dcat_warnings(prefixed) == detect_dcat_warnings(bare)
+        assert types(detect_dcat_warnings(prefixed)) == ["duplicate_keyword"]
+
+    def test_prefixed_distribution_dispatches_same_as_bare(self):
+        prefixed = {"@type": "dcat:Distribution", "byteSize": "big"}
+        bare = {"@type": "Distribution", "byteSize": "big"}
+        assert detect_dcat_warnings(prefixed) == detect_dcat_warnings(bare)
+        assert types(detect_dcat_warnings(prefixed)) == ["invalid_byte_size"]
+
+    def test_prefixed_period_of_time_dispatches_same_as_bare(self):
+        prefixed = {
+            "@type": "dct:PeriodOfTime",
+            "startDate": "2024-12-31",
+            "endDate": "2024-01-01",
+        }
+        bare = {**prefixed, "@type": "PeriodOfTime"}
+        assert detect_dcat_warnings(prefixed) == detect_dcat_warnings(bare)
+        assert types(detect_dcat_warnings(prefixed)) == ["date_out_of_order"]
+
+    def test_prefixed_kind_dispatches_same_as_bare(self):
+        prefixed = {"@type": "vcard:Kind", "tel": "+1-555-CLIMATE"}
+        bare = {"@type": "Kind", "tel": "+1-555-CLIMATE"}
+        assert detect_dcat_warnings(prefixed) == detect_dcat_warnings(bare)
+        assert types(detect_dcat_warnings(prefixed)) == ["invalid_tel"]
+
+    def test_unrecognized_types_are_unaffected_whether_prefixed_or_bare(self):
+        # vcard:Contact and org:Organization (the real feed's contactPoint /
+        # publisher types) have no registered rule under either their bare or
+        # prefixed form; stripping the prefix must not invent a match.
+        unrecognized_types = (
+            "vcard:Contact",
+            "Contact",
+            "org:Organization",
+            "Organization",
+        )
+        for type_value in unrecognized_types:
+            data = {"@type": type_value, "tel": "+1-555-CLIMATE"}
+            assert detect_dcat_warnings(data) == []
+
+    def test_unrecognized_prefixed_type_produces_no_warning_and_does_not_raise(self):
+        data = {"@type": "foo:Bogus", "byteSize": "big"}
+        assert detect_dcat_warnings(data) == []
+
+    def test_bare_type_behavior_is_unchanged(self):
+        # A bare @type with no colon must still dispatch exactly as before.
+        data = {"@type": "Dataset", "keyword": ["a", "a"]}
+        warnings = detect_dcat_warnings(data)
+        assert types(warnings) == ["duplicate_keyword"]
+
+    def test_multi_segment_curie_matches_on_final_segment(self):
+        # A full-IRI-style prefix (multiple colons) still resolves via the
+        # last segment.
+        data = {"@type": "http://xmlns.com/foaf/0.1/:Dataset", "keyword": ["a", "a"]}
+        assert types(detect_dcat_warnings(data)) == ["duplicate_keyword"]
+
+    def test_nested_prefixed_objects_all_dispatch(self):
+        # A Dataset nesting several prefixed typed objects (Distribution,
+        # Kind, Location) must dispatch warnings from every level, not just
+        # the top one.
+        data = {
+            "@type": "dcat:Dataset",
+            "issued": "2030-01-01",
+            "modified": "2020-01-01",
+            "distribution": [{"@type": "dcat:Distribution", "byteSize": "big"}],
+            "contactPoint": {"@type": "vcard:Kind", "tel": "+1-555-CLIMATE"},
+            "spatial": {"@type": "dct:Location", "bbox": "somewhere over there"},
+        }
+        warnings = detect_dcat_warnings(data)
+        assert set(types(warnings)) == {
+            "date_out_of_order",
+            "invalid_byte_size",
+            "invalid_tel",
+            "unresolvable_spatial_value",
+        }
+
+    def test_curie_fixture_regresses_the_same_warnings_as_its_bare_counterpart(self):
+        # example_data/dcatus/dcatus3_0_warning_curie.json is the CURIE-typed
+        # counterpart of dcatus3_0_warning.json: same shape, prefixed @type.
+        data = open_json(_EXAMPLE_DATA_DIR / "dcatus3_0_warning_curie.json")
+        warnings = detect_dcat_warnings(data)
+        assert sorted(types(warnings)) == [
+            "date_out_of_order",
+            "invalid_media_type",
+            "unresolvable_spatial_value",
+        ]


### PR DESCRIPTION
## Summary

Real DCAT-US 3 feeds (e.g. `portal.opentopography.org`'s `catalog30.json`) send CURIE-prefixed `@type` values like `dcat:Dataset` rather than bare class names. `_TYPE_RULES` in `harvester/utils/dcat_warnings.py` keyed on bare names only, so `detect_dcat_warnings()` never matched and silently produced zero content-quality warnings for such sources — even though the DCAT-US 3.0 schema permits CURIEs (`@type` has no enum/const).

## What changed

- `detect_dcat_warnings` now matches on the `@type`'s local name (the part after the last `:`) before dispatching to `_TYPE_RULES`, so a prefixed value (`dct:Location`) dispatches identically to its bare form (`Location`). Bare `@type` and non-string/unrecognized `@type` behavior is unchanged.
- Added unit tests in `tests/unit/test_dcat_warnings.py` covering the prefixed form.
- Added `example_data/dcatus/dcatus3_0_warning_curie.json`, a CURIE-typed counterpart to the existing `dcatus3_0_warning.json` fixture, to guard against regressions.

Closes GSA/data.gov#6295