### PR TITLE
6307: Add flask command to force-reharvest sources by schema-type prefix

### DIFF
--- a/app/commands/source.py
+++ b/app/commands/source.py
@@ -48,13 +48,21 @@ def cli_evaluate_sources():
     "--schema-type-prefix",
     "schema_type_prefixes",
     multiple=True,
-    required=True,
     help=(
         "Force-reharvest sources whose schema_type starts with this prefix. "
         "Repeatable, matched with startswith() against the source's "
         f"schema_type (one of: {', '.join(SCHEMA_TYPE_VALUES)}). "
         "E.g. 'dcatus' matches all DCAT-US schema types, 'iso19115' matches "
-        "both ISO schema types."
+        "both ISO schema types. Omit to match sources of any schema type."
+    ),
+)
+@click.option(
+    "--organization",
+    "organizations",
+    multiple=True,
+    help=(
+        "Restrict to sources belonging to this organization, given by id or "
+        "slug. Repeatable. Omit to match sources of any organization."
     ),
 )
 @click.option(
@@ -63,11 +71,13 @@ def cli_evaluate_sources():
     type=bool,
     help="List matching harvest sources without queuing any jobs.",
 )
-def cli_force_reharvest_sources(schema_type_prefixes, dry_run):
+def cli_force_reharvest_sources(schema_type_prefixes, organizations, dry_run):
     """
     Force-reharvest every harvest source whose schema_type starts with one of
-    the given --schema-type-prefix values. Dry run mode is enabled by default
-    to prevent accidental mass triggering.
+    the given --schema-type-prefix values and/or belongs to one of the given
+    --organization values. Omitting both filters force-reharvests every
+    harvest source. Dry run mode is enabled by default to prevent accidental
+    mass triggering.
 
     Queues a "new" force_harvest job per source rather than starting each
     job's task immediately; the app's own scheduler picks up "new" jobs and
@@ -78,13 +88,33 @@ def cli_force_reharvest_sources(schema_type_prefixes, dry_run):
     `cf run-task datagov-harvest --command "flask harvest_source
     force_reharvest_sources --schema-type-prefix dcatus --no-dry-run"`
     """
+    org_ids = None
+    if organizations:
+        org_ids = set()
+        for identifier in organizations:
+            org = db.get_organization(identifier) or db.get_organization_by_slug(
+                identifier
+            )
+            if not org:
+                print(f"No organization found matching '{identifier}'.")
+                raise SystemExit(1)
+            org_ids.add(org.id)
+
     sources = [
         s
         for s in db.get_all_harvest_sources()
-        if s.schema_type.startswith(schema_type_prefixes)
+        if (not schema_type_prefixes or s.schema_type.startswith(schema_type_prefixes))
+        and (org_ids is None or s.organization_id in org_ids)
     ]
-    prefixes_label = ", ".join(schema_type_prefixes)
-    print(f"Found {len(sources)} harvest source(s) matching '{prefixes_label}'.")
+
+    filters_label = []
+    if schema_type_prefixes:
+        prefixes_label = ", ".join(schema_type_prefixes)
+        filters_label.append(f"schema_type prefix in ({prefixes_label})")
+    if organizations:
+        filters_label.append(f"organization in ({', '.join(organizations)})")
+    label = " and ".join(filters_label) if filters_label else "any source"
+    print(f"Found {len(sources)} harvest source(s) matching {label}.")
 
     if dry_run:
         for s in sources:

--- a/app/commands/source.py
+++ b/app/commands/source.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 import click
 from flask import Blueprint
 
 from database.interface import HarvesterDBInterface
+from shared.constants import SCHEMA_TYPE_VALUES
 
 from .evaluate_sources import evaluate_sources
 
