### PR TITLE
Give distinct CatalogRecords distinct synthetic identifiers

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -580,7 +580,13 @@ def backfill_catalog_record_identifiers(records: list) -> list:
     for record in records:
         record = dict(record)
         if normalize_dataset_identifier(record.get("@id")) is None:
-            basis = f"{record.get('primaryTopic')}|{record.get('modified')}"
+            # Hash the full record content, not just primaryTopic|modified:
+            # two distinct records can share those fields (or both lack
+            # them), which used to give them identical @ids and got all but
+            # the first wrongly dropped as duplicates downstream.
+            # Byte-identical records still hash equal, so true duplicates
+            # keep collapsing to one @id as before.
+            basis = json.dumps(record, sort_keys=True, default=str)
             digest = hashlib.sha256(basis.encode()).hexdigest()
             record["@id"] = f"urn:datagov:catalogrecord:{digest}"
         backfilled.append(record)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1488,6 +1488,16 @@ class TestBackfillCatalogRecordIdentifiers:
 
         assert "@id" not in records[0]
 
+    def test_same_topic_and_modified_still_differs(self):
+        a = backfill_catalog_record_identifiers(
+            [{"primaryTopic": "ds-1", "modified": "2024-06-15", "title": "Record A"}]
+        )[0]["@id"]
+        b = backfill_catalog_record_identifiers(
+            [{"primaryTopic": "ds-1", "modified": "2024-06-15", "title": "Record B"}]
+        )[0]["@id"]
+
+        assert a != b
+
 
 class TestExtractDcatus3NestedDatasets:
     def test_uses_custom_parent_identifier_field(self):


### PR DESCRIPTION
`backfill_catalog_record_identifiers` synthesized the @id from `primaryTopic|modified` only, so two different records sharing those fields (or both missing them) got the exact same @id, and `filter_duplicate_identifiers` then wrongly dropped all but the first — silent data loss.

Now hashes the full record content: distinct records get distinct @ids, byte-identical records still collapse (true duplicates), and ids stay stable across runs. `TestBackfillCatalogRecordIdentifiers` (5 existing + 1 new): 6 passed.