### PR TITLE
add theme keyword to opensearch mapping

### DIFF
--- a/search/mappings.py
+++ b/search/mappings.py
@@ -53,6 +53,12 @@ MAPPINGS = {
             "type": "text",
             "analyzer": TEXT_ANALYZER,
             "search_analyzer": TEXT_ANALYZER,
+            "fields": {
+                "normalized": {
+                    "type": "keyword",
+                    "normalizer": KEYWORD_NORMALIZER,  # simple lowercase normalizer
+                },
+            },
         },
         "identifier": {
             "type": "text",

--- a/tests/integration/search/test_client.py
+++ b/tests/integration/search/test_client.py
@@ -33,6 +33,12 @@ def test_mappings_include_catalog_compatible_fields():
         "type": "text",
         "analyzer": client.TEXT_ANALYZER,
         "search_analyzer": client.TEXT_ANALYZER,
+        "fields": {
+            "normalized": {
+                "type": "keyword",
+                "normalizer": client.KEYWORD_NORMALIZER,  # simple lowercase normalizer
+            },
+        },
     }
     assert mappings["distribution_titles"]["type"] == "text"
     assert mappings["publisher"]["fields"]["raw"] == {"type": "keyword"}


### PR DESCRIPTION
# Pull Request

Related to [6161](https://github.com/GSA/data.gov/issues/6161)

## About
adds theme keyword for opensearch mapping. catalog [PR](https://github.com/GSA/datagov-catalog/pull/386/)

## PR TASKS

- [ ] Code well documented
- [ ] Tests written, run and passed
- [ ] Files linted