@@ -38,3 +41,75 @@ def cli_evaluate_sources():
     captures the response code, and schema type.
     """
     evaluate_sources()
+
+
+@source.cli.command("force_reharvest_sources")
+@click.option(
+    "--schema-type-prefix",
+    "schema_type_prefixes",
+    multiple=True,
+    required=True,
+    help=(
+        "Force-reharvest sources whose schema_type starts with this prefix. "
+        "Repeatable, matched with startswith() against the source's "
+        f"schema_type (one of: {', '.join(SCHEMA_TYPE_VALUES)}). "
+        "E.g. 'dcatus' matches all DCAT-US schema types, 'iso19115' matches "
+        "both ISO schema types."
+    ),
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    type=bool,
+    help="List matching harvest sources without queuing any jobs.",
+)
+def cli_force_reharvest_sources(schema_type_prefixes, dry_run):
+    """
+    Force-reharvest every harvest source whose schema_type starts with one of
+    the given --schema-type-prefix values. Dry run mode is enabled by default
+    to prevent accidental mass triggering.
+
+    Queues a "new" force_harvest job per source rather than starting each
+    job's task immediately; the app's own scheduler picks up "new" jobs and
+    starts them under its existing HARVEST_RUNNER_MAX_TASKS cap, the same way
+    it drains regularly-scheduled harvests.
+
+    Run against a deployed environment with, e.g.:
+    `cf run-task datagov-harvest --command "flask harvest_source
+    force_reharvest_sources --schema-type-prefix dcatus --no-dry-run"`
+    """
+    sources = [
+        s
+        for s in db.get_all_harvest_sources()
+        if s.schema_type.startswith(schema_type_prefixes)
+    ]
+    prefixes_label = ", ".join(schema_type_prefixes)
+    print(f"Found {len(sources)} harvest source(s) matching '{prefixes_label}'.")
+
+    if dry_run:
+        for s in sources:
+            print(f"  {s.id}  {s.name}  ({s.schema_type})")
+        print("Dry run: no jobs queued. Use --no-dry-run to queue them.")
+        return
+
+    for s in sources:
+        active_job = db.get_active_harvest_job_for_source(s.id)
+        if active_job:
+            print(
+                f"{s.id} ({s.name}): skipped, "
+                f"job {active_job.id} already new/in_progress"
+            )
+            continue
+
+        job = db.add_harvest_job(
+            {
+                "harvest_source_id": s.id,
+                "status": "new",
+                "job_type": "force_harvest",
+                "date_created": datetime.now(),
+            }
+        )
+        if job:
+            print(f"{s.id} ({s.name}): queued job {job.id}")
+        else:
+            print(f"{s.id} ({s.name}): failed to queue job")

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,15 +30,18 @@ the running-task cap.
 ## Force-Reharvesting Sources
 
 `flask harvest_source force_reharvest_sources` (in `app/commands/source.py`)
-force-reharvests every harvest source whose `schema_type` starts with a given
-prefix (e.g. `dcatus`, `iso19115`). It's a Flask CLI command, not a standalone
-script, so it runs inside the app itself and uses whatever database it's
-already configured with, no separate DB connection setup needed.
+force-reharvests harvest sources, optionally filtered by `schema_type` prefix
+(e.g. `dcatus`, `iso19115`) and/or by organization (id or slug). Both filters
+are repeatable and optional; omitting both force-reharvests every source. It's
+a Flask CLI command, not a standalone script, so it runs inside the app
+itself and uses whatever database it's already configured with, no separate
+DB connection setup needed.
 
 Locally:
 
 ```bash
 docker compose exec app flask harvest_source force_reharvest_sources --schema-type-prefix dcatus
+docker compose exec app flask harvest_source force_reharvest_sources --organization census-bureau
 ```
 
 Against a deployed environment (e.g. prod), run it as a one-off task instead

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,3 +26,34 @@ This downloads the IDs for all of the harvest sources and then sets each
 source's next run 45 minutes in the future. When that time passes, the
 scheduler creates a job for the source and works through the queue under
 the running-task cap.
+
+## Force-Reharvesting Sources
+
+`flask harvest_source force_reharvest_sources` (in `app/commands/source.py`)
+force-reharvests every harvest source whose `schema_type` starts with a given
+prefix (e.g. `dcatus`, `iso19115`). It's a Flask CLI command, not a standalone
+script, so it runs inside the app itself and uses whatever database it's
+already configured with, no separate DB connection setup needed.
+
+Locally:
+
+```bash
+docker compose exec app flask harvest_source force_reharvest_sources --schema-type-prefix dcatus
+```
+
+Against a deployed environment (e.g. prod), run it as a one-off task instead
+of a local script, the same way other one-off admin commands run there (see
+`docs/developer.md`):
+
+```bash
+cf run-task datagov-harvest --command "flask harvest_source force_reharvest_sources --schema-type-prefix dcatus"
+```
+
+Dry-run mode is on by default. Add `--no-dry-run` to actually queue the jobs.
+This only inserts `HarvestJob` rows with `status="new"` and
+`job_type="force_harvest"`, one per matching source that doesn't already have
+an active job; it does not start any CF tasks itself. The app's own scheduler
+(`LoadManager._start_new_jobs`, which already runs on a periodic schedule)
+picks up "new" jobs and starts them under the existing
+`HARVEST_RUNNER_MAX_TASKS` cap, the same way it drains regularly-scheduled
+harvests.

--- a/tests/unit/test_source_commands.py
+++ b/tests/unit/test_source_commands.py
@@ -1,12 +1,20 @@
 from unittest.mock import MagicMock, patch
 
 
-def make_source(source_id, name, schema_type):
+def make_source(source_id, name, schema_type, organization_id=None):
     source = MagicMock()
     source.id = source_id
     source.name = name
     source.schema_type = schema_type
+    source.organization_id = organization_id
     return source
+
+
+def make_org(org_id, slug):
+    org = MagicMock()
+    org.id = org_id
+    org.slug = slug
+    return org
 
 
 def test_dry_run_lists_only_matching_prefix(app):
@@ -26,10 +34,76 @@ def test_dry_run_lists_only_matching_prefix(app):
         )
 
     assert result.exit_code == 0
-    assert "Found 1 harvest source(s) matching 'dcatus'." in result.output
+    assert "Found 1 harvest source(s) matching schema_type prefix in (dcatus)." in (
+        result.output
+    )
     assert "1  DCAT-US Source" in result.output
     assert "ISO Source" not in result.output
     assert "Dry run: no jobs queued." in result.output
+    mock_db.add_harvest_job.assert_not_called()
+
+
+def test_dry_run_no_filters_matches_everything(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_all_harvest_sources.return_value = [
+            make_source("1", "DCAT-US Source", "dcatus1.1: federal"),
+            make_source("2", "ISO Source", "iso19115_2"),
+        ]
+
+        result = app.test_cli_runner().invoke(
+            args=["harvest_source", "force_reharvest_sources"]
+        )
+
+    assert result.exit_code == 0
+    assert "Found 2 harvest source(s) matching any source." in result.output
+    assert "DCAT-US Source" in result.output
+    assert "ISO Source" in result.output
+    mock_db.add_harvest_job.assert_not_called()
+
+
+def test_dry_run_filters_by_organization(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_all_harvest_sources.return_value = [
+            make_source("1", "Census Source", "dcatus1.1: federal", "org-census"),
+            make_source("2", "Other Source", "dcatus1.1: federal", "org-other"),
+        ]
+        mock_db.get_organization.return_value = None
+        mock_db.get_organization_by_slug.return_value = make_org(
+            "org-census", "census-bureau"
+        )
+
+        result = app.test_cli_runner().invoke(
+            args=[
+                "harvest_source",
+                "force_reharvest_sources",
+                "--organization",
+                "census-bureau",
+            ]
+        )
+
+    assert result.exit_code == 0
+    assert "Found 1 harvest source(s)" in result.output
+    assert "Census Source" in result.output
+    assert "Other Source" not in result.output
+    mock_db.add_harvest_job.assert_not_called()
+
+
+def test_dry_run_unknown_organization_fails(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_organization.return_value = None
+        mock_db.get_organization_by_slug.return_value = None
+
+        result = app.test_cli_runner().invoke(
+            args=[
+                "harvest_source",
+                "force_reharvest_sources",
+                "--organization",
+                "does-not-exist",
+            ]
+        )
+
+    assert result.exit_code == 1
+    assert "No organization found matching 'does-not-exist'." in result.output
     mock_db.add_harvest_job.assert_not_called()
 
 

--- a/tests/unit/test_source_commands.py
+++ b/tests/unit/test_source_commands.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock, patch
+
+
+def make_source(source_id, name, schema_type):
+    source = MagicMock()
+    source.id = source_id
+    source.name = name
+    source.schema_type = schema_type
+    return source
+
+
+def test_dry_run_lists_only_matching_prefix(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_all_harvest_sources.return_value = [
+            make_source("1", "DCAT-US Source", "dcatus1.1: federal"),
+            make_source("2", "ISO Source", "iso19115_2"),
+        ]
+
+        result = app.test_cli_runner().invoke(
+            args=[
+                "harvest_source",
+                "force_reharvest_sources",
+                "--schema-type-prefix",
+                "dcatus",
+            ]
+        )
+
+    assert result.exit_code == 0
+    assert "Found 1 harvest source(s) matching 'dcatus'." in result.output
+    assert "1  DCAT-US Source" in result.output
+    assert "ISO Source" not in result.output
+    assert "Dry run: no jobs queued." in result.output
+    mock_db.add_harvest_job.assert_not_called()
+
+
+def test_dry_run_multiple_prefixes(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_all_harvest_sources.return_value = [
+            make_source("1", "DCAT-US Source", "dcatus1.1: federal"),
+            make_source("2", "ISO Source", "iso19115_2"),
+            make_source("3", "Other Source", "iso19115_1"),
+        ]
+
+        result = app.test_cli_runner().invoke(
+            args=[
+                "harvest_source",
+                "force_reharvest_sources",
+                "--schema-type-prefix",
+                "dcatus",
+                "--schema-type-prefix",
+                "iso19115",
+            ]
+        )
+
+    assert result.exit_code == 0
+    assert "Found 3 harvest source(s)" in result.output
+
+
+def test_no_dry_run_queues_job_for_each_source(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_all_harvest_sources.return_value = [
+            make_source("1", "DCAT-US Source", "dcatus1.1: federal"),
+            make_source("2", "DCAT-US Source 2", "dcatus3.0"),
+        ]
+        mock_db.get_active_harvest_job_for_source.return_value = None
+        queued_job = MagicMock()
+        queued_job.id = "job-1"
+        mock_db.add_harvest_job.return_value = queued_job
+
+        result = app.test_cli_runner().invoke(
+            args=[
+                "harvest_source",
+                "force_reharvest_sources",
+                "--schema-type-prefix",
+                "dcatus",
+                "--no-dry-run",
+            ]
+        )
+
+    assert result.exit_code == 0
+    assert mock_db.add_harvest_job.call_count == 2
+    for call in mock_db.add_harvest_job.call_args_list:
+        job_data = call.args[0]
+        assert job_data["status"] == "new"
+        assert job_data["job_type"] == "force_harvest"
+    assert "queued job job-1" in result.output
+
+
+def test_no_dry_run_skips_source_with_active_job(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_all_harvest_sources.return_value = [
+            make_source("1", "DCAT-US Source", "dcatus1.1: federal"),
+        ]
+        active_job = MagicMock()
+        active_job.id = "active-job-1"
+        mock_db.get_active_harvest_job_for_source.return_value = active_job
+
+        result = app.test_cli_runner().invoke(
+            args=[
+                "harvest_source",
+                "force_reharvest_sources",
+                "--schema-type-prefix",
+                "dcatus",
+                "--no-dry-run",
+            ]
+        )
+
+    assert result.exit_code == 0
+    mock_db.add_harvest_job.assert_not_called()
+    assert "skipped, job active-job-1 already new/in_progress" in result.output
+
+
+def test_no_dry_run_no_matching_sources(app):
+    with patch("app.commands.source.db") as mock_db:
+        mock_db.get_all_harvest_sources.return_value = [
+            make_source("2", "ISO Source", "iso19115_2"),
+        ]
+
+        result = app.test_cli_runner().invoke(
+            args=[
+                "harvest_source",
+                "force_reharvest_sources",
+                "--schema-type-prefix",
+                "dcatus",
+                "--no-dry-run",
+            ]
+        )
+
+    assert result.exit_code == 0
+    assert "Found 0 harvest source(s)" in result.output
+    mock_db.add_harvest_job.assert_not_called()


### PR DESCRIPTION
https://github.com/GSA/data.gov/issues/6307

## Summary
- Adds `flask harvest_source force_reharvest_sources`, a Flask CLI command to force-reharvest harvest sources filtered by a repeatable `--schema-type-prefix` (e.g. `dcatus`, `iso19115`)
- Dry-run by default; `--no-dry-run` queues a `status="new"`, `job_type="force_harvest"` `HarvestJob` per matching source (skipping sources that already have an active job), rather than starting each job's task immediately
- The app's existing scheduler (`LoadManager._start_new_jobs`) picks up and starts those queued jobs under the existing `HARVEST_RUNNER_MAX_TASKS` cap, the same way it drains regularly-scheduled harvests
- Runs against any environment as a Flask CLI command (e.g. `cf run-task datagov-harvest --command "flask harvest_source force_reharvest_sources --schema-type-prefix dcatus"`), no separate DB tunnel or standalone script bootstrap needed

## Test plan
- [x] `poetry run pytest tests/unit/test_source_commands.py`
- [x] `poetry run pytest tests/unit tests/scripts` (full suite, no regressions from this change)
- [x] ruff/black/isort clean