### PR TITLE
6284: log WAF detection header on proxy access log

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -7,7 +7,7 @@ http {
   map_hash_bucket_size 128;
   server_names_hash_bucket_size 128;
   charset utf-8;
-  log_format cloudfoundry 'NginxLog "$request" $status $body_bytes_sent';
+  log_format cloudfoundry 'NginxLog "$request" $status $body_bytes_sent "$http_x_amzn_waf_detection"';
   access_log /dev/stdout cloudfoundry;
   default_type application/octet-stream;
   include mime.types;


### PR DESCRIPTION
## Summary
- Adds `$http_x_amzn_waf_detection` to the `cloudfoundry` nginx log_format so flagged requests show *why* they got a 429, instead of just an unexplained status code.

Part of #6284.

## Test plan
- [ ] `make up` and confirm nginx config parses/starts without error
- [ ] Manually set the WAF detection header on a request against local proxy and confirm access log line includes the value
