### PR TITLE
6297: fall back to altLabel for named-place spatial values

### DIFF
--- a/harvester/utils/general_utils.py
+++ b/harvester/utils/general_utils.py
@@ -1332,7 +1332,11 @@ def _get_geo_lookup_interface():
 
 def _unwrap_single_location(input_value):
     """Resolve a single (non-array) spatial value to its geometry-bearing
-    value, or None if it has nothing usable."""
+    value, or None if it has nothing usable.
+
+    When a Location defines more than one of these at once, bbox outranks
+    centroid outranks geometry (decided in #6297).
+    """
 
     if (
         isinstance(input_value, dict)
@@ -1342,7 +1346,7 @@ def _unwrap_single_location(input_value):
         }
         <= input_value.keys()
     ):
-        for field in ("geometry", "bbox", "centroid"):
+        for field in ("bbox", "centroid", "geometry"):
             value = input_value.get(field)
             if value:
                 return value
@@ -1351,9 +1355,9 @@ def _unwrap_single_location(input_value):
     return input_value
 
 
-def _extract_pref_label(input_value):
-    """Return a Location's prefLabel as a plain string, or None if absent,
-    blank, or not a dict.
+def _extract_label(input_value, field_name):
+    """Return a Location's `field_name` (prefLabel or altLabel) as a plain
+    string, or None if absent, blank, or not a dict.
 
     Consulted by _unwrap_location only when nothing in the whole input has
     usable geometry - real geometry always outranks a named-place fallback.
@@ -1365,9 +1369,9 @@ def _extract_pref_label(input_value):
 
     if not isinstance(input_value, dict):
         return None
-    pref_label = input_value.get("prefLabel")
-    if isinstance(pref_label, str) and pref_label.strip():
-        return pref_label
+    label = input_value.get(field_name)
+    if isinstance(label, str) and label.strip():
+        return label
     return None
 
 
@@ -1377,26 +1381,33 @@ def _unwrap_location(input_value):
     v3.0 `spatial` is a Location object or a list of them; v1.1 is a plain
     string. A bare {type, coordinates} GeoJSON dict is passed through.
 
+    Priority (decided in #6297) is bbox > centroid > geometry > prefLabel >
+    altLabel, first valid value wins:
+
     Real geometry anywhere in the input always wins over a named-place
-    (prefLabel) fallback found anywhere else: the first element with usable
-    geometry short-circuits the scan immediately. Only when NO element has
-    any geometry do we fall back to the first prefLabel seen during that
-    same scan, returned as a plain string so it flows into translate_spatial's
-    existing string branch (and from there, its existing locations-table
-    lookup) instead of being discarded.
+    (prefLabel/altLabel) fallback found anywhere else: the first element
+    with usable geometry short-circuits the scan immediately. Only when NO
+    element has any geometry do we fall back to the first prefLabel seen
+    across the whole input, or - only if no element has a prefLabel either -
+    the first altLabel seen. The winning label is returned as a plain string
+    so it flows into translate_spatial's existing string branch (and from
+    there, its existing locations-table lookup) instead of being discarded.
     """
 
     items = input_value if isinstance(input_value, list) else [input_value]
 
-    pref_label_fallback = None
     for item in items:
         unwrapped = _unwrap_single_location(item)
         if unwrapped:
             return unwrapped
-        if pref_label_fallback is None:
-            pref_label_fallback = _extract_pref_label(item)
 
-    return pref_label_fallback
+    for field_name in ("prefLabel", "altLabel"):
+        for item in items:
+            label = _extract_label(item, field_name)
+            if label:
+                return label
+
+    return None
 
 
 def translate_spatial(input_value) -> str:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -434,6 +434,68 @@ class TestCKANUtils:
             assert translate_spatial_to_geojson(locations) is None
             fake_dbi.get_geo_from_string.assert_called_once_with("Nebraska")
 
+    def test_translate_spatial_location_bbox_centroid_geometry_all_present_prefers_bbox(
+        self,
+    ):
+        location = {
+            "@type": "Location",
+            "geometry": "POINT (1.0 1.0)",
+            "centroid": {"type": "Point", "coordinates": [2.0, 2.0]},
+            "bbox": {"type": "Point", "coordinates": [3.0, 3.0]},
+        }
+        assert translate_spatial(location) == (
+            '{"type": "Point", "coordinates": [3.0, 3.0]}'
+        )
+
+    def test_translate_spatial_location_centroid_and_geometry_prefers_centroid(self):
+        location = {
+            "@type": "Location",
+            "geometry": "POINT (1.0 1.0)",
+            "centroid": {"type": "Point", "coordinates": [2.0, 2.0]},
+        }
+        assert translate_spatial(location) == (
+            '{"type": "Point", "coordinates": [2.0, 2.0]}'
+        )
+
+    def test_translate_spatial_location_array_pref_label_wins_over_earlier_alt_label(
+        self,
+    ):
+        locations = [
+            {"@type": "Location", "altLabel": "NE"},
+            {"@type": "Location", "prefLabel": "Nebraska"},
+        ]
+        fake_dbi = Mock(
+            get_geo_from_string=Mock(
+                return_value='{"type": "Point", "coordinates": [-99.9018, 41.4925]}'
+            )
+        )
+        with patch(
+            "harvester.utils.general_utils._get_geo_lookup_interface",
+            lambda: fake_dbi,
+        ):
+            assert translate_spatial(locations) == (
+                '{"type": "Point", "coordinates": [-99.9018, 41.4925]}'
+            )
+        fake_dbi.get_geo_from_string.assert_called_once_with("Nebraska")
+
+    def test_translate_spatial_location_array_falls_back_to_alt_label_db_hit(self):
+        locations = [
+            {"@type": "Location", "altLabel": "NE"},
+        ]
+        fake_dbi = Mock(
+            get_geo_from_string=Mock(
+                return_value='{"type": "Point", "coordinates": [-99.9018, 41.4925]}'
+            )
+        )
+        with patch(
+            "harvester.utils.general_utils._get_geo_lookup_interface",
+            lambda: fake_dbi,
+        ):
+            assert translate_spatial(locations) == (
+                '{"type": "Point", "coordinates": [-99.9018, 41.4925]}'
+            )
+        fake_dbi.get_geo_from_string.assert_called_once_with("NE")
+
     def test_translate_spatial_location_falls_back_to_bbox(self):
         location = {
             "@type": "Location",
@@ -490,6 +552,35 @@ class TestCKANUtils:
             fake_dbi.get_geo_from_string.reset_mock()
             assert translate_spatial_to_geojson(location) is None
             fake_dbi.get_geo_from_string.assert_called_once_with("Washington, D.C.")
+
+    def test_translate_spatial_location_alt_label_only_db_hit(self):
+        location = {"@type": "Location", "altLabel": "D.C."}
+        fake_dbi = Mock(
+            get_geo_from_string=Mock(
+                return_value='{"type": "Point", "coordinates": [-77.0369, 38.9072]}'
+            )
+        )
+        with patch(
+            "harvester.utils.general_utils._get_geo_lookup_interface",
+            lambda: fake_dbi,
+        ):
+            assert translate_spatial(location) == (
+                '{"type": "Point", "coordinates": [-77.0369, 38.9072]}'
+            )
+        fake_dbi.get_geo_from_string.assert_called_once_with("D.C.")
+
+    def test_translate_spatial_location_alt_label_only_db_miss(self):
+        location = {"@type": "Location", "altLabel": "D.C."}
+        fake_dbi = Mock(get_geo_from_string=Mock(return_value=None))
+        with patch(
+            "harvester.utils.general_utils._get_geo_lookup_interface",
+            lambda: fake_dbi,
+        ):
+            assert translate_spatial(location) == ""
+            fake_dbi.get_geo_from_string.assert_called_once_with("D.C.")
+            fake_dbi.get_geo_from_string.reset_mock()
+            assert translate_spatial_to_geojson(location) is None
+            fake_dbi.get_geo_from_string.assert_called_once_with("D.C.")
 
     def test_translate_spatial_location_input_unchanged(self):
         location = {


### PR DESCRIPTION
## Summary
- Closes GSA/data.gov#6297.
- `Location.altLabel` never reached the gazetteer lookup, so a v3.0 `spatial` value using only `altLabel` (no `prefLabel`) resolved to `NULL` even when the equivalent v1.1 plain string would have resolved. Extends the `prefLabel` fallback from #925/#6296 to also try `altLabel` when `prefLabel` is absent anywhere in the input.
- Decided priority order for a Location's spatial fields (per maintainer input on #6297) is now `bbox > centroid > geometry > prefLabel > altLabel`, first valid value wins. Previously `_unwrap_single_location` checked a single Location's own fields in `geometry > bbox > centroid` order; that's now `bbox > centroid > geometry`.
- `_extract_pref_label` is generalized to `_extract_label(input_value, field_name)` so the same helper handles both `prefLabel` and `altLabel`.

## Test plan
- [x] `pytest tests/unit/test_utils.py -k translate_spatial` — 31 passed, including new tests:
  - `test_translate_spatial_location_bbox_centroid_geometry_all_present_prefers_bbox`
  - `test_translate_spatial_location_centroid_and_geometry_prefers_centroid`
  - `test_translate_spatial_location_array_pref_label_wins_over_earlier_alt_label`
  - `test_translate_spatial_location_array_falls_back_to_alt_label_db_hit`
  - `test_translate_spatial_location_alt_label_only_db_hit` / `_db_miss`
- [x] `pytest tests/unit/` — 571 passed (no regressions)