### PR TITLE
Keep validate jobs alive when a record transform fails

### DIFF
--- a/harvester/harvest.py
+++ b/harvester/harvest.py
@@ -1607,9 +1607,9 @@ def harvest_job_starter(job_id, job_type="harvest"):
     if job_type == "validate":
         harvest_source.acquire_minimum_external_data()
         for record in harvest_source.external_records_to_process():
-            if harvest_source.schema_type.startswith("iso19115"):
-                record.transform()
             try:
+                if harvest_source.schema_type.startswith("iso19115"):
+                    record.transform()
                 record.validate()
             except:  # noqa: E722
                 pass


### PR DESCRIPTION
In `harvest_job_starter`, the `validate` path called `record.transform()` outside the per-record try/except, so a single untransformable ISO record (e.g. mdtranslator 422) raised `TransformationException` out of the whole job: remaining records never validated and `report()` never ran, leaving the job without a report.

The main harvest path already catches `TransformationException` per record, so this just brings the validate path in line: move the transform call inside the existing try.

Verified with a mocked-driver run of the real `harvest_job_starter`: before, the exception escaped / only the first record validated / `report()` never called; after, the job completes and `report()` runs. Related unit suites: 177 passed (full integration suite needs docker, couldn't run here).