### PR TITLE
6277: fix progress bar CSS class collision across job rows

### DIFF
--- a/app/templates/components/job-table/job_table.j2
+++ b/app/templates/components/job-table/job_table.j2
@@ -57,11 +57,11 @@
                         <div class="progress-meter">
                             {# [:-1] slices off "%" #}
                             <style nonce="{{ csp_nonce() }}">
-                              .this-progress {
+                              .progress-{{ job.id }} {
                                 --progress: {{ job.percent_complete[:-1] }};
                               }
                             </style>
-                            <div class="progress-percent this-progress"></div>
+                            <div class="progress-percent progress-{{ job.id }}"></div>
                         </div>
                     </td>
                 {% endif %}

--- a/tests/playwright/test_metrics_display.py
+++ b/tests/playwright/test_metrics_display.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from playwright.sync_api import expect
 
@@ -39,5 +41,5 @@ class TestMetricsUnauthed:
 
         expect(upage.locator(".progress-meter")).to_have_count(1)
         expect(upage.locator(".progress-percent")).to_have_attribute(
-            "class", "progress-percent this-progress"
+            "class", re.compile(r"^progress-percent progress-[0-9a-f-]+$")
         )


### PR DESCRIPTION
https://github.com/GSA/data.gov/issues/6277

- Every job row's progress bar rendered a `<style>` block targeting the same `.this-progress` class
- When multiple jobs were in progress, the browser cascade applied whichever row rendered last to every progress bar on the page
- Scoped each row's selector to `.progress-{{ job.id }}` so each bar reflects its own job's percent complete
- Kept the nonce'd `<style>` tag rather than an inline `style` attribute, since the app's CSP `style-src-attr` has no nonce support and would silently block inline attributes

## Test plan
- [x] Verified via curl against local docker env that each row now renders a unique `.progress-<job-id>` selector/class pair